### PR TITLE
[IMP] runbot: add a copy to clipboard button for branch

### DIFF
--- a/runbot/static/src/js/runbot.js
+++ b/runbot/static/src/js/runbot.js
@@ -41,5 +41,7 @@
             return false;
        });
     });
-
+    $(function() {
+      new Clipboard('.clipbtn');
+    });
 })(jQuery);

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -7,7 +7,9 @@
               <div class="row">
                   <div class='col-md-12'>
                         <div class="navbar navbar-default">
-                            <span class="text-center" style="font-size: 18px;">Builds for branch: <t t-esc="builds[0].branch_id.name.split('/')[-1]" /></span>
+                            <span class="text-center" style="font-size: 18px;">Builds for branch: <span id="branchclp"><t t-esc="builds[0].branch_id.branch_name" /></span>
+                            <a href="#" class="clipbtn octicon octicon-clippy" data-clipboard-target="#branchclp" title="Copy branch name to clipboard"/><br/>
+                            </span>
                             <span class="pull-right"><t t-call="website.pager" /></span>
                         </div>
                     <table class="table table-condensed table-stripped" style="table-layout: initial;">

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -209,6 +209,8 @@
                                   <t t-if='dep.closest_branch_id'> from branch <t t-esc="dep.closest_branch_id.name"/></t>
                                   <br/>
                                 </t>
+                                Branch: <span id="branchclp"><t t-esc="build.branch_id.branch_name"/></span>
+                                <a href="#" class="clipbtn octicon octicon-clippy" data-clipboard-target="#branchclp" title="Copy branch name to clipboard"/><br/>
                                 Build host: <t t-esc="build.real_build.host"/><br/>
                             </td>
                             <td t-if="build.children_ids">


### PR DESCRIPTION
When using the runbot frontend, it's sometimes very frustrating when
trying to copy branch name, some mouse gym is necessary.

With this commit, a copy to clipboard button is added near the branch
name on the frontend.