### PR TITLE
[FIX] runbot: limit number of allowed connections per db

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -792,6 +792,11 @@ class runbot_build(models.Model):
         with local_pgadmin_cursor() as local_cr:
             local_cr.execute("""CREATE DATABASE "%s" TEMPLATE template0 LC_COLLATE 'C' ENCODING 'unicode'""" % dbname)
 
+    def _local_pg_limit_db(self, db_name, datconnlimit=25):
+        """Limit number of connections allowed for a db"""
+        with local_pgadmin_cursor() as local_cr:
+            local_cr.execute('UPDATE pg_database SET datconnlimit=%s WHERE datname=%s', (datconnlimit, db_name))
+
     def _log(self, func, message, level='INFO', log_type='runbot', path='runbot'):
         self.ensure_one()
         _logger.debug("Build %s %s %s", self.id, func, message)

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -280,6 +280,7 @@ class ConfigStep(models.Model):
         self.invalidate_cache()
         res = docker_run(cmd.build(), log_path, build_path, docker_name, exposed_ports=[build_port, build_port + 1], ro_volumes=exports)
         build.repo_id._reload_nginx()
+        build._local_pg_limit_db(db_name, 25)
         return res
 
     def _run_odoo_install(self, build, log_path):
@@ -335,7 +336,9 @@ class ConfigStep(models.Model):
 
         max_timeout = int(self.env['ir.config_parameter'].get_param('runbot.runbot_timeout', default=10000))
         timeout = min(self.cpu_limit, max_timeout)
-        return docker_run(cmd.build(), log_path, build._path(), build._get_docker_name(), cpu_limit=timeout, ro_volumes=exports)
+        res = docker_run(cmd.build(), log_path, build._path(), build._get_docker_name(), cpu_limit=timeout, ro_volumes=exports)
+        build._local_pg_limit_db(db_name, 25)
+        return res
 
     def _modules_to_install(self, build):
         modules_to_install = set([mod.strip() for mod in self.install_modules.split(',')])

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_frontend
 from . import test_schedule
 from . import test_cron
 from . import test_build_config_step
+from . import test_local_pg

--- a/runbot/tests/test_local_pg.py
+++ b/runbot/tests/test_local_pg.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import psycopg2
+import uuid
+
+from odoo.tests import common
+
+
+class TestLocalPg(common.TransactionCase):
+
+    def setUp(self):
+        super(TestLocalPg, self).setUp()
+        self.Build = self.env['runbot.build']
+
+    def test_build_local_pg(self):
+            """ test create and drop of a local database even with an open cursor"""
+            dbname = str(uuid.uuid4())
+            self.Build._local_pg_createdb(dbname)
+            self.Build._local_pg_limit_db(dbname, 2)
+            cnx = psycopg2.connect("dbname=%s" % dbname)
+            cur = cnx.cursor()
+            cur.execute("CREATE TABLE test (id serial PRIMARY KEY, foo varchar);")
+            cur.execute("INSERT INTO test (foo) VALUES ('bar')")
+            failure = False
+            try:
+                self.Build._local_pg_dropdb(dbname)
+            except psycopg2.OperationalError:
+                cnx.close()
+                self.Build._local_pg_dropdb(dbname)
+                failure = True
+            self.assertFalse(failure, "_local_pg_dropdb failed when a cursor is still using DB")


### PR DESCRIPTION
When a runbot builds fails in a loop and creates connections in each
loop iteration, it can exhaust postgres connections.

With this commit, a build database is limited to 25 psql connections at
the same time, which should be enough.

Unfortunately, it implies that the runbot user have enough privileges to
update the datconnlimit column in pg_database table.