### PR TITLE
[IMP] runbot: uses fnmatch to black list modules

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '4.4',
+    'version': '4.5',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',

--- a/runbot/migrations/4.5/post-migration.py
+++ b/runbot/migrations/4.5/post-migration.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+
+def migrate(cr, version):
+
+    repo_modules = '-auth_ldap,-document_ftp,-base_gengo,-website_gengo,-website_instantclick,-pad,-pad_project,-note_pad,-pos_cache,-pos_blackbox_be,-hw_*,-theme_*,-l10n_*,'
+    cr.execute("UPDATE runbot_repo SET modules = CONCAT(%s, modules) WHERE modules_auto = 'all' or modules_auto = 'repo';", (repo_modules,))
+
+    # ceux qui n'ont pas d'étoile on prefix par '-*,'
+    cr.execute("SELECT id,install_modules FROM runbot_build_config_step")
+    for step_id, install_modules in cr.fetchall():
+        install_modules_list = [mod.strip() for mod in (install_modules or '').split(',') if mod.strip()]
+        if '*' in install_modules_list:
+            install_modules_list.remove('*')
+            install_modules = ', '.join(install_modules_list)
+        elif install_modules_list:
+            install_modules = '-*,%s' % install_modules
+        else:
+            install_modules = '-*'
+        cr.execute("UPDATE runbot_build_config_step SET install_modules = %s WHERE id=%s", (install_modules, step_id))


### PR DESCRIPTION
Actually some Odoo modules are black_listed from a set hardcoded in the
runbot code. On some cases, one needs to blacklist custom modules,
preferably in a config_step.

With this commit, a mod_black_list field is added on the Repo and on the
ConfigStep. They optionaly hold a comma separated list of fnmatch patterns. If a
module name match any of the pattern, it's filtered out from the build.