### PR TITLE
[FIX] runbot: search common ancestor against build branch

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -230,7 +230,7 @@ class runbot_build(models.Model):
             """, [repo.id, target_id])
             for common_name, in self.env.cr.fetchall():
                 try:
-                    commit = repo._git(['merge-base', branch['name'], common_name]).strip()
+                    commit = repo._git(['merge-base', build.branch_id.name, common_name]).strip()
                     cmd = ['log', '-1', '--format=%cd', '--date=iso', commit]
                     common_refs[common_name] = repo._git(cmd).strip()
                 except CalledProcessError:


### PR DESCRIPTION
4 year bug introduction by 2e01744b0df61e6ab123c3b99b6bc90f18549652 in
which, the variable `branch` has been shadowed by the for loop in case
3.

42ae78f6476c7c12144caf33f656fd22b72299dc try to fix it, but incorrectly.