### PR TITLE
[IMP] runbot: allow extra builds based on a cron

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -15,6 +15,7 @@
         'views/repo_views.xml',
         'views/branch_views.xml',
         'views/build_views.xml',
+        'views/cronbuild_views.xml',
         'views/res_config_settings_views.xml',
         'templates/frontend.xml',
         'templates/build.xml',
@@ -22,6 +23,7 @@
         'templates/dashboard.xml',
         'templates/nginx.xml',
         'templates/badge.xml',
-        'data/runbot_cron.xml'
+        'data/runbot_cron.xml',
+        'data/runbot_cronbuild.xml'
     ],
 }

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -33,7 +33,7 @@ class Runbot(http.Controller):
             'port': real_build.port,
             'server_match': real_build.server_match,
             'duplicate_of': build.duplicate_id if build.state == 'duplicate' else False,
-            'coverage': build.branch_id.coverage,
+            'coverage': build.coverage or build.branch_id.coverage,
             'revdep_build_ids': sorted(build.revdep_build_ids, key=lambda x: x.repo_id.name),
         }
 

--- a/runbot/data/runbot_cronbuild.xml
+++ b/runbot/data/runbot_cronbuild.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<odoo>
+    <data>
+        <record model="ir.cron" id="runbot_cronbuild_daily">
+            <field name="name">Runbot cron daily extra builds</field>
+            <field name="model_id" ref="model_runbot_cronbuild"/>
+            <field name="state">code</field>
+            <field name="code">model._cron()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+            <field name="nextcall" eval="datetime.now().replace(hour=1,minute=0,second=0) + timedelta(days=1)"/>
+        </record>
+    </data>
+</odoo>

--- a/runbot/models/__init__.py
+++ b/runbot/models/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-from . import repo, branch, build, event
+from . import repo, branch, build, event, cronbuild
 from . import res_config_settings

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import coverage
 import glob
 import logging
 import operator
@@ -62,6 +63,9 @@ class runbot_build(models.Model):
     revdep_build_ids = fields.Many2many('runbot.build', 'runbot_rev_dep_builds',
                                         column1='rev_dep_id', column2='dependent_id',
                                         string='Builds that depends on this build')
+    extra_params = fields.Char('Extra cmd args')
+    coverage = fields.Boolean('Enable code coverage')
+    coverage_result = fields.Float('Coverage result', digits=(5, 2))
 
     def copy(self, values=None):
         raise UserError("Cannot duplicate build!")
@@ -749,6 +753,8 @@ class runbot_build(models.Model):
         if grep(build._server("tools/config.py"), "test-enable"):
             cmd.append("--test-enable")
         cmd += ['-d', '%s-base' % build.dest, '-i', 'base', '--stop-after-init', '--log-level=test', '--max-cron-threads=0']
+        if build.extra_params:
+            cmd.extend(build.extra_params.split(' '))
         return self._spawn(cmd, lock_path, log_path, cpu_limit=300)
 
     def _job_20_test_all(self, build, lock_path, log_path):
@@ -758,8 +764,10 @@ class runbot_build(models.Model):
         if grep(build._server("tools/config.py"), "test-enable"):
             cmd.append("--test-enable")
         cmd += ['-d', '%s-all' % build.dest, '-i', mods, '--stop-after-init', '--log-level=test', '--max-cron-threads=0']
+        if build.extra_params:
+            cmd.extend(build.extra_params.split(' '))
         env = None
-        if build.branch_id.coverage:
+        if build.coverage:
             pyversion = get_py_version(build)
             env = self._coverage_env(build)
             available_modules = [
@@ -777,14 +785,22 @@ class runbot_build(models.Model):
     def _coverage_env(self, build):
         return dict(os.environ, COVERAGE_FILE=build._path('.coverage'))
 
-    def _job_21_coverage(self, build, lock_path, log_path):
-        if not build.branch_id.coverage:
+    def _job_21_coverage_html(self, build, lock_path, log_path):
+        if not build.coverage:
             return -2
         pyversion = get_py_version(build)
         cov_path = build._path('coverage')
         os.makedirs(cov_path, exist_ok=True)
         cmd = [pyversion, "-m", "coverage", "html", "-d", cov_path, "--ignore-errors"]
         return self._spawn(cmd, lock_path, log_path, env=self._coverage_env(build))
+
+    def _job_22_coverage_result(self, build, lock_path, log_path):
+        if not build.coverage:
+            return -2
+        cov = coverage.coverage(data_file=build._path('.coverage'))
+        cov.load()
+        build.coverage_result = cov.report()
+        return -2  # nothing to wait for
 
     def _job_30_run(self, build, lock_path, log_path):
         # adjust job_end to record an accurate job_20 job_time

--- a/runbot/models/cronbuild.py
+++ b/runbot/models/cronbuild.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import logging
+from odoo import models, fields
+
+_logger = logging.getLogger(__name__)
+
+
+class runbot_cronbuild(models.Model):
+    """ Model that permit to force an extra build based on a daily cron """
+
+    _name = 'runbot.cronbuild'
+
+    name = fields.Char(required=True)
+    branch_id = fields.Many2one('runbot.branch', 'Branch', required=True, ondelete='cascade', index=True)
+    extra_params = fields.Char('Extra cmd args')
+    coverage = fields.Boolean(string='Enable code coverage', default=False)
+
+    def _cron(self):
+        """ Generate extra builds when needed (called by cron's)"""
+        build_model = self.env['runbot.build']
+        for cronbuild in self.search([]):
+            last_build = build_model.search([('branch_id', '=', cronbuild.branch_id.id)],
+                                            limit=1,
+                                            order='sequence desc')
+            if last_build:
+                build_model.with_context(force_rebuild=True).create({
+                    'branch_id': cronbuild.branch_id.id,
+                    'name': last_build.name,
+                    'author': last_build.author,
+                    'author_email': last_build.author_email,
+                    'committer': last_build.committer,
+                    'committer_email': last_build.committer_email,
+                    'subject': cronbuild.name,
+                    'modules': last_build.modules,
+                    'extra_params': cronbuild.extra_params,
+                    'coverage': cronbuild.coverage,
+                })

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -201,6 +201,7 @@ class runbot_repo(models.Model):
                     'committer_email': committer_email,
                     'subject': subject,
                     'date': dateutil.parser.parse(date[:19]),
+                    'coverage': branch.coverage,
                 }
                 if not branch.sticky:
                     # pending builds are skipped as we have a new ref

--- a/runbot/security/ir.model.access.csv
+++ b/runbot/security/ir.model.access.csv
@@ -5,4 +5,5 @@ access_runbot_build,runbot_build,runbot.model_runbot_build,group_user,1,0,0,0
 access_runbot_repo_admin,runbot_repo_admin,runbot.model_runbot_repo,runbot.group_runbot_admin,1,1,1,1
 access_runbot_branch_admin,runbot_branch_admin,runbot.model_runbot_branch,runbot.group_runbot_admin,1,1,1,1
 access_runbot_build_admin,runbot_build_admin,runbot.model_runbot_build,runbot.group_runbot_admin,1,1,1,1
+access_runbot_cronbuild_admin,runbot_cronbuild_admin,runbot.model_runbot_cronbuild,runbot.group_runbot_admin,1,1,1,1
 access_irlogging,log by runbot users,base.model_ir_logging,group_user,0,0,1,0

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -125,6 +125,10 @@
                                       <a t-attf-href="{{br['branch'].branch_url}}" class="btn btn-default btn-xs">Branch or pull <i class="fa fa-github"/></a>
                                       <a t-attf-href="/runbot/#{repo.id}/#{br['branch'].branch_name}" class="btn btn-default btn-xs" aria-label="Quick Connect"><i class="fa fa-fast-forward" title="Quick Connect"/></a>
                                   </div>
+                                  <t t-if="br['branch'].sticky">
+                                      <br/>
+                                      <span class="label label-info">cov: <t t-esc="br['branch'].coverage_result"/>%</span>
+                                  </t>
                               </td>
                               <t t-foreach="br['builds']" t-as="bu">
                                   <t t-if="bu['state']=='pending'"><t t-set="klass">default</t></t>

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_subject_skip_build
+from . import test_cronbuild

--- a/runbot/tests/test_cronbuild.py
+++ b/runbot/tests/test_cronbuild.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+import coverage
+import os
+import shutil
+import subprocess
+import tempfile
+
+from odoo.tests import TransactionCase
+
+COVERAGE_APP = """
+def not_used():
+    pass
+
+def hello():
+    print("Hello world")
+    x = False
+    if x:
+        print("Hello again")
+
+if __name__ == '__main__':
+    hello()
+"""
+
+
+class TestRunbotCronBuild(TransactionCase):
+    def git(self, *cmd):
+        subprocess.call(["git"] + list(cmd), cwd=self.work_tree)
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = tempfile.mkdtemp()
+
+        @self.addCleanup
+        def remove_tmp_dir():
+            if os.path.isdir(self.tmp_dir):
+                shutil.rmtree(self.tmp_dir)
+
+        self.work_tree = os.path.join(self.tmp_dir, "git_example")
+        self.git_dir = os.path.join(self.work_tree, ".git")
+        os.mkdir(self.work_tree)
+        self.git("init", self.work_tree)
+        hooks_dir = os.path.join(self.git_dir, "hooks")
+        if os.path.isdir(hooks_dir):
+            # Avoid run a hooks for commit commands
+            shutil.rmtree(hooks_dir)
+        self.repo = self.env["runbot.repo"].create({"name": self.git_dir})
+        self.branch = self.env['runbot.branch'].create({
+            'name': 'refs/heads/master',
+            'branch_name': 'master',
+            'repo_id': self.repo.id
+        })
+        self.build_model = self.env['runbot.build']
+        self.cronbuild_model = self.env['runbot.cronbuild']
+
+        @self.addCleanup
+        def remove_clone_dir():
+            if os.path.isdir(self.repo.path):
+                shutil.rmtree(self.repo.path)
+
+    def test_cronbuild_generate_build(self):
+        """ Test that a build is generated based on the last build """
+
+        cron_name = 'Nightly build'
+        extra_params = '--test-tags nightly'
+        cronbuild = self.cronbuild_model.create({
+            'name': cron_name,
+            'repo_id': self.repo.id,
+            'branch_id': self.branch.id,
+            'extra_params': extra_params,
+        })
+
+        # check that coverage flag is False by default
+        self.assertFalse(cronbuild.coverage)
+
+        # check that no new builds are created at bootstrap
+        self.cronbuild_model._cron()
+        self.assertEqual(self.build_model.search_count([]), 0)
+
+        msg = 'Initial commit'
+        self.git("commit", "--allow-empty", "-m", msg)
+        self.repo._update_git()
+        first_build = self.build_model.search([], order='id')[0]
+        self.cronbuild_model._cron()
+        last_build = self.build_model.search([], order='id')[-1]
+
+        # check that a new build was generated
+        self.assertEqual(self.build_model.search_count([]), 2)
+        self.assertNotEqual(first_build, last_build)
+        self.assertEqual(last_build.extra_params, extra_params)
+        self.assertEqual(last_build.state, 'pending')
+        self.assertEqual(last_build.subject, cron_name)
+        self.assertFalse(last_build.result)
+        self.assertFalse(last_build.coverage)
+        self.assertFalse(last_build.coverage_result)
+
+        # change the cronbuild to use coverage
+        cronbuild.coverage = True
+        # Regenerate a build like if a user click 'run manually' in the cron
+        # form
+        self.cronbuild_model._cron()
+        last_build = self.build_model.search([], order='id')[-1]
+        self.assertTrue(last_build.coverage)
+
+    def test_coverage(self):
+        """ Test that the coverage result is written on the build """
+
+        hello_path = os.path.join(self.work_tree, 'hello.py')
+        with open(hello_path, 'w') as f:
+            f.write(COVERAGE_APP)
+
+        subprocess.call(['python3', '-m', 'coverage', 'run', '--branch', 'hello.py'], cwd=self.work_tree)
+
+        cronbuild = self.cronbuild_model.create({
+            'name': 'Nightly coverage build',
+            'repo_id': self.repo.id,
+            'branch_id': self.branch.id,
+            'coverage': True,
+        })
+
+        self.git("add", "hello.py")
+        msg = 'Hello'
+        self.git("commit", "-m", msg)
+
+        self.repo._update_git()
+        last_build = self.build_model.search([], order='id desc', limit=1)
+        branch = self.env['runbot.branch'].search([('id', '=', last_build.branch_id.id)])
+        self.assertEqual(branch.coverage_result, 0)
+
+        self.cronbuild_model._cron()
+
+        last_build = self.build_model.search([], order='id desc', limit=1)
+        last_build.state = 'done'  # mock a finished build job
+
+        cov = coverage.Coverage(data_file=os.path.join(self.work_tree, '.coverage'))
+        cov.load()
+        r = cov.report()
+
+        last_build.coverage_result = r
+        # check that coverage is stored with 2 digits precision
+        self.assertEqual(last_build.coverage_result, round(r, 2))
+
+        # check that the computed field on the branch returns the last build
+        # coverage value
+        branch.invalidate_cache()
+        self.assertEqual(branch.coverage_result, last_build.coverage_result)
+
+        # The last build may be a running build
+        last_build.state = 'running'
+        branch.invalidate_cache()
+        self.assertEqual(branch.coverage_result, last_build.coverage_result)

--- a/runbot/views/build_views.xml
+++ b/runbot/views/build_views.xml
@@ -50,6 +50,7 @@
                 <field name="port"/>
                 <field name="job"/>
                 <field name="result"/>
+                <field name="coverage_result"/>
                 <field name="pid"/>
                 <field name="host"/>
                 <field name="job_start"/>

--- a/runbot/views/cronbuild_views.xml
+++ b/runbot/views/cronbuild_views.xml
@@ -1,0 +1,48 @@
+<odoo>
+  <data>
+    <record id="cronbuild_form" model="ir.ui.view">
+        <field name="name">runbot.cronbuild.form</field>
+        <field name="model">runbot.cronbuild</field>
+        <field name="arch" type="xml">
+          <form>
+            <header>
+            </header>
+            <sheet>
+              <group name="cronbuild_group">
+                <field name="name"/>
+                <field name="branch_id"/>
+                <field name="coverage"/>
+                <field name="extra_params"/>
+              </group>
+            </sheet>
+          </form>
+        </field>
+    </record>
+
+    <record id="cronbuild_view_tree" model="ir.ui.view">
+        <field name="name">runbot.cronbuild.tree</field>
+        <field name="model">runbot.cronbuild</field>
+        <field name="arch" type="xml">
+            <tree string="Cron builds">
+                <field name="name"/>
+                <field name="coverage"/>
+                <field name="branch_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="open_view_cronbuild_tree" model="ir.actions.act_window">
+        <field name="name">Cronbuilds</field>
+        <field name="res_model">runbot.cronbuild</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem
+        name="Cron builds"
+        id="runbot_menu_cronbuild_tree"
+        parent="runbot_menu_root"
+        sequence="25"
+        action="open_view_cronbuild_tree"
+        />
+  </data>
+</odoo>


### PR DESCRIPTION
Actually, a build in a branch is created when a new commit is found.
When a user wants to schedule a time-based build, he has to generate a
commit outside of the runbot (e.g. in a cron script).

With this commit, cron builds can be scheduled hourly, daily, weekly or  monthly with extra parameters.