### PR TITLE
[IMP] runbot: add a frontend template

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -22,6 +22,7 @@
         'templates/dashboard.xml',
         'templates/nginx.xml',
         'templates/badge.xml',
+        'templates/branch.xml',
         'data/runbot_cron.xml'
     ],
 }

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -331,3 +331,19 @@ class Runbot(http.Controller):
             'data': ctx,
         }
         return request.render("runbot.glances", qctx)
+
+    @http.route(['/runbot/branch/<int:branch_id>', '/runbot/branch/<int:branch_id>/page/<int:page>'], website=True, auth='public', type='http')
+    def branch_builds(self, branch_id=None, search='', page=1, limit=50, refresh='', **kwargs):
+        """ list builds of a runbot branch """
+        builds_count = request.env['runbot.build'].search_count([('branch_id','=',branch_id)])
+        pager = request.website.pager(
+            url='/runbot/branch/%s' % branch_id,
+            total=builds_count,
+            page=page,
+            step=50
+        )
+        builds = request.env['runbot.build'].search([('branch_id','=',branch_id)], limit=limit, offset=pager.get('offset',0))
+
+        context = {'pager': pager, 'builds': builds}
+        return request.render("runbot.branch", context)
+

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data>
+    <template id="runbot.branch">
+        <t t-call='website.layout'>
+          <div class="container-fluid">
+              <div class="row">
+                  <div class='col-md-12'>
+                        <div class="navbar navbar-default">
+                            <span class="text-center" style="font-size: 18px;">Builds for branch: <t t-esc="builds[0].branch_id.name.split('/')[-1]" /></span>
+                            <span class="pull-right"><t t-call="website.pager" /></span>
+                        </div>
+                    <table class="table table-condensed table-stripped" style="table-layout: initial;">
+                        <thead>
+                            <tr>
+                                <th>Seq</th>
+                                <th>Date</th>
+                                <th>Dest</th>
+                                <th>Subject</th>
+                                <th>Revno</th>
+                                <th>result</th>
+                                <th>state</th>
+                                <th>host</th>
+                                <th>job</th>
+                                <th>duration</th>
+                                <th>type</th>
+                            </tr>
+                        </thead>
+                        <t t-foreach="builds" t-as="build">
+                            <t t-if="build['state'] in ['running','done'] and build['result'] == 'ko'"><t t-set="rowclass">danger</t></t>
+                            <t t-if="build['state'] in ['running','done'] and build['result'] == 'warn'"><t t-set="rowclass">warning</t></t>
+                            <t t-if="build['state'] in ['running','done'] and build['result'] == 'ok'"><t t-set="rowclass">success</t></t>
+                            <t t-if="build['state'] in ['running','done'] and build['result'] == 'skipped'"><t t-set="rowclass">default</t></t>
+                            <t t-if="build['state'] in ['running','done'] and build['result'] in ['killed', 'manually_killed']"><t t-set="rowclass">killed</t></t>
+                            <tr t-attf-class="{{rowclass}}">
+                                <td><t t-esc="build.sequence" /></td>
+                                <td><t t-esc="build.date" /></td>
+                                <td><a t-attf-href="/runbot/build/{{build['id']}}" title="Build details" aria-label="Build details"><t t-esc="build.dest" /></a></td>
+                                <td><t t-esc="build.subject" /></td>
+                                <td><t t-esc="build.name" /></td>
+                                <td><t t-esc="build.result" /></td>
+                                <td><t t-esc="build.state" /></td>
+                                <td><t t-esc="build.host" /></td>
+                                <td><t t-esc="build.job" /></td>
+                                <td><t t-esc="build.job_time" /></td>
+                                <td><t t-esc="build.build_type" /></td>
+                            </tr>
+                        </t>
+                    </table>
+                  </div>
+              </div>
+          </div>
+        </t>
+    </template>
+  </data>
+</odoo>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -119,7 +119,7 @@
                           <tr t-foreach="branches" t-as="br">
                               <td>
                                   <i t-if="br['branch'].sticky" class="fa fa-star" style="color: #f0ad4e" />
-                                  <b t-esc="br['branch'].branch_name"/>
+                                  <a t-attf-href="/runbot/branch/#{br['branch'].id}"><b t-esc="br['branch'].branch_name"/></a>
                                   <small><t t-esc="br['builds'] and br['builds'][0]['job_age']"/></small><br/>
                                   <div class="btn-group btn-group-xs">
                                       <a t-attf-href="{{br['branch'].branch_url}}" class="btn btn-default btn-xs">Branch or pull <i class="fa fa-github"/></a>


### PR DESCRIPTION
The frontend view shows only the four last builds by branch, which is a
little bit small to explore builds and search for failed builds.

With this commit, a new frontend template displays a paged list of
builds for a specified branch.