### PR TITLE
[FIX] runbot: speedup and limit search in frontend

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -47,7 +47,8 @@ class Runbot(Controller):
         return count, level
 
     @route(['/runbot', '/runbot/repo/<model("runbot.repo"):repo>'], website=True, auth='public', type='http')
-    def repo(self, repo=None, search='', limit='100', refresh='', **kwargs):
+    def repo(self, repo=None, search='', refresh='', **kwargs):
+        search = search if len(search) < 60 else search[:60]
         branch_obj = request.env['runbot.branch']
         build_obj = request.env['runbot.build']
         repo_obj = request.env['runbot.repo']
@@ -64,7 +65,6 @@ class Runbot(Controller):
             'host_stats': [],
             'pending_total': pending[0],
             'pending_level': pending[1],
-            'limit': limit,
             'search': search,
             'refresh': refresh,
         }
@@ -81,7 +81,7 @@ class Runbot(Controller):
                     search_domain += [('dest', 'ilike', to_search), ('subject', 'ilike', to_search), ('branch_id.branch_name', 'ilike', to_search)]
                 domain += search_domain[1:]
 
-            build_ids = build_obj.search(domain, limit=int(limit))
+            build_ids = build_obj.search(domain, limit=100)
             branch_ids, build_by_branch_ids = [], {}
 
             if build_ids:
@@ -137,7 +137,7 @@ class Runbot(Controller):
                 'testing': build_obj.search_count([('repo_id', '=', repo.id), ('state', '=', 'testing')]),
                 'running': build_obj.search_count([('repo_id', '=', repo.id), ('state', '=', 'running')]),
                 'pending': build_obj.search_count([('repo_id', '=', repo.id), ('state', '=', 'pending')]),
-                'qu': QueryURL('/runbot/repo/' + slug(repo), search=search, limit=limit, refresh=refresh, **filters),
+                'qu': QueryURL('/runbot/repo/' + slug(repo), search=search, refresh=refresh, **filters),
                 'filters': filters,
             })
 

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -82,10 +82,6 @@
                                         <li t-if="filters['running']=='1'"><a t-att-href="qu(running='0')"><i class="fa fa-check"/> Running</a></li>
                                         <li t-if="filters['done']=='0'"><a t-att-href="qu(done=1)">Done</a></li>
                                         <li t-if="filters['done']=='1'"><a t-att-href="qu(done='0')"><i class="fa fa-check"/> Done</a></li>
-                                        <li class="divider"></li>
-                                        <li t-att-class="'active' if limit=='100' else ''"><a t-att-href="qu(limit=100)">Show last 100</a></li>
-                                        <li t-att-class="'active' if limit=='1000' else ''"><a t-att-href="qu(limit=1000)">Show last 1000</a></li>
-                                        <li t-att-class="'active' if limit=='10000' else ''"><a t-att-href="qu(limit=10000)">Show last 10000</a></li>
                                       </ul>
                                     </div>
                                   </form>


### PR DESCRIPTION
When searching the builds for the frontend the resulting query can last
a very long time (up to 7sec).

With this commit, the search result is strictly limited to 1000 builds
and the search string length is limited to 60 chars.

Also, the branch_id many2one field on build is set to auto_join in order
to generate a better sql query. Thanks @tbe-odoo.