### PR TITLE
[FIX] runbot: prevent inter Docker communication

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -851,7 +851,7 @@ class runbot_build(models.Model):
         self._log('server_info', 'No server found in %s' % commit, level='ERROR')
         raise ValidationError('No server found in %s' % commit)
 
-    def _cmd(self, python_params=None, py_version=None):
+    def _cmd(self, python_params=None, py_version=None, local_only=True):
         """Return a list describing the command to start the build
         """
         self.ensure_one()
@@ -868,6 +868,11 @@ class runbot_build(models.Model):
         cmd = ['python%s' % py_version] + python_params + [os.path.join(server_dir, server_file), '--addons-path', ",".join(addons_paths)]
         # options
         config_path = build._server("tools/config.py")
+        if local_only:
+            if grep(config_path, "--http-interface"):
+                cmd.append("--http-interface=127.0.0.1")
+            elif grep(config_path, "--xmlrpc-interface"):
+                cmd.append("--xmlrpc-interface=127.0.0.1")
         if grep(config_path, "no-xmlrpcs"):  # move that to configs ?
             cmd.append("--no-xmlrpcs")
         if grep(config_path, "no-netrpc"):

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -242,7 +242,7 @@ class ConfigStep(models.Model):
         # adjust job_end to record an accurate job_20 job_time
         build._log('run', 'Start running build %s' % build.dest)
         # run server
-        cmd = build._cmd()
+        cmd = build._cmd(local_only=False)
         if os.path.exists(build._get_server_commit()._source_path('addons/im_livechat')):
             cmd += ["--workers", "2"]
             cmd += ["--longpolling-port", "8070"]


### PR DESCRIPTION
When an Odoo instance is run in a Docker container, it listen on all
interfaces by default and a bridge interface is used to communicate with
the outside world.

This bridge interface is necessary to allow the instance to send logging
messages into the runbot postgresql database.

Even though Docker isolate the container from the oustide world, it's
still possible to reach the Odoo instace from the runbot host and worse,
from other Docker containers using the same bridge interface.

To confirm the  Murphy's law, it finally happened with this commit
odoo/enterprise@0ba0ef99de that scanned the ip range of the interface,
disturbing other builds.

One solution would be to create a bridge interface for each instance to
isolate each Docker but that would imply a big change to garbage collect
forgotten bridges ...

An 'icc' (Inter Container Communication) option exists for the Docker
daemon which defaults to True. Setting it to False was tested but it
appears that this option can be messed-up by the firewall on the runbot
host.

Finally, if applied, this commit will prevent the Odoo instance to
listen on the bridge interface by only listening to 127.0.0.1.