### PR TITLE
[IMP] runbot: add icons for reverse dependency builds

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -34,7 +34,7 @@ class Runbot(http.Controller):
             'server_match': real_build.server_match,
             'duplicate_of': build.duplicate_id if build.state == 'duplicate' else False,
             'coverage': build.branch_id.coverage,
-            'revdep_build_ids': build.revdep_build_ids,
+            'revdep_build_ids': sorted(build.revdep_build_ids, key=lambda x: x.repo_id.name),
         }
 
     @http.route(['/runbot', '/runbot/repo/<model("runbot.repo"):repo>'], website=True, auth='public', type='http')

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -29,6 +29,9 @@
                             <t t-if="rbu['result']=='skipped'"><i class="text-danger fa fa-ban"/></t>
                             <t t-if="rbu['result']=='killed'"><i class="text-danger fa fa-times"/>&#x1f480;</t>
                             <t t-if="rbu['result']=='manually_killed'"><i class="text-danger fa fa-times"/>&#x1f52b;</t>
+                            <t t-if="rbu['state']=='deathrow'"><i class="fa fa-crosshairs" style="color: #666666;"/></t>
+                            <t t-if="rbu['state']=='pending'"><i class="fa fa-pause" style="color: #666666;"/></t>
+                            <t t-if="rbu['state']=='testing'"><i class="fa fa-spinner fa-spin" style="color: #666666;"/></t>
                             </a>
                 </t>
             </small>


### PR DESCRIPTION
When a reverse dependency is in testing, pending or deathrow state, there is no
icon in the depending build box.
This commit adds icons for testing, pending and deathrow states.
Also, icons are now displayed in the repository name order.