### PR TITLE
Fix fast-forward error logging message

### DIFF
--- a/runbot_merge/github.py
+++ b/runbot_merge/github.py
@@ -116,7 +116,7 @@ class GH(object):
             _logger.debug('fast_forward(%s, %s, %s) -> OK', self._repo, branch, sha)
         except requests.HTTPError:
             _logger.debug('fast_forward(%s, %s, %s) -> ERROR', self._repo, branch, sha, exc_info=True)
-            raise exceptions.FastForwardError()
+            raise exceptions.FastForwardError(self._repo)
 
     def set_ref(self, branch, sha):
         # force-update ref

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -1392,7 +1392,6 @@ class Stagings(models.Model):
         project = self.target.project_id
         if self.state == 'success':
             gh = {repo.name: repo.github() for repo in project.repo_ids}
-            repo_name = None
             staging_heads = json.loads(self.heads)
             self.env.cr.execute('''
             SELECT 1 FROM runbot_merge_pull_requests
@@ -1400,11 +1399,11 @@ class Stagings(models.Model):
             FOR UPDATE
             ''', [tuple(self.mapped('batch_ids.prs.id'))])
             try:
-                repo_name = self._safety_dance(gh, staging_heads)
+                self._safety_dance(gh, staging_heads)
             except exceptions.FastForwardError as e:
                 logger.warning(
                     "Could not fast-forward successful staging on %s:%s",
-                    repo_name, self.target.name,
+                    e.args[0], self.target.name,
                     exc_info=True
                 )
                 self.write({


### PR DESCRIPTION
In case of error while fast-forwarding a staging to its source, we'd
log the target to which we couldn't FF. Sadly this relied on a
`repo_name` variable which (likely since the introduction of the
"safety dance" fast forwarding) can not actually be set in case of
failure.