### PR TITLE
[IMP] runbot: avoid running test when installing base

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -423,6 +423,11 @@ class runbot_build(models.Model):
                         build._logger('%s time exceded (%ss)', build.job, build.job_time)
                         build.write({'job_end': now()})
                         build._kill(result='killed')
+                    else:
+                        # failfast
+                        if not build.result and build.guess_result in ('ko', 'warn'):
+                            build.result = build.guess_result
+                            build._github_status()
                     continue
                 build._logger('%s finished', build.job)
                 # schedule

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -753,11 +753,8 @@ class runbot_build(models.Model):
     @runbot_job('testing')
     def _job_10_test_base(self, build, log_path):
         build._log('test_base', 'Start test base module')
-        # run base test
         self._local_pg_createdb("%s-base" % build.dest)
         cmd, mods = build._cmd()
-        if grep(build._server("tools/config.py"), "test-enable"):
-            cmd.append("--test-enable")
         cmd += ['-d', '%s-base' % build.dest, '-i', 'base', '--stop-after-init', '--log-level=test', '--max-cron-threads=0']
         if build.extra_params:
             cmd.extend(shlex.split(build.extra_params))


### PR DESCRIPTION
When running the _job_10 method, a database is created with base module
alone. Tests are enabled during this job. Those tests are run again with
the _job_20 method. Moreover, even if the tests fail during _job_10,
they are not taken into account for the final result. The _job_10 method
duration is approximately 4 min.

With this commit, the tests are not enabled during _job_10.