### PR TITLE
[FIX] runbot, runbot_cla: notify each repo of cla status

### DIFF
--- a/runbot_cla/runbot.py
+++ b/runbot_cla/runbot.py
@@ -38,6 +38,6 @@ class runbot_build(models.Model):
                 "context": "legal/cla"
             }
             build._log('check_cla', 'CLA %s' % state)
-            build.repo_id._github('/repos/:owner/:repo/statuses/%s' % build.name, status, ignore_errors=True)
+            build._github_status_notify_all(status)
         # 0 is myself, -1 is everybody else, -2 nothing
         return -2


### PR DESCRIPTION
When a PR is a duplicate of a branch, only the branch CLA status are
update. The same issue for build status was fixed in commit 4f1a55da9.

With this commit, there is new method than can be used in runbot_cla.
This method updates commit given status in each repo.