### PR TITLE
[IMP] runbot: create a temporary symlink in Docker container

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -38,6 +38,8 @@ def build_odoo_cmd(odoo_cmd):
     """
     # build cmd
     cmd_chain = []
+    cmd_chain.append('mkdir -p /data/build/tests')
+    cmd_chain.append('ln -s /data/build/tests /tmp/odoo_tests')
     cmd_chain.append('cd /data/build')
     cmd_chain.append('head -1 odoo-bin | grep -q python3 && sudo pip3 install -r requirements.txt || sudo pip install -r requirements.txt')
     cmd_chain.append(' '.join(odoo_cmd))


### PR DESCRIPTION
When odoo saves files in '/tmp' during a build, those files are lost
when the container is stopped. Typically screenshots during the HttpCase
tests.

With this commit, a directory 'tests' is created in the build dir and a
symlink is also created in /tmp, pointing to it.

With this mechanism, the files saved in '/tmp/odoo_tests' automatically
goes in buildir and survives the container removal.