### PR TITLE
[FIX] runbot: avoid recursive duplicate repos

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -11,6 +11,7 @@ import subprocess
 import time
 
 from odoo import models, fields, api
+from odoo.exceptions import ValidationError
 from odoo.modules.module import get_module_resource
 from odoo.tools import config
 from ..common import fqdn, dt2time
@@ -48,6 +49,11 @@ class runbot_repo(models.Model):
         help="Community addon repos which need to be present to run tests.")
     token = fields.Char("Github token", groups="runbot.group_runbot_admin")
     group_ids = fields.Many2many('res.groups', string='Limited to groups')
+
+    @api.constrains('duplicate_id')
+    def _check_000_duplicate_repo(self):
+        if not self._check_recursion(parent='duplicate_id'):
+            raise ValidationError('You cannot create recursive duplicated repos')
 
     def _root(self):
         """Return root directory of repository"""

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -47,7 +47,6 @@ class Test_Build(common.TransactionCase):
         """ test PR is a duplicate of a dev branch build """
         dup_repo = self.Repo.create({
             'name': 'bla@example.com:foo-dev/bar',
-            'duplicate_id': self.repo.id
         })
         self.repo.duplicate_id = dup_repo.id
         dev_branch = self.Branch.create({
@@ -74,7 +73,6 @@ class Test_Build(common.TransactionCase):
         """ test dev branch build is a duplicate of a PR """
         dup_repo = self.Repo.create({
             'name': 'bla@example.com:foo-dev/bar',
-            'duplicate_id': self.repo.id
         })
         self.repo.duplicate_id = dup_repo.id
         dev_branch = self.Branch.create({
@@ -86,16 +84,17 @@ class Test_Build(common.TransactionCase):
             'name': 'refs/pull/12345'
         })
 
-        pr_build = self.Build.create({
-            'branch_id': pr.id,
-            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
-        })
         dev_build = self.Build.create({
             'branch_id': dev_branch.id,
             'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
         })
-        self.assertEqual(dev_build.state, 'duplicate')
-        self.assertEqual(dev_build.duplicate_id.id, pr_build.id)
+
+        pr_build = self.Build.create({
+            'branch_id': pr.id,
+            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
+        })
+        self.assertEqual(pr_build.state, 'duplicate')
+        self.assertEqual(pr_build.duplicate_id.id, dev_build.id)
 
     @patch('odoo.addons.runbot.models.branch.runbot_branch._is_on_remote')
     def test_closest_branch_01(self, mock_is_on_remote):

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import patch
+from odoo.exceptions import ValidationError
 from odoo.tests import common
 
 class Test_Repo(common.TransactionCase):
@@ -15,3 +16,12 @@ class Test_Repo(common.TransactionCase):
         self.assertEqual(repo.path, '/tmp/static/repo/bla_example.com_foo_bar')
 
         self.assertEqual(repo.base, 'example.com/foo/bar')
+
+    def test_duplicate_repo_cross_reference(self):
+        """ Test that a repo is not cross referenced in its duplicate repo """
+        repo = self.Repo.create({'name': 'bla@example.com:foo/bar'})
+        repo_dev = self.Repo.create({'name': 'bla@example.com:foo-dev/bar'})
+
+        repo.duplicate_id = repo_dev.id
+        with self.assertRaises(ValidationError):
+            repo_dev.duplicate_id = repo.id


### PR DESCRIPTION
When defining a duplicate repository on repo A pointing to repo B, it
happens that repo B already has a duplicate repository pointing to A.
In that case, an infinite loop may happen.

With this commit, a validation error is raised whenever that happens.

Note: two other test are fixed here because they were using that kind of
recursive reference.