### PR TITLE
[IMP] runbot: add priority field on branch

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '2.2',
+    'version': '2.3',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',

--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -25,7 +25,7 @@ class runbot_branch(models.Model):
     state = fields.Char('Status')
     modules = fields.Char("Modules to Install", help="Comma-separated list of modules to install and test.")
     job_timeout = fields.Integer('Job Timeout (minutes)', help='For default timeout: Mark it zero')
-    # test_tags = fields.Char("Test tags", help="Tags for the --test-tags params (same syntax)")  # keep for next version
+    priority = fields.Boolean('Build priority', default=False)
 
     @api.depends('name')
     def _get_branch_name(self):

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -261,9 +261,9 @@ class runbot_repo(models.Model):
 
         while testing < workers and pending > 0:
 
-            # find sticky pending build if any, otherwise, last pending (by id, not by sequence) will do the job
+            # find sticky / priority pending build if any, otherwise, last pending (by id, not by sequence) will do the job
 
-            pending_ids = Build.search(domain + [('state', '=', 'pending'), ('branch_id.sticky', '=', True)], limit=1)
+            pending_ids = Build.search(domain + [('state', '=', 'pending'), '|', ('branch_id.sticky', '=', True), ('branch_id.priority', '=', True)], limit=1)
             if not pending_ids:
                 pending_ids = Build.search(domain + [('state', '=', 'pending')], order="sequence", limit=1)
 

--- a/runbot/views/branch_views.xml
+++ b/runbot/views/branch_views.xml
@@ -15,6 +15,7 @@
                 <field name="branch_url"/>
                 <field name="pull_head_name"/>
                 <field name="sticky"/>
+                <field name="priority"/>
                 <field name="coverage"/>
                 <field name="state"/>
                 <field name="modules"/>
@@ -37,6 +38,7 @@
                 <field name="repo_id"/>
                 <field name="name"/>
                 <field name="sticky"/>
+                <field name="priority"/>
                 <field name="coverage"/>
                 <field name="state"/>
             </tree>


### PR DESCRIPTION
This commit permits to prioritize a branch when scheduling builds.
It's main purpose is for the runbot_merge module. It avoids to have
staging branches as sticky and pollutes the main repo view.
Also, that branch can benefit of the autokill feature when a newer build
is found, freeing ressources for other builds.