### PR TITLE
[IMP] runbot: allow to configure workers per host

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -347,9 +347,10 @@ class runbot_repo(models.Model):
         if not ids:
             return
         icp = self.env['ir.config_parameter']
-        workers = int(icp.get_param('runbot.runbot_workers', default=6))
-        running_max = int(icp.get_param('runbot.runbot_running_max', default=75))
         host = fqdn()
+        settings_workers = int(icp.get_param('runbot.runbot_workers', default=6))
+        workers = int(icp.get_param('%s.workers' % host, default=settings_workers))
+        running_max = int(icp.get_param('runbot.runbot_running_max', default=75))
 
         Build = self.env['runbot.build']
         domain = [('repo_id', 'in', ids)]


### PR DESCRIPTION
When a runbot instance is scheduling builds, the numbers of builds
depends of a global ir.config_parameter. Even if one of the runbot
instance is running on a more powerful systsem, its number of workers is
limited by this global parameter.

With this commit, this parameter still exists but can be overriden by
specific ir.config_parameter.

For example, if the host 'runbot24.odoo.com' has more cpu power, the
number of workers for this host can be specified in the
ir.config_parameter named 'runbot24.odoo.com.workers'.