### PR TITLE
[IMP] runbot: update nginx template

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -289,10 +289,10 @@ class runbot_repo(models.Model):
         nginx_dir = os.path.join(self._root(), 'nginx')
         settings['nginx_dir'] = nginx_dir
         settings['re_escape'] = re.escape
+        settings['fqdn'] = fqdn()
         nginx_repos = self.search([('nginx', '=', True)], order='id')
         if nginx_repos:
-            builds = self.env['runbot.build'].search([('repo_id', 'in', nginx_repos.ids), ('state', '=', 'running')])
-            settings['builds'] = self.env['runbot.build'].browse(builds.ids)
+            settings['builds'] = self.env['runbot.build'].search([('repo_id', 'in', nginx_repos.ids), ('state', '=', 'running'), ('host', '=', fqdn())])
 
             nginx_config = self.env['ir.ui.view'].render_template("runbot.nginx_config", settings)
             os.makedirs(nginx_dir, exist_ok=True)

--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -52,6 +52,11 @@ server {
     location /longpolling { proxy_pass http://127.0.0.1:<t t-esc="build.port + 1"/>; }
 }
 </t>
+server {
+    listen 8080;
+    server_name ~.+\.<t t-raw="re_escape(fqdn)"/>$;
+    location / { return 404; }
+}
 }
       </template>
     </data>


### PR DESCRIPTION
When someone tries to log in an old runbot build that is not running
anymore, he lands on the runbot instance that was running the build.
Also, all the running builds are allowed on all runbot instances,
leading to the same behavior.

With this commit, only the builds that are running on the runbot
instance can be reached, others are defaulted to a 404.