### PR TITLE
[FIX] runbot: choose quickconnect build with same config

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -93,12 +93,6 @@ class runbot_branch(models.Model):
 
         return super(runbot_branch, self).create(vals)
 
-    def _get_branch_quickconnect_url(self, fqdn, dest):
-        self.ensure_one()
-        r = {}
-        r[self.id] = "http://%s/web/login?db=%s-all&login=admin&redirect=/web?debug=1" % (fqdn, dest)
-        return r
-
     def _get_last_coverage_build(self):
         """ Return the last build with a coverage value > 0"""
         self.ensure_one()

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -119,7 +119,7 @@
                                   <small><t t-esc="br['builds'] and br['builds'][0].get_formated_build_time()"/></small><br/>
                                   <div class="btn-group btn-group-xs">
                                       <a t-attf-href="{{br['branch'].branch_url}}" class="btn btn-default btn-xs">Branch or pull <i class="fa fa-github"/></a>
-                                      <a t-attf-href="/runbot/#{repo.id}/#{br['branch'].branch_name}" class="btn btn-default btn-xs" aria-label="Quick Connect"><i class="fa fa-fast-forward" title="Quick Connect"/></a>
+                                      <a t-attf-href="/runbot/quick_connect/#{br['branch'].id}" class="btn btn-default btn-xs" aria-label="Quick Connect"><i class="fa fa-fast-forward" title="Quick Connect"/></a>
                                   </div>
                                   <t t-if="br['branch'].sticky">
                                       <br/>


### PR DESCRIPTION
When the quickconnect button is used, the last running build is
searched in the last 10 builds. If no running build is found, the last
one is rebuilt, even if it's a nightly build.

With this commit, the quickconnect build is choosen only among the ones
with the same config.