### PR TITLE
[IMP] runbot: perform fetch with one git command

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -143,8 +143,7 @@ class runbot_repo(models.Model):
                               repo.name, int(t0 - fetch_time), int(t0 - dt2time(repo.hook_time)))
                 return
 
-        repo._git(['fetch', '-p', 'origin', '+refs/heads/*:refs/heads/*'])
-        repo._git(['fetch', '-p', 'origin', '+refs/pull/*/head:refs/pull/*'])
+        repo._git(['fetch', '-p', 'origin', '+refs/heads/*:refs/heads/*', '+refs/pull/*/head:refs/pull/*'])
 
         fields = ['refname', 'objectname', 'committerdate:iso8601', 'authorname', 'authoremail', 'subject', 'committername', 'committeremail']
         fmt = "%00".join(["%(" + field + ")" for field in fields])


### PR DESCRIPTION
This improves the time needed to fetch the refs from https://github.com/odoo/odoo.

Running 2 commands needs to sessions on the client and server to fetch the refs. Running both fetches in one command drastically safes time needed for the fetches.

Performance tests taken on my system indicate safed time of 2seconds per run of repo._schedule (if no refs are updated):
```
(venv) bigbear3001@wt-io-it-bigbear3001:~/Documents/workspace_odoo11/runbot/runbot/static/repo/https___github.com_odoo_odoo.git$ time bash -c 'git fetch -p origin +refs/heads/*:refs/heads/* && git fetch -p origin +refs/pulls/*:refs/pulls/*'

real    0m4,440s
user    0m0,184s
sys     0m0,083s
(venv) bigbear3001@wt-io-it-bigbear3001:~/Documents/workspace_odoo11/runbot/runbot/static/repo/https___github.com_odoo_odoo.git$ time bash -c 'git fetch -p origin +refs/heads/*:refs/heads/* +refs/pulls/*:refs/pulls/*'

real    0m1,961s
user    0m0,117s
sys     0m0,039s
```

As repo._schedule is (should be) invoked every 10 seconds this improves runbot performance quite a bit (on our system we are never able to complete a repo._schedule run within 10 seconds)