### PR TITLE
PR splits should be updated on PR state change

### DIFF
--- a/runbot_merge/controllers/__init__.py
+++ b/runbot_merge/controllers/__init__.py
@@ -153,7 +153,7 @@ def handle_pr(env, event):
             return "It's my understanding that closed/merged PRs don't get sync'd"
 
         if pr_obj.state == 'ready':
-            pr_obj.staging_id.cancel(
+            pr_obj.unstage(
                 "PR %s:%s updated by %s",
                 pr_obj.repository.name, pr_obj.number,
                 event['sender']['login']
@@ -201,7 +201,7 @@ def handle_pr(env, event):
                 'state_from': res[1] if not pr_obj.staging_id else 'staged',
                 'state_to': 'closed',
             })
-            pr_obj.staging_id.cancel(
+            pr_obj.unstage(
                 "PR %s:%s closed by %s",
                 pr_obj.repository.name, pr_obj.number,
                 event['sender']['login']

--- a/runbot_merge/tests/remote.py
+++ b/runbot_merge/tests/remote.py
@@ -348,8 +348,8 @@ class Model:
         ids = self._env(self._model, 'exists', self._ids)
         return Model(self._env, self._model, ids)
 
-    def search(self, domain):
-        ids = self._env(self._model, 'search', domain)
+    def search(self, domain, **kw):
+        ids = self._env(self._model, 'search', domain, **kw)
         return Model(self._env, self._model, ids)
 
     def create(self, values):


### PR DESCRIPTION
Unlike stagings, splits would not get cancelled / updated if a PR was moved out of "ready" state (updated, cancelled, unapproved, …). The split would then get staged straight without checking the PR's state, potentially staging closed or unreviewed PR, or updated PRs which hadn't been re-CI'd yet.