### PR TITLE
[FIX] runbot: kill builds when unlinking repo or branch

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -21,6 +21,17 @@ def fqdn():
     return socket.getfqdn()
 
 
+def is_port_available(port):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(('localhost', port))
+    except OSError:
+        return False
+    finally:
+        s.close()
+    return True
+
+
 def time2str(t):
     return time.strftime(DEFAULT_SERVER_DATETIME_FORMAT, t)
 

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -10,7 +10,7 @@ import signal
 import subprocess
 import time
 from subprocess import CalledProcessError
-from ..common import dt2time, fqdn, now, locked, grep, time2str, rfind, uniq_list, local_pgadmin_cursor, lock
+from ..common import dt2time, fqdn, now, locked, grep, time2str, rfind, uniq_list, local_pgadmin_cursor, lock, is_port_available
 from odoo import models, fields, api
 from odoo.exceptions import UserError
 from odoo.http import request
@@ -344,7 +344,7 @@ class runbot_build(models.Model):
 
     def _find_port(self):
         # currently used port
-        ids = self.search([('state', 'not in', ['pending', 'done'])])
+        ids = self.search([('state', 'not in', ['pending', 'done']), ('host', '=', fqdn())])
         ports = set(i['port'] for i in ids.read(['port']))
 
         # starting port
@@ -352,7 +352,7 @@ class runbot_build(models.Model):
         port = int(icp.get_param('runbot.runbot_starting_port', default=2000))
 
         # find next free port
-        while port in ports:
+        while port in ports or is_port_available(port):
             port += 2
         return port
 


### PR DESCRIPTION
When a repo is deleted, the corresponding builds processes continues to
run indefinitely. Because of that, it may happens that the runbot launch
a new build using a port that is still in use by such a zombie build.

If this commit is applied, when unlinking a repo or a branch, the
corresponding builds are marked to be killed. Also, when searching for a
free port, the port is checked to avoid 'port already in use'
tracebacks.

It should fix https://github.com/odoo/runbot/issues/9