### PR TITLE
[REF] runbot: hook - Find the right repo from payload

### DIFF
--- a/runbot/controllers/hook.py
+++ b/runbot/controllers/hook.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import json
 
 from odoo import http, tools
 from odoo.http import request
@@ -8,9 +9,21 @@ from odoo.http import request
 
 class RunbotHook(http.Controller):
 
-    @http.route(['/runbot/hook/<int:repo_id>'], type='http', auth="public", website=True, csrf=False)
+    @http.route(['/runbot/hook/<int:repo_id>', '/runbot/hook/org'], type='http', auth="public", website=True, csrf=False)
     def hook(self, repo_id=None, **post):
-        # TODO if repo_id == None parse the json['repository']['ssh_url'] and find the right repo
+        if repo_id is None:
+            event = request.httprequest.headers.get("X-Github-Event")
+            repo_data = json.loads(request.params['payload']).get('repository')
+            if repo_data and event in ['push', 'pull_request']:
+                repo_domain = [
+                    '|', '|', ('name', '=', repo_data['ssh_url']),
+                    ('name', '=', repo_data['clone_url']),
+                    ('name', '=', repo_data['clone_url'].rstrip('.git')),
+                ]
+                repo = request.env['runbot.repo'].sudo().search(
+                    repo_domain, limit=1)
+                repo_id = repo.id
+
         repo = request.env['runbot.repo'].sudo().browse([repo_id])
         repo.hook_time = datetime.datetime.now().strftime(tools.DEFAULT_SERVER_DATETIME_FORMAT)
         return ""


### PR DESCRIPTION
Work the task from TODO comment.

This change allow use a global webhook from github based on the organization without use a configuration for each repository.

I means, you should configure a global webook for all repository from the organization:
 - https://github.com/organizations/Vauxoo/settings/hooks

Instead of use a configuration for each project:
 - https://github.com/Vauxoo/project1/settings/hooks
 - https://github.com/Vauxoo/project2/settings/hooks
 - https://github.com/Vauxoo/project3/settings/hooks
 - https://github.com/Vauxoo/project4/settings/hooks
...
