### PR TITLE
[FIX] runbot: fix name in branch matching for pull requests

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -186,8 +186,10 @@ class runbot_build(models.Model):
         )
         branches = sorted(branches, key=sort_by_repo)
 
+        # for prefix matching we remove the pull request prefix (project_name:) from the pull_head_name
+        name_for_prefix_match = branch.pull_head_name and branch.pull_head_name.split(':', 1)[-1] or branch.branch_name
         for branch in branches:
-            if name.startswith(branch['branch_name'] + '-') and self._branch_exists(branch['id']):
+            if name_for_prefix_match.startswith(branch['branch_name'] + '-') and self._branch_exists(branch['id']):
                 return result_for(branch, 'prefix')
 
         # 4. Common ancestors (git merge-base)


### PR DESCRIPTION
since 439e336a2f0e401b7cae6bb401d3ad77694db1a9 the pull_head_name
consists of the label (project_name:branch_name) therefore we need only
the last part of the label for finding the closest branch

Info @wt-io-it