### PR TITLE
[IMP] runbot: add es-check tool to the Docker image

### DIFF
--- a/runbot/data/Dockerfile
+++ b/runbot/data/Dockerfile
@@ -56,10 +56,14 @@ RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 
 RUN npm install -g rtlcss
 
+# Install es-check tool
+RUN npm install -g es-check
+
 # Install Odoo Debian dependencies
 ADD https://raw.githubusercontent.com/odoo/odoo/10.0/debian/control /tmp/p2-control
 ADD https://raw.githubusercontent.com/odoo/odoo/master/debian/control /tmp/p3-control
 RUN pip install -U setuptools wheel \
+    && apt-get update \
     && sed -n '/^Depends:/,/^[A-Z]/p' /tmp/p2-control /tmp/p3-control | awk '/^ [a-z]/ { gsub(/,/,"") ; print }' | sort -u | sed 's/python-imaging/python-pil/'| sed 's/python-pypdf/python-pypdf2/' | DEBIAN_FRONTEND=noninteractive xargs apt-get install -y -qq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In order to use the new test odoo/odoo#33724 the es-check tool is needed
in the Docker runbot image.

To merge once the above PR is validated and merged