### PR TITLE
[REF] runbot: store the target branch name

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '2.3',
+    'version': '2.4',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -134,6 +134,7 @@ class runbot_build(models.Model):
         build = self
         branch, repo = build.branch_id, build.repo_id
         name = branch.pull_head_name or branch.branch_name
+        target_branch = branch.target_branch_name or 'master'
 
         target_repo = self.env['runbot.repo'].browse(target_repo_id)
 
@@ -216,7 +217,7 @@ class runbot_build(models.Model):
                 return target_id, b, 'fuzzy'
 
         # 5. last-resort value
-        return target_repo_id, 'master', 'default'
+        return target_repo_id, target_branch, 'default'
 
     @api.depends('name', 'branch_id.name')
     def _get_dest(self):


### PR DESCRIPTION
In the case of PR, the name contains 'refs/pull/3175', the branch_name
contains '3175' and because of the previous fix e095170f8c98, the
pull_head_name sontains something like 'blah:12.0-something'.

In that case, the _get_closest_branch_name reaches the fallback.

With this commit, the target_branch_name is stored in a new field and is
used as the fallback.