### PR TITLE
[IMP] runbot: kill older builds when a new one is created

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -205,6 +205,16 @@ class runbot_repo(models.Model):
                     builds_to_skip._skip(reason='New ref found')
                     if builds_to_skip:
                         build_info['sequence'] = builds_to_skip[0].sequence
+                    # testing builds are killed
+                    builds_to_kill = Build.search([
+                        ('branch_id', '=', branch.id),
+                        ('state', '=', 'testing'),
+                        ('committer', '=', committer)
+                    ])
+                    builds_to_kill.write({'state': 'deathrow'})
+                    for btk in builds_to_kill:
+                        btk._log('repo._update_git', 'Build automatically killed, newer build found.')
+
                 new_build = Build.create(build_info)
                 # create a reverse dependency build if needed
                 if branch.sticky:


### PR DESCRIPTION
When a new commit is found and a new build is created. When a user
pushes more commits in the same branch a few minutes later, it causes
more builds in testing phase, resulting in a CPU waste.

With this commit, previous builds in testing phase in non sticky
branches are killed when a new build is created.