### PR TITLE
[IMP]: runbot_merge: sort unready PRs alphabetically

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -769,7 +769,7 @@ class PullRequests(models.Model):
         for [ids] in self.env.cr.fetchall():
             prs = self.browse(ids)
             ready = prs.filtered(lambda p: p.state == 'ready')
-            unready = (prs - ready).sorted()
+            unready = (prs - ready).sorted(key=lambda p: (p.repository.name, p.number))
 
             for r in ready:
                 self.env['runbot_merge.pull_requests.feedback'].create({


### PR DESCRIPTION
The `_order` of pull requests are just the `number`.

Allow test `test_two_of_three_unready` to be reliable as both unready
PRs have the same number.