### PR TITLE
[IMP] runbot_merge: send feedback when merge method is changed

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -625,6 +625,11 @@ class PullRequests(models.Model):
                 if is_admin:
                     self.merge_method = param
                     ok = True
+                    Feedback.create({
+                        'repository': self.repository.id,
+                        'pull_request': self.number,
+                        'message':"Merge method set to %s" % param
+                    })
 
             _logger.info(
                 "%s %s(%s) on %s:%s by %s (%s)",


### PR DESCRIPTION
When a user changes the merge method via github messages, no feedback is
sent. This could lead to strange behavior, for example when a user try
to joke with the mergebot like this:
robodoo are you goin ti merge my PR rogntudju !
This set the merge method to "merge" and the user is not aware of it.

With this commit, a feedback is sent via github.