### PR TITLE
[IMP] runbot: share sources between builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 # runbot work files
 runbot/static/build
 runbot/static/repo
+runbot/static/sources
 runbot/static/nginx

--- a/runbot/common.py
+++ b/runbot/common.py
@@ -17,6 +17,20 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 _logger = logging.getLogger(__name__)
 
 
+class Commit():
+    def __init__(self, repo, sha):
+        self.repo = repo
+        self.sha = sha
+
+    def _source_path(self, *path):
+        return self.repo._source_path(self.sha, *path)
+
+    def export(self):
+        return self.repo._git_export(self.sha)
+
+    def __str__(self):
+        return '%s:%s' % (self.repo.short_name, self.sha)
+
 def fqdn():
     return socket.getfqdn()
 

--- a/runbot/container.py
+++ b/runbot/container.py
@@ -39,7 +39,9 @@ def build_odoo_cmd(odoo_cmd):
     # build cmd
     cmd_chain = []
     cmd_chain.append('cd /data/build')
-    cmd_chain.append('head -1 odoo-bin | grep -q python3 && sudo pip3 install -r requirements.txt || sudo pip install -r requirements.txt')
+    server_path = odoo_cmd[0]
+    requirement_path = os.path.join(os.path.dirname(server_path), 'requirements.txt')
+    cmd_chain.append('head -1 %s | grep -q python3 && sudo pip3 install -r %s || sudo pip install -r %s' % (server_path, requirement_path, requirement_path))
     cmd_chain.append(' '.join(odoo_cmd))
     return ' && '.join(cmd_chain)
 
@@ -60,7 +62,7 @@ def docker_build(log_path, build_dir):
     dbuild = subprocess.Popen(['docker', 'build', '--tag', 'odoo:runbot_tests', '.'], stdout=logs, stderr=logs, cwd=docker_dir)
     dbuild.wait()
 
-def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None, cpu_limit=None, preexec_fn=None):
+def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None, cpu_limit=None, preexec_fn=None, ro_volumes=None):
     """Run tests in a docker container
     :param run_cmd: command string to run in container
     :param log_path: path to the logfile that will contain odoo stdout and stderr
@@ -68,6 +70,7 @@ def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None,
                       This directory is shared as a volume with the container
     :param container_name: used to give a name to the container for later reference
     :param exposed_ports: if not None, starting at 8069, ports will be exposed as exposed_ports numbers
+    :params ro_volumes: dict of dest:source volumes to mount readonly in builddir
     """
     _logger.debug('Docker run command: %s', run_cmd)
     logs = open(log_path, 'w')
@@ -81,13 +84,18 @@ def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None,
         '--shm-size=128m',
         '--init',
     ]
+    if ro_volumes:
+        for dest, source in ro_volumes.items():
+            logs.write("Adding readonly volume '%s' pointing to %s \n" % (dest, source))
+            docker_command.append('--volume=%s:/data/build/%s:ro' % (source, dest))
+
     serverrc_path = os.path.expanduser('~/.openerp_serverrc')
     odoorc_path = os.path.expanduser('~/.odoorc')
     final_rc = odoorc_path if os.path.exists(odoorc_path) else serverrc_path if os.path.exists(serverrc_path) else None
     if final_rc:
         docker_command.extend(['--volume=%s:/home/odoo/.odoorc:ro' % final_rc])
     if exposed_ports:
-        for dp,hp in enumerate(exposed_ports, start=8069):
+        for dp, hp in enumerate(exposed_ports, start=8069):
             docker_command.extend(['-p', '127.0.0.1:%s:%s' % (hp, dp)])
     if cpu_limit:
         docker_command.extend(['--ulimit', 'cpu=%s' % int(cpu_limit)])

--- a/runbot/models/build_dependency.py
+++ b/runbot/models/build_dependency.py
@@ -9,3 +9,7 @@ class RunbotBuildDependency(models.Model):
     dependency_hash = fields.Char('Name of commit', index=True)
     closest_branch_id = fields.Many2one('runbot.branch', 'Branch', required=True, ondelete='cascade')
     match_type = fields.Char('Match Type')
+
+    def get_repo(self):
+        return self.closest_branch_id.repo_id or self.dependecy_repo_id
+

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -21,10 +21,7 @@
           <t t-if="bu.global_result=='killed'"><i class="text-danger fa fa-times"/> killed</t>
           <t t-if="bu.global_result=='manually_killed'"><i class="text-danger fa fa-times"/> manually killed</t>
         </t>
-        <t t-if="bu.real_build.server_match == 'default'">
-            <i class="text-warning fa fa-question-circle fa-fw"
-                title="Server branch cannot be determined exactly. Please use naming convention '12.0-my-branch' to build with '12.0' server branch."/>
-        </t>
+
         <t t-if="bu.revdep_build_ids">
             <small class="pull-right">Dep builds:
                 <t t-foreach="bu.sorted_revdep_build_ids()" t-as="rbu">

--- a/runbot/tests/test_schedule.py
+++ b/runbot/tests/test_schedule.py
@@ -45,6 +45,9 @@ class TestSchedule(common.TransactionCase):
         build_ids = self.Build.search(domain_host + [('local_state', 'in', ['testing', 'running', 'deathrow'])])
         mock_running.return_value = False
         self.assertEqual(build.local_state, 'testing')
+        build_ids._schedule()  # too fast, docker not started
+        self.assertEqual(build.local_state, 'testing')
+        build_ids.write({'job_start': datetime.datetime.now() - datetime.timedelta(seconds=20)})  # job is now a little older
         build_ids._schedule()
         self.assertEqual(build.local_state, 'done')
         self.assertEqual(build.local_result, 'ok')

--- a/runbot/views/build_views.xml
+++ b/runbot/views/build_views.xml
@@ -32,7 +32,6 @@
                         <field name="build_time"/>
                         <field name="build_age"/>
                         <field name="duplicate_id"/>
-                        <field name="modules"/>
                         <field name="build_type" groups="base.group_no_one"/>
                         <field name="config_id" readonly="1"/>
                         <field name="config_id" groups="base.group_no_one"/>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -23,6 +23,9 @@
                 <field name="group_ids"  widget="many2many_tags"/>
                 <field name="hook_time"/>
                 <field name="config_id"/>
+                <field name="server_files"/>
+                <field name="manifest_files"/>
+                <field name="addons_paths"/>
               </group>
             </sheet>
           </form>


### PR DESCRIPTION
Multibuild can create generate a lots of checkout, especially for small
and fast jobs, which can overload runbot discs since we are trying not
to clean build immediatly. (To ease bug fix and allow wake up)

This commit proposes to store source on a single place, so that
docker can add them as ro volume in the build directory.
The checkout is also moved to the installs jobs, so that
builds containing only create builds steps won't checkout
the sources.

This change implies to use --addons-path correctly, since odoo
and enterprise addons wont be merged in the same repo anymore.
This will allow to test addons a dev will do, with a closer
command line.

This implies to change the code structure a litle, some changes
where made to remove no-so-usefull fields on build, and some
hard-coded logic (manifest_names and server_names) are now
stored on repo instead.

This changes implies that a build CANNOT write in his sources.
It shouldn't be the case, but it means that runbot cannot be
tested on runbot untill datas are written elsewhere than in static.

Other possibilities are possible, like bind mounting the sources
in the build directory instead of adding ro volumes in docker.
Unfortunately, this needs to give access to mount as sudo for
runbot user and changes docjker config to allow mounts
in volumes which is not the case by default. A plus of this
solution would be to be able to make an overlay mount.