### PR TITLE
Map PR commits to integrated commits in mergebot

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -491,6 +491,7 @@ class PullRequests(models.Model):
     batch_id = fields.Many2one('runbot_merge.batch',compute='_compute_active_batch', store=True)
     batch_ids = fields.Many2many('runbot_merge.batch')
     staging_id = fields.Many2one(related='batch_id.staging_id', store=True)
+    commits_map = fields.Char(help="JSON-encoded mapping of PR commits to actually integrated commits. The integration head (either a merge commit or the PR's topmost) is mapped from the 'empty' pr commit (the key is an empty string, because you can't put a null key in json maps).", default='{}')
 
     link_warned = fields.Boolean(
         default=False, help="Whether we've already warned that this (ready)"
@@ -958,12 +959,16 @@ class PullRequests(models.Model):
         # on top of target
         msg = self._build_merge_message(commits[-1]['commit']['message'])
         commits[-1]['commit']['message'] = msg
-        return gh.rebase(self.number, target, commits=commits)
+        head, mapping = gh.rebase(self.number, target, commits=commits)
+        self.commits_map = json.dumps({**mapping, '': head})
+        return head
 
     def _stage_rebase_merge(self, gh, target, commits):
         msg = self._build_merge_message(self.message)
-        h = gh.rebase(self.number, target, reset=True, commits=commits)
-        return gh.merge(h, target, msg)['sha']
+        h, mapping = gh.rebase(self.number, target, reset=True, commits=commits)
+        merge_head = gh.merge(h, target, msg)['sha']
+        self.commits_map = json.dumps({**mapping, '': merge_head})
+        return merge_head
 
     def _stage_merge(self, gh, target, commits):
         pr_head = commits[-1] # oldest to newest
@@ -978,6 +983,7 @@ class PullRequests(models.Model):
             if len(merge) == 1:
                 [base_commit] = merge
 
+        commits_map = {c['sha']: c['sha'] for c in commits}
         if base_commit:
             # replicate pr_head with base_commit replaced by
             # the current head
@@ -993,11 +999,18 @@ class PullRequests(models.Model):
                 'parents': new_parents,
             }).json()
             gh.set_ref(target, copy['sha'])
+            # merge commit *and old PR head* map to the pr head replica
+            commits_map[''] = commits_map[pr_head['sha']] = copy['sha']
+            self.commits_map = json.dumps(commits_map)
             return copy['sha']
         else:
             # otherwise do a regular merge
             msg = self._build_merge_message(self.message)
-            return gh.merge(self.head, target, msg)['sha']
+            merge_head = gh.merge(self.head, target, msg)['sha']
+            # and the merge commit is the normal merge head
+            commits_map[''] = merge_head
+            self.commits_map = json.dumps(commits_map)
+            return merge_head
 
 # state changes on reviews
 RPLUS = {
@@ -1360,7 +1373,7 @@ class Stagings(models.Model):
                     self.env['runbot_merge.pull_requests.feedback'].create({
                         'repository': pr.repository.id,
                         'pull_request': pr.number,
-                        'message': "Merged, thanks!",
+                        'message': "Merged at %s, thanks!" % json.loads(pr.commits_map)[''],
                         'close': True,
                     })
             finally:


### PR DESCRIPTION
* when rebasing, store a map of rebased to source, that way it'll be possible to link cherry-picked forward ports to the originally integrated commit rather than just the one from the PR (which was likely not itself integrated as the straight merge mode is somewhat rare: as of 5600 PRs merged so far only 100 were straight merged)
* while at it, store the "merge head" of the PR (whether squashed, merged or rebased) and put *that* in the commit message: the information is already provided through github back-referencing the commit through the "closes" tag automatically added but given point 1 it shouldn't take much to provide accurate commit info explicitly
