### PR TITLE
Support for blacklisting branches (builds-wise)

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '2.5',
+    'version': '2.6',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',

--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -27,6 +27,12 @@ class runbot_branch(models.Model):
     modules = fields.Char("Modules to Install", help="Comma-separated list of modules to install and test.")
     job_timeout = fields.Integer('Job Timeout (minutes)', help='For default timeout: Mark it zero')
     priority = fields.Boolean('Build priority', default=False)
+    job_type = fields.Selection([
+        ('testing', 'Testing jobs only'),
+        ('running', 'Running job only'),
+        ('all', 'All jobs'),
+        ('none', 'Do not execute jobs')
+    ], required=True, default='all')
 
     @api.depends('name')
     def _get_branch_infos(self):

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -248,7 +248,7 @@ class runbot_repo(models.Model):
         host = fqdn()
 
         Build = self.env['runbot.build']
-        domain = [('repo_id', 'in', ids)]
+        domain = [('repo_id', 'in', ids), ('branch_id.job_type', '!=', 'none')]
         domain_host = domain + [('host', '=', host)]
 
         # schedule jobs (transitions testing -> running, kill jobs, ...)

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_branch
 from . import test_build
 from . import test_jobs
 from . import test_frontend
+from . import test_job_types

--- a/runbot/tests/test_branch.py
+++ b/runbot/tests/test_branch.py
@@ -22,6 +22,7 @@ class Test_Branch(common.TransactionCase):
 
         self.assertEqual(branch.branch_name, 'master')
         self.assertEqual(branch.branch_url, 'https://example.com/foo/bar/tree/master')
+        self.assertEqual(branch.job_type, 'all')
 
     @patch('odoo.addons.runbot.models.repo.runbot_repo._github')
     def test_pull_request(self, mock_github):

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -112,6 +112,33 @@ class Test_Build(common.TransactionCase):
         self.assertEqual(dev_build.state, 'duplicate')
         self.assertEqual(dev_build.duplicate_id.id, pr_build.id)
 
+    def test_build_job_type_from_branch_default(self):
+        """test build job_type is computed from branch default job_type"""
+        build = self.Build.create({
+            'branch_id': self.branch.id,
+            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
+        })
+        self.assertEqual(build.job_type, 'all', "job_type should be the same as the branch")
+
+    def test_build_job_type_from_branch_none(self):
+        """test build job_type is computed from branch"""
+        self.branch.job_type = 'none'
+        build = self.Build.create({
+            'branch_id': self.branch.id,
+            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
+        })
+        self.assertEqual(build.job_type, 'none', "job_type should be the same as the branch")
+
+    def test_build_job_type_can_be_set(self):
+        """test build job_type can be set to something different than the one on the branch"""
+        self.branch.job_type = 'running'
+        build = self.Build.create({
+            'branch_id': self.branch.id,
+            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
+            'job_type': 'testing'
+        })
+        self.assertEqual(build.job_type, 'testing', "job_type should be the one set on the build")
+
     @patch('odoo.addons.runbot.models.branch.runbot_branch._is_on_remote')
     def test_closest_branch_01(self, mock_is_on_remote):
         """ test find a matching branch in a target repo based on branch name """

--- a/runbot/tests/test_job_types.py
+++ b/runbot/tests/test_job_types.py
@@ -1,0 +1,55 @@
+
+# -*- coding: utf-8 -*-
+from time import localtime
+from unittest.mock import patch
+from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tests import common
+
+
+class Test_Jobs(common.TransactionCase):
+
+
+    def setUp(self):
+        super(Test_Jobs, self).setUp()
+        self.Repo = self.env['runbot.repo']
+        self.repo = self.Repo.create({'name': 'bla@example.com:foo/bar', 'token': 'xxx'})
+        self.Branch = self.env['runbot.branch']
+        self.branch_master = self.Branch.create({
+            'repo_id': self.repo.id,
+            'name': 'refs/heads/master',
+        })
+        self.Build = self.env['runbot.build']
+        self.build = self.Build.create({
+            'branch_id': self.branch_master.id,
+            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
+            'port' : '1234',
+        })
+
+    @patch('odoo.addons.runbot.models.build.docker_run')
+    @patch('odoo.addons.runbot.models.build.runbot_build._local_pg_createdb')
+    def test_job_10(self, mock_create_db, mock_docker_run):
+        """ Test that job10 is done or skipped depending on job_type """
+        # test that the default job_type value executes the tests
+        mock_docker_run.return_value = "Mocked run"
+        ret = self.Build._job_10_test_base(self.build, '/tmp/x.log')
+        self.assertEqual("Mocked run", ret, "A branch with default job_type should run job_10")
+
+        # test skip when job_type is none
+        self.build.job_type = 'none'
+        ret = self.Build._job_10_test_base(self.build, '/tmp/x.log')
+        self.assertEqual(-2, ret, "A branch with job_type 'none' should skip job_10")
+
+        # test skip when job_type is running
+        self.build.job_type = 'running'
+        ret = self.Build._job_10_test_base(self.build, '/tmp/x.log')
+        self.assertEqual(-2, ret, "A branch with job_type 'running' should skip job_10")
+
+        # test run when job_type is testing
+        self.build.job_type = 'testing'
+        ret = self.Build._job_10_test_base(self.build, '/tmp/x.log')
+        self.assertEqual("Mocked run", ret, "A branch with job_type 'testing' should run job_10")
+
+        # test run when job_type is all
+        self.build.job_type = 'all'
+        ret = self.Build._job_10_test_base(self.build, '/tmp/x.log')
+        self.assertEqual("Mocked run", ret, "A branch with job_type 'all' should run job_10")

--- a/runbot/views/branch_views.xml
+++ b/runbot/views/branch_views.xml
@@ -16,6 +16,7 @@
                 <field name="pull_head_name"/>
                 <field name="sticky"/>
                 <field name="priority"/>
+                <field name="job_type"/>
                 <field name="coverage"/>
                 <field name="state"/>
                 <field name="modules"/>
@@ -39,6 +40,7 @@
                 <field name="name"/>
                 <field name="sticky"/>
                 <field name="priority"/>
+                <field name="job_type"/>
                 <field name="coverage"/>
                 <field name="state"/>
             </tree>

--- a/runbot_cla/runbot.py
+++ b/runbot_cla/runbot.py
@@ -5,6 +5,7 @@ import io
 import logging
 import re
 
+from odoo.addons.runbot.models.build import runbot_job
 from odoo import models
 
 _logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ _logger = logging.getLogger(__name__)
 class runbot_build(models.Model):
     _inherit = "runbot.build"
 
+    @runbot_job('testing')
     def _job_05_check_cla(self, build, log_path):
         cla_glob = glob.glob(build._path("doc/cla/*/*.md"))
         if cla_glob:


### PR DESCRIPTION
On our runbot, there's no reason to build or mount tmp branches (they're where runbot_merge sets up / creates the branches it's eventually staging so there's a lot of churn none of which matters).
Also, there is little reasons to keep staging branches running after the build.

This PR adds a selection field to choose the kind of jobs wanted for the branches, that way the tmp branches can be ignored and the staging branches can be built but not keeping running.

The ability to create ignore patterns at the repo level (or somesuch) might eventually be useful, but for now it looks way overkill: new tmp branches only get defined when adding new branches/targets to runbot_merge, and it's not super problematic if we forget to blacklist one such branch, it just creates some unnecessary builds/churns.