### PR TITLE
[FIX] runbot: store pull_head_name on branch

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -73,7 +73,7 @@ class runbot_branch(models.Model):
         for branch in self:
             pi = self._get_pull_info()
             if pi:
-                self.pull_head_name = pi['head']['ref']
+                branch.pull_head_name = pi['head']['ref']
 
     def _get_branch_quickconnect_url(self, fqdn, dest):
         self.ensure_one()


### PR DESCRIPTION
This one flew under the radar because it only affects a PR when its
branch name changes.