### PR TITLE
[FIX] runbot: correctly order repo by sequence

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -26,6 +26,7 @@ class HashMissingException(Exception):
 class runbot_repo(models.Model):
 
     _name = "runbot.repo"
+    _order = 'sequence, id'
 
     name = fields.Char('Repository', required=True)
     short_name = fields.Char('Repository', compute='_compute_short_name', store=False, readonly=True)


### PR DESCRIPTION
Even if present and editable the user, changing the sequence
of a repository has no effect

Fix by adding missing _order on runbot.repo model