### PR TITLE
[IMP] runbot: split branch creation and pending builds creation

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -471,7 +471,7 @@ class runbot_build(models.Model):
 
         # update repo if needed
         if not build.repo_id._hash_exists(build.name):
-            build.repo_id._update(build.repo_id)
+            build.repo_id._update()
 
         # checkout branch
         build.branch_id.repo_id._git_export(build.name, build._path())
@@ -512,7 +512,7 @@ class runbot_build(models.Model):
                     '%s match branch %s of %s' % (build_dependency.match_type, closest_name, repo.name)
                 )
                 if not repo._hash_exists(latest_commit):
-                    repo._update(repo, force=True)
+                    repo._update(force=True)
                 if not repo._hash_exists(latest_commit):
                     repo._git(['fetch', 'origin', latest_commit])
                 if not repo._hash_exists(latest_commit):

--- a/runbot/tests/test_cron.py
+++ b/runbot/tests/test_cron.py
@@ -42,8 +42,8 @@ class Test_Cron(common.TransactionCase):
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_update_frequency', 1)
         ret = self.Repo._cron_fetch_and_schedule('runbotx.foo.com')
         self.assertEqual(None, ret)
-        mock_update.assert_called_with(self.Repo, force=False)
-        mock_create.assert_called_with(self.Repo)
+        mock_update.assert_called_with(force=False)
+        mock_create.assert_called_with()
 
     @patch('odoo.addons.runbot.models.repo.runbot_repo._get_cron_period')
     @patch('odoo.addons.runbot.models.repo.runbot_repo._reload_nginx')
@@ -56,5 +56,5 @@ class Test_Cron(common.TransactionCase):
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_update_frequency', 1)
         ret = self.Repo._cron_fetch_and_build('runbotx.foo.com')
         self.assertEqual(None, ret)
-        mock_scheduler.assert_called_with([])
+        mock_scheduler.assert_called()
         self.assertTrue(mock_reload.called)

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -1,13 +1,27 @@
 # -*- coding: utf-8 -*-
+from unittest import skip
 from unittest.mock import patch
 from odoo.tests import common
+import logging
 import odoo
+import time
+
+_logger = logging.getLogger(__name__)
+
 
 class Test_Repo(common.TransactionCase):
 
     def setUp(self):
         super(Test_Repo, self).setUp()
         self.Repo = self.env['runbot.repo']
+        self.commit_list = []
+
+    def mock_git_helper(self):
+        """Helper that returns a mock for repo._git()"""
+        def mock_git(repo, cmd):
+            if cmd[0] == 'for-each-ref' and self.commit_list:
+                return '\n'.join(['\0'.join(commit_fields) for commit_fields in self.commit_list])
+        return mock_git
 
     @patch('odoo.addons.runbot.models.repo.runbot_repo._root')
     def test_base_fields(self, mock_root):
@@ -23,6 +37,115 @@ class Test_Repo(common.TransactionCase):
 
         local_repo = self.Repo.create({'name': '/path/somewhere/rep.git'})
         self.assertEqual(local_repo.short_name, 'somewhere/rep')
+
+    @patch('odoo.addons.runbot.models.repo.runbot_repo._root')
+    def test_repo_create_pending_builds(self, mock_root):
+        """ Test that when finding new refs in a repo, the missing branches
+        are created and new builds are created in pending state
+        """
+        mock_root.return_value = '/tmp/static'
+        repo = self.Repo.create({'name': 'bla@example.com:foo/bar'})
+
+        # create another repo and branch to ensure there is no mismatch
+        other_repo = self.Repo.create({'name': 'bla@example.com:foo/foo'})
+        self.env['runbot.branch'].create({
+            'repo_id': other_repo.id,
+            'name': 'refs/heads/bidon'
+        })
+
+        self.commit_list = [('refs/heads/bidon',
+                             'd0d0caca',
+                             '2019-04-29 13:03:17 +0200',
+                             'Marc Bidule',
+                             '<marc.bidule@somewhere.com>',
+                             'A nice subject',
+                             'Marc Bidule',
+                             '<marc.bidule@somewhere.com>')]
+
+        with patch('odoo.addons.runbot.models.repo.runbot_repo._git', new=self.mock_git_helper()):
+            repo._create_pending_builds()
+
+        branch = self.env['runbot.branch'].search([('repo_id', '=', repo.id)])
+        self.assertEqual(branch.name, 'refs/heads/bidon', 'A new branch should have been created')
+
+        build = self.env['runbot.build'].search([('repo_id', '=', repo.id), ('branch_id', '=', branch.id)])
+        self.assertEqual(build.subject, 'A nice subject')
+        self.assertEqual(build.state, 'pending')
+        self.assertFalse(build.result)
+
+        # Simulate that a new commit is found in the other repo
+        self.commit_list = [('refs/heads/bidon',
+                             'deadbeef',
+                             '2019-04-29 13:05:30 +0200',
+                             'Marc Bidule',
+                             '<marc.bidule@somewhere.com>',
+                             'A better subject',
+                             'Marc Bidule',
+                             '<marc.bidule@somewhere.com>')]
+
+        with patch('odoo.addons.runbot.models.repo.runbot_repo._git', new=self.mock_git_helper()):
+            other_repo._create_pending_builds()
+
+        branch_count = self.env['runbot.branch'].search_count([('repo_id', '=', repo.id)])
+        self.assertEqual(branch_count, 1, 'No new branch should have been created')
+
+        build = self.env['runbot.build'].search([('repo_id', '=', repo.id), ('branch_id', '=', branch.id)])
+        self.assertEqual(build.subject, 'A nice subject')
+        self.assertEqual(build.state, 'pending')
+        self.assertFalse(build.result)
+
+        # A new commit is found in the first repo, the previous pending build should be skipped
+        self.commit_list = [('refs/heads/bidon',
+                             'b00b',
+                             '2019-04-29 13:07:30 +0200',
+                             'Marc Bidule',
+                             '<marc.bidule@somewhere.com>',
+                             'Another subject',
+                             'Marc Bidule',
+                             '<marc.bidule@somewhere.com>')]
+
+        with patch('odoo.addons.runbot.models.repo.runbot_repo._git', new=self.mock_git_helper()):
+            repo._create_pending_builds()
+
+        branch_count = self.env['runbot.branch'].search_count([('repo_id', '=', repo.id)])
+        self.assertEqual(branch_count, 1, 'No new branch should have been created')
+
+        build = self.env['runbot.build'].search([('repo_id', '=', repo.id), ('branch_id', '=', branch.id), ('name', '=', 'b00b')])
+        self.assertEqual(build.subject, 'Another subject')
+        self.assertEqual(build.state, 'pending')
+        self.assertFalse(build.result)
+
+        previous_build = self.env['runbot.build'].search([('repo_id', '=', repo.id), ('branch_id', '=', branch.id), ('name', '=', 'd0d0caca')])
+        self.assertEqual(previous_build.state, 'done', 'Previous pending build should be done')
+        self.assertEqual(previous_build.result, 'skipped', 'Previous pending build result should be skipped')
+
+    @skip('This test is for performances. It needs a lot of real branches in DB to mean something')
+    @patch('odoo.addons.runbot.models.repo.runbot_repo._root')
+    def test_repo_perf_find_new_commits(self, mock_root):
+        mock_root.return_value = '/tmp/static'
+        repo = self.env['runbot.repo'].search([('name', '=', 'blabla')])
+
+        self.commit_list = []
+
+        # create 20000 branches and refs
+        start_time = time.time()
+        self.env['runbot.build'].search([], limit=5).write({'name': 'jflsdjflj'})
+
+        for i in range(20005):
+            self.commit_list.append(['refs/heads/bidon-%05d' % i,
+                                     'd0d0caca %s' % i,
+                                     '2019-04-29 13:03:17 +0200',
+                                     'Marc Bidule',
+                                     '<marc.bidule@somewhere.com>',
+                                     'A nice subject',
+                                     'Marc Bidule',
+                                     '<marc.bidule@somewhere.com>'])
+        inserted_time = time.time()
+        _logger.info('Insert took: %ssec', (inserted_time - start_time))
+        with patch('odoo.addons.runbot.models.repo.runbot_repo._git', new=self.mock_git_helper()):
+            repo._create_pending_builds()
+
+        _logger.info('Create pending builds took: %ssec', (time.time() - inserted_time))
 
 
 class Test_Repo_Scheduler(common.TransactionCase):
@@ -83,7 +206,7 @@ class Test_Repo_Scheduler(common.TransactionCase):
             'state': 'pending',
         })
         builds.append(build)
-        self.env['runbot.repo']._scheduler(ids=[self.foo_repo.id, ])
+        self.foo_repo._scheduler()
 
         build.invalidate_cache()
         scheduled_build.invalidate_cache()
@@ -93,7 +216,7 @@ class Test_Repo_Scheduler(common.TransactionCase):
         # give some room for the pending build
         Build_model.search([('name', '=', 'a')]).write({'state': 'done'})
 
-        self.env['runbot.repo']._scheduler(ids=[self.foo_repo.id, ])
+        self.foo_repo._scheduler()
         build.invalidate_cache()
         scheduled_build.invalidate_cache()
         self.assertEqual(build.host, 'test_host')


### PR DESCRIPTION
When searching for new builds by parsing git refs, the new branches are
created as well as the pending builds in the same _find_new_commits
method.

With this commit, this behavior is splitted into two methods, that way,
it's now possible to create missing branches without creating new
builds.