### PR TITLE
[FIX][IMP] runbot: use environament variable for fqdn

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -44,7 +44,7 @@ class Commit():
 
 
 def fqdn():
-    return socket.getfqdn()
+    return os.environ.get('RUNBOTNAME', socket.getfqdn())
 
 
 def time2str(t):


### PR DESCRIPTION
In some conditions, the getfqdn method does not return the expected
fqdn. e.g. when the local fqdn gives something else than the resolved
fqdn.

Also, in a near future, the runbot should not depend on the fqdn
anymore, in order to manually assign host identification.

With this commit, fqdn is still used unless a RUNBOTNAME environment
variable exists.