### PR TITLE
[FIX] runbot: Fix commit body multiline

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -150,11 +150,10 @@ class runbot_repo(models.Model):
         repo._git(['fetch', '-p', 'origin', '+refs/pull/*/head:refs/pull/*'])
 
         fields = ['refname', 'objectname', 'committerdate:iso8601', 'authorname', 'authoremail', 'subject', 'committername', 'committeremail', 'body']
-        fmt = "%00".join(["%(" + field + ")" for field in fields])
+        fmt = "%00".join(["%(" + field + ")" for field in fields]) + "%00"
         git_refs = repo._git(['for-each-ref', '--format', fmt, '--sort=-committerdate', 'refs/heads', 'refs/pull'])
-        git_refs = git_refs.strip()
 
-        refs = [[field for field in line.split('\x00')] for line in git_refs.split('\n')]
+        refs = [[field for field in line.split('\x00')] for line in git_refs.split('\x00\n')[:-1]]
 
         self.env.cr.execute("""
             WITH t (branch) AS (SELECT unnest(%s))

--- a/runbot/tests/test_subject_skip_build.py
+++ b/runbot/tests/test_subject_skip_build.py
@@ -50,13 +50,13 @@ class TestRunbotSkipBuild(TransactionCase):
         build = self.build.search([("subject", "=", cimsg)])
         self.assertTrue(build)
 
-        cimsg = "Testing body\n\n[ci skip]"
+        cimsg = "Testing body\n\n[ci skip]\nother line"
         self.git("commit", "--allow-empty", "-m", cimsg)
         self.repo._update_git()
         build = self.build.search([("subject", "=", cimsg.split("\n")[0])])
         self.assertFalse(build)
 
-        cimsg = "Testing body without\n\nci skip"
+        cimsg = "Testing body without\n\nci skip\nother line"
         self.git("commit", "--allow-empty", "-m", cimsg)
         self.repo._update_git()
         build = self.build.search([("subject", "=", cimsg.split("\n")[0])])


### PR DESCRIPTION
 - Add testcase

Running the tests without the fix `ValueError: not enough values to unpack (expected 9, got 1)`
```bash
2018-05-09 19:23:55,582 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: ERROR
2018-05-09 19:23:55,583 11255 INFO runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: ======================================================================
2018-05-09 19:23:55,583 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: ERROR: test_subject_skip_build (odoo.addons.runbot.tests.test_subject_skip_build.TestRunbotSkipBuild)
2018-05-09 19:23:55,583 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: ` Test [ci skip] feature
2018-05-09 19:23:55,583 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: Traceback (most recent call last):
2018-05-09 19:23:55,583 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: `   File "/Users/moylop260/odoo/odoo-extra/runbot/tests/test_subject_skip_build.py", line 55, in test_subject_skip_build
2018-05-09 19:23:55,583 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: `     self.repo._update_git()
2018-05-09 19:23:55,584 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: `   File "/Users/moylop260/odoo/odoo-extra/runbot/models/repo.py", line 167, in _update_git
2018-05-09 19:23:55,584 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: `     for name, sha, date, author, author_email, subject, committer, committer_email, body in refs:
2018-05-09 19:23:55,584 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: ` ValueError: not enough values to unpack (expected 9, got 1)
2018-05-09 19:23:55,584 11255 INFO runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: Ran 1 test in 1.214s
2018-05-09 19:23:55,584 11255 ERROR runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: FAILED
2018-05-09 19:23:55,584 11255 INFO runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build:  (errors=1)
2018-05-09 19:23:55,584 11255 ERROR runbot_11_3 odoo.modules.module: Module runbot: 0 failures, 1 errors
2018-05-09 19:23:55,715 11255 INFO runbot_11_3 odoo.modules.loading: 23 modules loaded in 5.04s, 33 queries
2018-05-09 19:23:56,097 11255 ERROR runbot_11_3 odoo.modules.loading: At least one test failed when loading the modules.
```

Running  the tests with the fix

```bash
2018-05-09 19:25:07,463 11424 INFO runbot_11_3 odoo.addons.runbot.models.repo: git command: git --git-dir=/Users/moylop260/odoo/odoo-extra/runbot/static/repo/_var_folders_zc_1m37yppx4z5596yfyzg385140000gn_T_tmpx6t_qg6k_git_example_.git for-each-ref --format %(refname)%00%(objectname)%00%(committerdate:iso8601)%00%(authorname)%00%(authoremail)%00%(subject)%00%(committername)%00%(committeremail)%00%(body)%00 --sort=-committerdate refs/heads refs/pull
2018-05-09 19:25:07,714 11424 INFO runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: Ran 1 test in 1.482s
2018-05-09 19:25:07,714 11424 INFO runbot_11_3 odoo.addons.runbot.tests.test_subject_skip_build: OK
2018-05-09 19:25:07,852 11424 INFO runbot_11_3 odoo.modules.loading: 23 modules loaded in 5.78s, 50 queries
```