### PR TITLE
[FIX] runbot: avoid traceback during run_odoo_install steps

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -457,7 +457,7 @@ class runbot_build(models.Model):
             existing = builds.exists()
             remaining = (builds - existing)
             if remaining:
-                dest_list = [dest for sublist in [dest_by_builds_ids[rem_id] for rem_id in remaining] for dest in sublist]
+                dest_list = [dest for sublist in [dest_by_builds_ids[rem_id] for rem_id in remaining.ids] for dest in sublist]
                 #dest_list = [dest for dest in dest_by_builds_ids[rem_id] for rem_id in remaining]
                 _logger.debug('(%s) (%s) not deleted because no corresponding build found' % (label, " ".join(dest_list)))
             for build in existing:

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -314,7 +314,7 @@ class ConfigStep(models.Model):
         modules_to_install = set([mod.strip() for mod in self.install_modules.split(',')])
         if '*' in modules_to_install:
             modules_to_install.remove('*')
-            default_mod = set([mod.strip() for mod in build.modules.split(',')])
+            default_mod = set([mod.strip() for mod in build.modules.split(',')]) if build.modules else set()
             modules_to_install = default_mod | modules_to_install
             #  todo add without support
         return modules_to_install

--- a/runbot/tests/test_cron.py
+++ b/runbot/tests/test_cron.py
@@ -48,11 +48,12 @@ class Test_Cron(common.TransactionCase):
         mock_update.assert_called_with(force=False)
         mock_create.assert_called_with()
 
+    @patch('odoo.addons.runbot.models.build.runbot_build._local_cleanup')
     @patch('odoo.addons.runbot.models.repo.runbot_repo._get_cron_period')
     @patch('odoo.addons.runbot.models.repo.runbot_repo._reload_nginx')
     @patch('odoo.addons.runbot.models.repo.runbot_repo._scheduler')
     @patch('odoo.addons.runbot.models.repo.fqdn')
-    def test_cron_build(self, mock_fqdn, mock_scheduler, mock_reload, mock_cron_period):
+    def test_cron_build(self, mock_fqdn, mock_scheduler, mock_reload, mock_cron_period, mock_cleanup):
         """ test that cron_fetch_and_build do its work """
         mock_fqdn.return_value = 'runbotx.foo.com'
         mock_cron_period.return_value = 2
@@ -64,3 +65,4 @@ class Test_Cron(common.TransactionCase):
         self.assertEqual(None, ret)
         mock_scheduler.assert_called()
         self.assertTrue(mock_reload.called)
+        mock_cleanup.assert_called()


### PR DESCRIPTION
If build.modules is falsy, a traceback occurs when trying to split a
boolean.

While at it, fix empty debug message during _local_cleanup and mock
_local_cleanup in test to avoid messing up with local dirs and
databases.