### PR TITLE
[FIX] runbot: avoid "Modules loaded not found in logs"

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -567,6 +567,9 @@ class runbot_build(models.Model):
                         build._log('_schedule', '%s time exceeded (%ss)' % (build.active_step.name if build.active_step else "?", build.job_time))
                         build._kill(result='killed')
                     continue
+                elif build.job_time < 15:
+                    _logger.debug('container "%s" seems too take a while to start', build._get_docker_name())
+                    continue
                 # No job running, make result and select nex job
                 build_values = {
                     'job_end': now(),


### PR DESCRIPTION
In some conditions, Docker can take a little time to start a container.
In that case, if the runbot checks that the container is running before
it starts, runbot consider the job as finished. It the tries to grep the
logs and, as expected, it does not find the "Modules loaded".

With this commit, we consider young builds (less than 15 sec) as
running, giving more time to Docker for starting it.