### PR TITLE
[FIX] runbot: add recycle icon only once

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '2.1',
+    'version': '2.2',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -35,6 +35,8 @@ class Runbot(http.Controller):
             'duplicate_of': build.duplicate_id if build.state == 'duplicate' else False,
             'coverage': build.coverage or build.branch_id.coverage,
             'revdep_build_ids': sorted(build.revdep_build_ids, key=lambda x: x.repo_id.name),
+            'build_type' : build.build_type,
+            'build_type_label': dict(build.fields_get('build_type', 'selection')['build_type']['selection']).get(build.build_type, build.build_type),
         }
 
     def _pending(self):

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -66,6 +66,13 @@ class runbot_build(models.Model):
     extra_params = fields.Char('Extra cmd args')
     coverage = fields.Boolean('Enable code coverage')
     coverage_result = fields.Float('Coverage result', digits=(5, 2))
+    build_type = fields.Selection([('scheduled', 'This build was automatically scheduled'),
+                                   ('rebuild', 'This build is a rebuild'),
+                                   ('normal', 'normal build'),
+                                   ('indirect', 'Automatic rebuild'),
+                                   ],
+                                  default='normal',
+                                  string='Build type')
 
     def copy(self, values=None):
         raise UserError("Cannot duplicate build!")
@@ -283,8 +290,9 @@ class runbot_build(models.Model):
                     'author_email': build.author_email,
                     'committer': build.committer,
                     'committer_email': build.committer_email,
-                    'subject': u'♻️ %s' % build.subject,
+                    'subject': build.subject,
                     'modules': build.modules,
+                    'build_type': 'rebuild'
                 })
                 build = new_build
             else:

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -223,6 +223,7 @@ class runbot_repo(models.Model):
                         latest_rev_build = Build.search([('repo_id.id', '=', rev_repo.id), ('branch_id.branch_name', '=', branch.branch_name)], order='id desc', limit=1)
                         if latest_rev_build:
                             _logger.debug('Reverse dependency build %s forced in repo %s by commit %s', latest_rev_build.dest, rev_repo.name, sha[:6])
+                            latest_rev_build.build_type = 'indirect'
                             new_build.revdep_build_ids += latest_rev_build._force(message='Rebuild from dependency %s commit %s' % (repo.name, sha[:6]))
 
         # skip old builds (if their sequence number is too low, they will not ever be built)

--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -61,6 +61,8 @@
                         </t>
                         <br/>
                         <i class="fa fa-envelope-o"></i>
+                        <t t-if="bu['build_type']=='scheduled'"><i class="fa fa-clock-o" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
+                        <t t-if="bu['build_type'] in ('rebuild', 'redirect')"><i class="fa fa-recycle" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
                         <a t-attf-href="https://#{repo['base']}/commit/#{bu['name']}"><t t-esc="bu['subject'][:32] + ('...' if bu['subject'][32:] else '') " t-att-title="bu['subject']"/></a>
                         <br/>
                         <t t-call="runbot.build_name"/> — <small><a t-attf-href="/runbot/build/{{bu['id']}}"><t t-esc="bu['dest']"/></a> on <t t-esc="bu['host']"/> <a t-if="bu['state'] == 'running'" t-attf-href="http://{{bu['domain']}}/?db={{bu['dest']}}-all"><i class="fa fa-sign-in"></i></a></small>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -149,6 +149,8 @@
                                   <t t-if="bu['state'] in ['running','done'] and bu['result'] in ['killed', 'manually_killed']"><t t-set="klass">killed</t></t>
                                   <td t-attf-class="{{klass}}">
                                      <t t-call="runbot.build_button"><t t-set="klass">btn-group-sm</t></t>
+                                     <t t-if="bu['build_type']=='scheduled'"><i class="fa fa-clock-o" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
+                                     <t t-if="bu['build_type'] in ('rebuild', 'indirect')"><i class="fa fa-recycle" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
                                      <t t-if="bu['subject']">
                                           <span t-esc="bu['subject'][:32] + ('...' if bu['subject'][32:] else '') " t-att-title="bu['subject']"/>
                                            <br/>


### PR DESCRIPTION
Adding a unicode icon in the subject led to some issues. e.g. a user doesn't have any clue of what the icon really means. Also, the icon not the same everywhere, depending on the browser and the fonts installed.

With this commit, a field is added to differentiate build types. Using that information, an fa icon is displayed with the appropriate title description.
