### PR TITLE
[FIX] runbot_merge: keep co-authored-by

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -813,7 +813,13 @@ class PullRequests(models.Model):
         ), message)
         if m:
             return message
-        return message + '\n\ncloses {pr.repository.name}#{pr.number}'.format(pr=self)
+        message_lines = message.split('\n')
+        index = len(message_lines) - 1
+        while message_lines[index].lower().startswith("co-authored-by"):
+            index -= 1
+        return '\n'.join(message_lines[:index]) + \
+            '\n\ncloses {pr.repository.name}#{pr.number}\n'.format(pr=self) + \
+            '\n'.join(message_lines[index+1:])
 
     def _stage(self, gh, target):
         # nb: pr_commits is oldest to newest so pr.head is pr_commits[-1]


### PR DESCRIPTION
The runbot was not preserving the Co-authored-by instructions
To be recognized correctly by github, the authoring must end the commit message
mergebot was adding "closes ..." message at the end

cf https://help.github.com/articles/creating-a-commit-with-multiple-authors/