### PR TITLE
[FIX] runbot: clean running dockers with done builds

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -19,6 +19,7 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 _logger = logging.getLogger(__name__)
 
+dest_reg = re.compile(r'^\d{5,}-.{1,32}-[\da-f]{6}(.*)*$')
 
 class Commit():
     def __init__(self, repo, sha):

--- a/runbot/container.py
+++ b/runbot/container.py
@@ -135,6 +135,13 @@ def docker_get_gateway_ip():
         except KeyError:
             return None
 
+def docker_ps():
+    """Return a list of running containers names"""
+    docker_ps = subprocess.run(['docker', 'ps', '--format', '{{.Names}}'], stderr=subprocess.DEVNULL, stdout=subprocess.PIPE)
+    if docker_ps.returncode !=0:
+        return []
+    return docker_ps.stdout.decode().strip().split('\n')
+
 def build(args):
     """Build container from CLI"""
     _logger.info('Building the base image container')

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import time
 import datetime
-from ..common import dt2time, fqdn, now, grep, uniq_list, local_pgadmin_cursor, s2human, Commit
+from ..common import dt2time, fqdn, now, grep, uniq_list, local_pgadmin_cursor, s2human, Commit, dest_reg
 from ..container import docker_build, docker_stop, docker_is_running, Command
 from odoo.addons.runbot.models.repo import HashMissingException, ArchiveFailException
 from odoo import models, fields, api
@@ -461,7 +461,6 @@ class runbot_build(models.Model):
         def cleanup(dest_list, func, max_days, label):
             dest_by_builds_ids = defaultdict(list)
             ignored = set()
-            dest_reg = re.compile(r'^\d{5,}-.{1,32}-[\da-f]{6}(.*)*$')
             for dest in dest_list:
                 try:
                     if not dest_reg.match(dest):


### PR DESCRIPTION
In different situations, a docker container may stay alive even if the
build global_state is done. This can lead to a build failure when a
build wants to go in running state and tries to expose the same ports as
the left over build.