### PR TITLE
[FIX] runbot: Avoid infinite loop fetching

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -44,7 +44,7 @@ class runbot_repo(models.Model):
                              ('hook', 'Hook')],
                             default='poll',
                             string="Mode", required=True, help="hook: Wait for webhook on /runbot/hook/<id> i.e. github push event")
-    hook_time = fields.Float('Last hook time')
+    hook_time = fields.Datetime('Last hook time', default=fields.Datetime.now)
     get_ref_time = fields.Float('Last refs db update')
     duplicate_id = fields.Many2one('runbot.repo', 'Duplicate repo', help='Repository for finding duplicate builds')
     modules = fields.Char("Modules to install", help="Comma-separated list of modules to install and test.")


### PR DESCRIPTION
Using `repo.hook_time = None` and `repo.mode = hook` the cron run fetch command in an infinite-loop.

Using by default the current date the issue is fixed because the first command is a "git clone" if the path is not exists then the last time is now for first time.