### PR TITLE
[FIX] runbot: limit number of log lines shown on build page

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -190,7 +190,7 @@ class Runbot(Controller):
             domain.append(('level', '=', level.upper()))
         if search:
             domain.append(('message', 'ilike', search))
-        logging_ids = Logging.sudo().search(domain)
+        logging_ids = Logging.sudo().search(domain, limit=10000)
 
         context = {
             'repo': build.repo_id,


### PR DESCRIPTION
When displaying build logs, all the messages from ir_logging about this
particular build are fetched from the database.

From time to times, it happens that the number of logged messages is
really huge. Those messages lines could also contain multiple lines,
multiplying the number of row to generate in the html page.
When this happens, the process that generates the template last a long
time and ends with a MemoryError. If the end user, bored, hits the
refresh button multiple times, all the workers will be busy building
this template. In the end, all users get a Bad Gateway from nginx.

With this commit, the number of messages that will be taken into account
will be limited to 10000.