### PR TITLE
[IMP] runbot: choose the python version for coverage

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -98,3 +98,14 @@ def local_pgadmin_cursor():
     finally:
         if cnx:
             cnx.close()
+
+def get_py_version(build):
+    """return the python name to use from build instance"""
+    executables = [ 'odoo-bin', 'openerp-server' ]
+    for server_path in map(build._path, executables):
+        if os.path.exists(server_path):
+            with open(server_path, 'r') as f:
+                if f.readline().strip().endswith('python3'):
+                    return 'python3'
+    return 'python'
+


### PR DESCRIPTION
When code coverage was processed the 'coverage' utility was called the
same way regardless of the Odoo version. That was the cause of two
problems:
1) In some OS packages, the 'coverage' executable was renamed to
'python-coverage' and 'python3-coverage'
2) Since version 11.0, Odoo needs python3

With this commit, the coverage module is called from python '-m'
argument and the python version is choosen from the Odoo executable
shebang.