### PR TITLE
[FIX] runbot: make the cpu limit the same as the runbot timeout

### DIFF
--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -22,7 +22,7 @@ class ResConfigSettings(models.TransientModel):
         get_param = self.env['ir.config_parameter'].sudo().get_param
         res.update(runbot_workers=int(get_param('runbot.runbot_workers', default=6)),
                    runbot_running_max=int(get_param('runbot.runbot_running_max', default=75)),
-                   runbot_timeout=int(get_param('runbot.runbot_timeout', default=1800)),
+                   runbot_timeout=int(get_param('runbot.runbot_timeout', default=3600)),
                    runbot_starting_port=int(get_param('runbot.runbot_starting_port', default=2000)),
                    runbot_domain=get_param('runbot.runbot_domain', default=common.fqdn()),
                    runbot_max_age=int(get_param('runbot.runbot_max_age', default=30)),


### PR DESCRIPTION
When a build exceeds the cpu limit, it is simply killed by the kernel.
As a safeguard the "Initiating shutdown." sentence should be searched
in the log file, and the build marked as "ko" if not found.

Unfortunateley, there is no period (.) at the end of the sentence in the
Odoo logs (see: https://github.com/odoo/odoo/blob/12.0/odoo/service/server.py#L444)
Thus, this condition is never fulfilled.
On top of that, this was masked by the first part of the condition,
checking that the 'test/common.py' has no "post_install" string.
The "test" directory does not exists in Odoo ( but "tests" exists) , so
the condition was always falsy.

Finally, a build can be marked as "ok" when he is killed and no errors
are found until the kill.

With this commit:
    * The legacy grep for post_install is removed as it now exists in
      all Odoo supported versions.
    * The period typo is fixed.
    * A log is inserted when the final sentence is not found.
    * The cpu_limit is set as the same as the runbot_timeout parameter
      for better consitency.

Co-authored-by: @Xavier-Do