### PR TITLE
[FIX] runbot: use a repo short name to avoid bugs in qweb template

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -24,7 +24,7 @@ class runbot_repo(models.Model):
     _name = "runbot.repo"
 
     name = fields.Char('Repository', required=True)
-    # branch_ids = fields.One2many('runbot.branch', inverse_name='repo_id') # keep for next version
+    short_name = fields.Char('Repository', compute='_compute_short_name', store=False, readonly=True)
     sequence = fields.Integer('Sequence')
     path = fields.Char(compute='_get_path', string='Directory', readonly=True)
     base = fields.Char(compute='_get_base_url', string='Base URL', readonly=True)  # Could be renamed to a more explicit name like base_url
@@ -73,6 +73,11 @@ class runbot_repo(models.Model):
             name = re.sub('.git$', '', name)
             name = name.replace(':', '/')
             repo.base = name
+
+    @api.depends('name', 'base')
+    def _compute_short_name(self):
+        for repo in self:
+            repo.short_name = '/'.join(repo.base.split('/')[-2:])
 
     def _git(self, cmd):
         """Execute a git command 'cmd'"""

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -6,7 +6,7 @@
           <xpath expr="//t[@t-foreach=&quot;website.menu_id.child_id&quot;][@t-as=&quot;submenu&quot;]" position="replace">
               <t t-if="repos" >
                    <t t-foreach="repos[:5]" t-as="re">
-                       <li><a t-attf-href="/runbot/repo/{{slug(re)}}?search={{request.params.get('search', '')}}"><i class='fa fa-github' /> <t t-esc="re.name.split(':')[1]"/></a></li>
+                       <li><a t-attf-href="/runbot/repo/{{slug(re)}}?search={{request.params.get('search', '')}}"><i class='fa fa-github' /> <t t-esc="re.short_name"/></a></li>
                    </t>
               </t>
           </xpath>

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -15,3 +15,10 @@ class Test_Repo(common.TransactionCase):
         self.assertEqual(repo.path, '/tmp/static/repo/bla_example.com_foo_bar')
 
         self.assertEqual(repo.base, 'example.com/foo/bar')
+        self.assertEqual(repo.short_name, 'foo/bar')
+
+        https_repo = self.Repo.create({'name': 'https://bla@example.com/user/rep.git'})
+        self.assertEqual(https_repo.short_name, 'user/rep')
+
+        local_repo = self.Repo.create({'name': '/path/somewhere/rep.git'})
+        self.assertEqual(local_repo.short_name, 'somewhere/rep')


### PR DESCRIPTION
When using a local git repo, the git name does not have colon, making
the frontend crash.

With this commit, a non-stored computed field 'short_name' is added to
compute a shortest version of the name.