### PR TITLE
[FIX] runbot: Fixes for cleaned instances

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -46,7 +46,6 @@ def locked(filename):
     try:
         fd = os.open(filename, os.O_CREAT | os.O_RDWR, 0o600)
     except OSError:
-        os.close(fd)
         return False
     try:
         fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -113,7 +113,7 @@ class Runbot(http.Controller):
             def branch_info(branch):
                 return {
                     'branch': branch,
-                    'builds': [self.build_info(build_dict[build_id]) for build_id in build_by_branch_ids[branch.id]]
+                    'builds': [self.build_info(build_dict[build_id]) for build_id in build_by_branch_ids.get(branch.id) or []]
                 }
 
             context.update({

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -120,7 +120,7 @@
                               <td>
                                   <i t-if="br['branch'].sticky" class="fa fa-star" style="color: #f0ad4e" />
                                   <b t-esc="br['branch'].branch_name"/>
-                                  <small><t t-esc="br['builds'][0]['job_age']"/></small><br/>
+                                  <small><t t-esc="br['builds'] and br['builds'][0]['job_age']"/></small><br/>
                                   <div class="btn-group btn-group-xs">
                                       <a t-attf-href="{{br['branch'].branch_url}}" class="btn btn-default btn-xs">Branch or pull <i class="fa fa-github"/></a>
                                       <a t-attf-href="/runbot/#{repo.id}/#{br['branch'].branch_name}" class="btn btn-default btn-xs" aria-label="Quick Connect"><i class="fa fa-fast-forward" title="Quick Connect"/></a>


### PR DESCRIPTION
- [REF] runbot: Remove used variable before assigned
  - `ValueError: <class 'UnboundLocalError'>: "local variable 'fd' referenced before assignment" while evaluating 'model._cron()'`
- [REF] runbot: Consider empty returned values
  - if builds path is empty show the error `bad query:  ... WHERE dest IN ()`
- [FIX] runbot: Fix KeyError if there are sticky branches without builds