### PR TITLE
[REF] runbot: Skip build from commit message

### DIFF
--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_subject_skip_build

--- a/runbot/tests/test_subject_skip_build.py
+++ b/runbot/tests/test_subject_skip_build.py
@@ -1,0 +1,57 @@
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+from odoo.tests import TransactionCase
+
+
+class TestRunbotSkipBuild(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = tempfile.mkdtemp()
+        self.work_tree = os.path.join(self.tmp_dir, "git_example")
+        self.git_dir = os.path.join(self.work_tree, ".git")
+        subprocess.call(["git", "init", self.work_tree])
+        hooks_dir = os.path.join(self.git_dir, "hooks")
+        if os.path.isdir(hooks_dir):
+            # Avoid run a hooks for commit commands
+            shutil.rmtree(hooks_dir)
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.tmp_dir)
+
+    def git(self, *cmd):
+        subprocess.call(["git"] + list(cmd), cwd=self.work_tree)
+
+    def test_subject_skip_build(self):
+        """Test [ci skip] feature"""
+        repo = self.env["runbot.repo"].create({"name": self.git_dir})
+
+        cimsg = "Testing subject [ci skip]"
+        self.git("commit", "--allow-empty", "-m", cimsg)
+        repo._update_git()
+        build = self.env["runbot.build"].search([("subject", "=", cimsg)])
+        self.assertFalse(build)
+
+        cimsg = "Testing subject without ci skip"
+        self.git("commit", "--allow-empty", "-m", cimsg)
+        repo._update_git()
+        build = self.env["runbot.build"].search([("subject", "=", cimsg)])
+        self.assertTrue(build)
+
+        cimsg = "Testing body\n\n[ci skip]"
+        self.git("commit", "--allow-empty", "-m", cimsg)
+        repo._update_git()
+        build = self.env["runbot.build"].search([
+            ("subject", "=", cimsg.split("\n")[0])])
+        self.assertFalse(build)
+
+        cimsg = "Testing body without\n\nci skip"
+        self.git("commit", "--allow-empty", "-m", cimsg)
+        repo._update_git()
+        build = self.env["runbot.build"].search([
+            ("subject", "=", cimsg.split("\n")[0])])
+        self.assertTrue(build)

--- a/runbot/tests/test_subject_skip_build.py
+++ b/runbot/tests/test_subject_skip_build.py
@@ -18,40 +18,47 @@ class TestRunbotSkipBuild(TransactionCase):
         if os.path.isdir(hooks_dir):
             # Avoid run a hooks for commit commands
             shutil.rmtree(hooks_dir)
+        self.repo = self.env["runbot.repo"]
 
     def tearDown(self):
         super().tearDown()
         shutil.rmtree(self.tmp_dir)
+        if self.repo and os.path.isdir(self.repo.path):
+            shutil.rmtree(self.repo.path)
+        for build in self.env["runbot.build"].search([("repo_id", "in", self.repo.ids)]):
+            build_dir = os.path.join(self.repo._root(), build.dest)
+            if os.path.isdir(build_dir):
+                shutil.rmtree(build_dir)
 
     def git(self, *cmd):
         subprocess.call(["git"] + list(cmd), cwd=self.work_tree)
 
     def test_subject_skip_build(self):
         """Test [ci skip] feature"""
-        repo = self.env["runbot.repo"].create({"name": self.git_dir})
+        self.repo = self.repo.create({"name": self.git_dir})
 
         cimsg = "Testing subject [ci skip]"
         self.git("commit", "--allow-empty", "-m", cimsg)
-        repo._update_git()
+        self.repo._update_git()
         build = self.env["runbot.build"].search([("subject", "=", cimsg)])
         self.assertFalse(build)
 
         cimsg = "Testing subject without ci skip"
         self.git("commit", "--allow-empty", "-m", cimsg)
-        repo._update_git()
+        self.repo._update_git()
         build = self.env["runbot.build"].search([("subject", "=", cimsg)])
         self.assertTrue(build)
 
         cimsg = "Testing body\n\n[ci skip]"
         self.git("commit", "--allow-empty", "-m", cimsg)
-        repo._update_git()
+        self.repo._update_git()
         build = self.env["runbot.build"].search([
             ("subject", "=", cimsg.split("\n")[0])])
         self.assertFalse(build)
 
         cimsg = "Testing body without\n\nci skip"
         self.git("commit", "--allow-empty", "-m", cimsg)
-        repo._update_git()
+        self.repo._update_git()
         build = self.env["runbot.build"].search([
             ("subject", "=", cimsg.split("\n")[0])])
         self.assertTrue(build)

--- a/runbot/tests/test_subject_skip_build.py
+++ b/runbot/tests/test_subject_skip_build.py
@@ -25,10 +25,11 @@ class TestRunbotSkipBuild(TransactionCase):
             # Avoid run a hooks for commit commands
             shutil.rmtree(hooks_dir)
         self.repo = self.env["runbot.repo"].create({"name": self.git_dir})
+        self.build = self.env["runbot.build"]
 
         @self.addCleanup
         def remove_clone_dir():
-            if self.repo and os.path.isdir(self.repo.path):
+            if os.path.isdir(self.repo.path):
                 shutil.rmtree(self.repo.path)
 
     def git(self, *cmd):
@@ -36,30 +37,27 @@ class TestRunbotSkipBuild(TransactionCase):
 
     def test_subject_skip_build(self):
         """Test [ci skip] feature"""
-        self.repo = self.repo.create({"name": self.git_dir})
 
         cimsg = "Testing subject [ci skip]"
         self.git("commit", "--allow-empty", "-m", cimsg)
         self.repo._update_git()
-        build = self.env["runbot.build"].search([("subject", "=", cimsg)])
+        build = self.build.search([("subject", "=", cimsg)])
         self.assertFalse(build)
 
         cimsg = "Testing subject without ci skip"
         self.git("commit", "--allow-empty", "-m", cimsg)
         self.repo._update_git()
-        build = self.env["runbot.build"].search([("subject", "=", cimsg)])
+        build = self.build.search([("subject", "=", cimsg)])
         self.assertTrue(build)
 
         cimsg = "Testing body\n\n[ci skip]"
         self.git("commit", "--allow-empty", "-m", cimsg)
         self.repo._update_git()
-        build = self.env["runbot.build"].search([
-            ("subject", "=", cimsg.split("\n")[0])])
+        build = self.build.search([("subject", "=", cimsg.split("\n")[0])])
         self.assertFalse(build)
 
         cimsg = "Testing body without\n\nci skip"
         self.git("commit", "--allow-empty", "-m", cimsg)
         self.repo._update_git()
-        build = self.env["runbot.build"].search([
-            ("subject", "=", cimsg.split("\n")[0])])
+        build = self.build.search([("subject", "=", cimsg.split("\n")[0])])
         self.assertTrue(build)


### PR DESCRIPTION
This module skip a build based on the commit message.
Inspired by [Travis-CI#Skipping-a-build](https://docs.travis-ci.com/user/customizing-the-build#Skipping-a-build)

 - If you don’t want to run a build for a particular commit for any reason, add `[ci skip]` or `[skip ci]` to the git commit message.
 - Commits that have `[ci skip]` or `[skip ci]` anywhere in the commit messages are ignored by Travis CI.
 - Note that in case multiple commits are pushed together, the `[skip ci]` or `[ci skip]` takes effect only if present in the commit message of the HEAD commit.