### PR TITLE
[IMP] runbot: skip an additional port for chrome

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -377,7 +377,7 @@ class runbot_build(models.Model):
 
         # find next free port
         while port in ports:
-            port += 2
+            port += 3
         return port
 
     def _logger(self, *l):


### PR DESCRIPTION
In a near future, Odoo will use Chrome Headless instead of phantomjs.
Chrome needs a port to listen to and it was decided that it will be
http_port + 2.
With this commit, we ensure that this port is not used by another build.