### PR TITLE
[IMP] runbot: replace clock by moon icon

### DIFF
--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -61,7 +61,7 @@
                         </t>
                         <br/>
                         <i class="fa fa-envelope-o"></i>
-                        <t t-if="bu['build_type']=='scheduled'"><i class="fa fa-clock-o" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
+                        <t t-if="bu['build_type']=='scheduled'"><i class="fa fa-moon-o" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
                         <t t-if="bu['build_type'] in ('rebuild', 'redirect')"><i class="fa fa-recycle" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
                         <a t-attf-href="https://#{repo['base']}/commit/#{bu['name']}"><t t-esc="bu['subject'][:32] + ('...' if bu['subject'][32:] else '') " t-att-title="bu['subject']"/></a>
                         <br/>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -149,7 +149,7 @@
                                   <t t-if="bu['state'] in ['running','done'] and bu['result'] in ['killed', 'manually_killed']"><t t-set="klass">killed</t></t>
                                   <td t-attf-class="{{klass}}">
                                      <t t-call="runbot.build_button"><t t-set="klass">btn-group-sm</t></t>
-                                     <t t-if="bu['build_type']=='scheduled'"><i class="fa fa-clock-o" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
+                                     <t t-if="bu['build_type']=='scheduled'"><i class="fa fa-moon-o" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
                                      <t t-if="bu['build_type'] in ('rebuild', 'indirect')"><i class="fa fa-recycle" t-att-title="bu['build_type_label']" t-att-aria-label="bu['build_type_label']"/></t>
                                      <t t-if="bu['subject']">
                                           <span t-esc="bu['subject'][:32] + ('...' if bu['subject'][32:] else '') " t-att-title="bu['subject']"/>


### PR DESCRIPTION
For scheduled build
While schedule can be at any time, it typically runs during the night, hence the moon

![screenshot_2018-08-13 runbot repo](https://user-images.githubusercontent.com/564822/44023421-8f2844ae-9eea-11e8-93d9-6423eaf13f6e.png)

```shell
$ sed -i 's|fa-clock-o|fa-moon-o|g' runbot/*/*.xml
```