### PR TITLE
[FIX] runbot: terminate all active queries before dropping database

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -612,6 +612,9 @@ class runbot_build(models.Model):
 
     def _local_pg_dropdb(self, dbname):
         with local_pgadmin_cursor() as local_cr:
+            pid_col = 'pid' if local_cr._cnx.server_version >= 90200 else 'procpid'
+            query = 'SELECT pg_terminate_backend({}) FROM pg_stat_activity WHERE datname=%s'.format(pid_col)
+            local_cr.execute(query, [dbname])
             local_cr.execute('DROP DATABASE IF EXISTS "%s"' % dbname)
         # cleanup filestore
         datadir = appdirs.user_data_dir()


### PR DESCRIPTION
The docker using this database may still be alive.