### PR TITLE
[FIX] runbot: move transifex config dir to odoo/addons

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -547,6 +547,9 @@ class runbot_build(models.Model):
                         'Building environment',
                         'Server built based on commit %s from %s' % (commit_oneline, closest_name)
                     )
+                    # move transifex config before it gets overwritten by the one from community
+                    if os.path.isdir(build._path('.tx')):
+                        shutil.move(build._path('.tx'), build._server('addons'))
                     repo._git_export(closest_name, build._path())
 
                 # Finally mark all addons to move to openerp/addons


### PR DESCRIPTION
The odoo transifex module uses the .tx/config file to find translated
modules. This module search for .tx/config file in the addons_path
and their parent directories. In the case of an enterprise build, the
repo is exported to the build directory and right after that, the
community (server) repo is extracted, the .tx/config from enterprise is
overwritten.

With this commit, the .tx directory is moved to odoo/addons before it
gets overwritten by the one from the server.