### PR TITLE
[IMP] runbot: grant rights for the build logs

### DIFF
--- a/runbot/migrations/4.5/post-migration.py
+++ b/runbot/migrations/4.5/post-migration.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from odoo.addons.runbot.models.res_config_settings import grant_access
 
 
 def migrate(cr, version):
@@ -18,3 +19,9 @@ def migrate(cr, version):
         else:
             install_modules = '-*'
         cr.execute("UPDATE runbot_build_config_step SET install_modules = %s WHERE id=%s", (install_modules, step_id))
+
+    cr.execute("SELECT value FROM ir_config_parameter WHERE key='runbot.runbot_logdb_uri'")
+    res = cr.fetchone()
+    logdb_uri = res[0] if res else None
+    if logdb_uri:
+        grant_access(logdb_uri=logdb_uri, cr=cr)

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -7,4 +7,4 @@ from . import test_schedule
 from . import test_cron
 from . import test_build_config_step
 from . import test_event
-
+from . import test_config_settings

--- a/runbot/tests/test_config_settings.py
+++ b/runbot/tests/test_config_settings.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from odoo.tests import common
+from odoo.exceptions import UserError
+
+from odoo.addons.runbot.models.res_config_settings import RE_POSTGRE_URI
+
+
+class TestConfigSettings(common.TransactionCase):
+
+    def tests_log_user_validation(self):
+        """ Test the validation of the logdb_uri """
+
+        simple_uri = 'postgresql://mr_nobody:aS3cr3T!@ahost'
+
+        # test regex
+        res = RE_POSTGRE_URI.search(simple_uri)
+        self.assertTrue(res)
+        self.assertEqual('postgresql', res.group('protocol'))
+        self.assertEqual('mr_nobody', res.group('user'))
+        self.assertEqual('aS3cr3T!', res.group('password'))
+
+        rcs = self.env['res.config.settings'].create({'runbot_logdb_uri': 'blah blah'})
+
+        with self.assertRaises(UserError):
+            rcs._grant_access()
+
+        # check empty password or no password
+        rcs.write({'runbot_logdb_uri': 'postgresql://mr_nobody:@ahost'})
+        with self.assertRaises(UserError):
+            rcs._grant_access()
+
+        rcs.write({'runbot_logdb_uri': 'postgresql://mr_nobody@ahost'})
+        with self.assertRaises(UserError):
+            rcs._grant_access()
+
+        # check a valid URI twice to be sure that it works even if the user already exists
+        rcs.write({'runbot_logdb_uri': simple_uri})
+        rcs._grant_access()
+        rcs._grant_access()


### PR DESCRIPTION
When an Odoo instance is launched buy a build, the --log-db parameter is
used to write its logs into the runbot ir_logging table.
Also, a trigger on the postgresql server is used to add the build id on
the ir_logging.

Because of that, the user used in the --log-db parameter must have the
rights to do those operations. Before this commit, it was up to the
runbot administrator to properly setup thos rights.

With this commit, the rights are automatically granted when the logdb
uri is set or changed in the runbot settings.