### PR TITLE
[FIX] runbot: remove skip old builds logic

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -329,13 +329,6 @@ class runbot_repo(models.Model):
                                 indirect.build_type = 'indirect'
                                 new_build.revdep_build_ids += indirect
 
-        # skip old builds (if their sequence number is too low, they will not ever be built)
-        skippable_domain = [('repo_id', '=', self.id), ('local_state', '=', 'pending')]
-        icp = self.env['ir.config_parameter']
-        running_max = int(icp.get_param('runbot.runbot_running_max', default=75))
-        builds_to_be_skipped = Build.search(skippable_domain, order='sequence desc', offset=running_max)
-        builds_to_be_skipped._skip()
-
     @api.multi
     def _create_pending_builds(self):
         """ Find new commits in physical repos"""


### PR DESCRIPTION
When finding new commits, if there is more pending builds on a repo than
the running_max parameter, the exceeding builds are skipped.

As a result, when nightly builds are created on the runbot, it happens
that some of them are skipped.

Also, since e51412d , only refs newer than max_age are builded; thus the
logic is not needed to prevent rebuild of olds refs in case of a fresh
runbot install.