### PR TITLE
[FIX] runbot: set force_rebuild when creating multi builds

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -121,6 +121,13 @@ class ConfigStep(models.Model):
             if msg:
                 raise ValidationError(msg)
 
+    @api.onchange('number_builds')
+    def _onchange_number_builds(self):
+        if self.number_builds > 1:
+            self.force_build = True
+        else:
+            self.force_build = False
+
     @api.depends('name', 'custom_db_name')
     def _compute_db_name(self):
         for step in self:


### PR DESCRIPTION
When creating multi builds config steps, the force_build option is often
forgotten. In that case, the multi builds are detected as duplicate of
the first one.

With this commit, when asking for more that one multi build, the
force_build is chnaged to to True.