### PR TITLE
Add sentry integration to more easily track issues

### DIFF
--- a/sentry/__init__.py
+++ b/sentry/__init__.py
@@ -1,0 +1,20 @@
+import logging
+from os import environ
+
+import sentry_sdk
+from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
+from sentry_sdk.integrations.logging import LoggingIntegration
+from odoo import http
+
+def load_sentry():
+    sentry_sdk.init(
+        environ['SENTRY_DSN'],
+        integrations=[
+            # note: if the colorformatter is enabled, sentry gets lost
+            # and classifies everything as errors because it fails to
+            # properly classify levels as the colorformatter injects
+            # the ANSI color codes right into LogRecord.levelname
+            LoggingIntegration(level=logging.INFO, event_level=logging.WARNING),
+        ]
+    )
+    http.root = SentryWsgiMiddleware(http.root)

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -1,0 +1,6 @@
+{
+    'name': "Sentry-SDK integration",
+    'summary': "Sentry-SDK integration module. Use --load=sentry,... to enable, can not be installed.",
+    'post_load': 'load_sentry',
+    'installable': False,
+}


### PR DESCRIPTION
Currently, we track mergebot (& runbot?) issues by checking the logs once in a while, or when colleagues arrive screaming the end of the world 
![philippulus_the_prophet](https://user-images.githubusercontent.com/7571158/53796795-2484a480-3f35-11e9-83a2-83e50261fd48.jpg)

Sending warnings and errors to sentry seems like it could be useful there. The saas already has an integration, but it uses the old client (raven as opposed to python-sdk) and it seems a bit extreme to install saas-management modules to get sentry reporting when the integration looks so simple (though I could have missed stuff).

OTOH this is not quite ideal as our org is permanently rate-limited. Still, issues do seem to go through (testing locally with reportable warning) so…