### PR TITLE
[IMP] runbot: add link to the latest coverage

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -81,12 +81,17 @@ class runbot_branch(models.Model):
         r[self.id] = "http://%s/web/login?db=%s-all&login=admin&redirect=/web?debug=1" % (fqdn, dest)
         return r
 
-    def _get_last_coverage(self):
-        """ Return the coverage result of the last build in branch """
-        for branch in self:
-            last_build = self.env['runbot.build'].search([
-                ('branch_id.id', '=', branch.id),
+    def _get_last_coverage_build(self):
+        """ Return the last build with a coverage value > 0"""
+        self.ensure_one()
+        return self.env['runbot.build'].search([
+                ('branch_id.id', '=', self.id),
                 ('state', 'in', ['done', 'running']),
                 ('coverage_result', '>=', 0.0),
             ], order='sequence desc', limit=1)
+
+    def _get_last_coverage(self):
+        """ Compute the coverage result of the last build in branch """
+        for branch in self:
+            last_build = branch._get_last_coverage_build()
             branch.coverage_result = last_build.coverage_result or 0.0

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -127,7 +127,15 @@
                                   </div>
                                   <t t-if="br['branch'].sticky">
                                       <br/>
-                                      <span class="label label-info">cov: <t t-esc="br['branch'].coverage_result"/>%</span>
+                                      <t t-if="br['branch'].coverage_result > 0">
+                                        <t t-set="last_build" t-value="br['branch']._get_last_coverage_build()" />
+                                        <a t-attf-href="http://{{last_build['host']}}/runbot/static/build/#{last_build['dest']}/coverage/index.html">
+                                        <span class="label label-info">cov: <t t-esc="br['branch'].coverage_result"/>%</span>
+                                      </a>
+                                      </t>
+                                      <t t-else="">
+                                        <span class="label label-info">cov: <t t-esc="br['branch'].coverage_result"/>%</span>
+                                      </t>
                                   </t>
                               </td>
                               <t t-foreach="br['builds']" t-as="bu">


### PR DESCRIPTION
On the frontend, the coverage is a static indication.
With this commit, this indication is now a link to the coverage details
page.