### PR TITLE
[IMP] runbot: add a multibuild wizard

### DIFF
--- a/runbot/__init__.py
+++ b/runbot/__init__.py
@@ -4,3 +4,4 @@ from . import controllers
 from . import models
 from . import common
 from . import container
+from . import wizards

--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '4.5',
+    'version': '4.6',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',
@@ -21,6 +21,7 @@
         'views/error_log_views.xml',
         'views/config_views.xml',
         'views/res_config_settings_views.xml',
+        'wizards/mutli_build_wizard_views.xml',
         'templates/frontend.xml',
         'templates/build.xml',
         'templates/assets.xml',

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -28,6 +28,8 @@ class Config(models.Model):
     step_order_ids = fields.One2many('runbot.build.config.step.order', 'config_id')
     update_github_state = fields.Boolean('Notify build state to github', default=False, track_visibility='onchange')
     protected = fields.Boolean('Protected', default=False, track_visibility='onchange')
+    group = fields.Many2one('runbot.build.config', 'Configuration group', help="Group of config's and config steps")
+    group_name = fields.Char(related='group.name')
 
     @api.model
     def create(self, values):
@@ -94,6 +96,9 @@ class ConfigStep(models.Model):
     ], default='install_odoo', required=True, track_visibility='onchange')
     protected = fields.Boolean('Protected', default=False, track_visibility='onchange')
     default_sequence = fields.Integer('Sequence', default=100, track_visibility='onchange')  # or run after? # or in many2many rel?
+    step_order_ids = fields.One2many('runbot.build.config.step.order', 'step_id')
+    group = fields.Many2one('runbot.build.config', 'Configuration group', help="Group of config's and config steps")
+    group_name = fields.Char('Group name', related='group.name')
     # install_odoo
     create_db = fields.Boolean('Create Db', default=True, track_visibility='onchange')  # future
     custom_db_name = fields.Char('Custom Db Name', track_visibility='onchange')  # future

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -8,7 +8,7 @@
                 <sheet>
                     <div attrs="{'invisible': [('protected', '=', False)]}">
                         <i class="fa fa-warning text-warning"/>This record is protected and can only be edited by config administrator.
-                    </div> 
+                    </div>
                     <group>
                         <field name="name"/>
                         <field name="description"/>
@@ -22,6 +22,7 @@
                         <field name="update_github_state" readonly='1'/>
                         <field name="update_github_state" groups="base.group_no_one"/>
                         <field name="protected" groups="base.group_no_one"/>
+                        <field name="group" groups="base.group_no_one"/>
                     </group>
                 </sheet>
                 <div class="oe_chatter">
@@ -45,6 +46,7 @@
                         <field name="job_type"/>
                         <field name="protected" groups="base.group_no_one"/>
                         <field name="default_sequence" groups="base.group_no_one"/>
+                        <field name="group" groups="base.group_no_one"/>
                     </group>
                     <group string="Python settings" attrs="{'invisible': [('job_type', 'not in', ('python'))]}">
                         <field name="python_code" widget="ace" options="{'mode': 'python'}"/>
@@ -76,6 +78,62 @@
         </field>
     </record>
 
+    <record id="runbot_config_tree_view" model="ir.ui.view">
+      <field name="name">Runbot Config tree view</field>
+      <field name="model">runbot.build.config</field>
+      <field name="arch" type="xml">
+        <tree string="Build Configs">
+          <field name="name"/>
+          <field name="description"/>
+          <field name="group"/>
+        </tree>
+      </field>
+    </record>
+
+    <record id="runbot_step_config_tree_view" model="ir.ui.view">
+      <field name="name">Runbot Config Step tree view</field>
+      <field name="model">runbot.build.config.step</field>
+      <field name="arch" type="xml">
+        <tree string="Build Config Steps">
+          <field name="name"/>
+          <field name="job_type"/>
+          <field name="group"/>
+        </tree>
+      </field>
+    </record>
+
+    <record id="runbot_config_search_view" model="ir.ui.view">
+      <field name="name">runbot.build.config.filter</field>
+      <field name="model">runbot.build.config</field>
+      <field name="arch" type="xml">
+        <search string="Search config">
+          <field name="name"/>
+          <field name="group_name"/>
+          <filter string="Is in a group" domain="[(['group', '!=', False])]"/>
+          <filter string="No step's defined" name="no_step" domain="[(['step_order_ids', '=', False])]"/>
+        </search>
+      </field>
+    </record>
+
+    <record id="runbot_config_step_search_view" model="ir.ui.view">
+      <field name="name">runbot.build.config.step.filter</field>
+      <field name="model">runbot.build.config.step</field>
+      <field name="arch" type="xml">
+        <search string="Search config step">
+          <field name="name"/>
+          <field name="group_name"/>
+          <filter string="Install job" domain="[(['job_type', '=', 'install_odoo'])]"/>
+          <filter string="Run job" domain="[(['job_type', '=', 'run_odoo'])]"/>
+          <filter string="Python job" domain="[(['job_type', '=', 'python'])]"/>
+          <filter string="Create job" domain="[(['job_type', '=', 'create_build'])]"/>
+          <separator/>
+          <filter string="Is in a group" domain="[(['group', '!=', False])]"/>
+          <separator/>
+          <filter string="No config defined" name="no_step" domain="[(['step_order_ids', '=', False])]"/>
+        </search>
+      </field>
+    </record>
+
     <record id="open_view_job_config_tree" model="ir.actions.act_window">
         <field name="name">Build Configs</field>
         <field name="res_model">runbot.build.config</field>
@@ -88,20 +146,26 @@
         <field name="view_mode">tree,form</field>
     </record>
 
-    
     <menuitem
-        name="Build Configs" 
-        id="runbot_menu_job_config_tree"
+        name="Configs"
+        id="runbot_menu_configs"
         parent="runbot_menu_root"
         sequence="30"
+        />
+
+    <menuitem
+        name="Build Configs"
+        id="runbot_menu_job_config_tree"
+        parent="runbot_menu_configs"
+        sequence="10"
         action="open_view_job_config_tree"
         />
 
     <menuitem
-        name="Build Config Step" 
+        name="Build Config Step"
         id="runbot_menu_job_tree"
-        parent="runbot_menu_root"
-        sequence="31"
+        parent="runbot_menu_configs"
+        sequence="20"
         action="open_view_job_tree"
         />
 

--- a/runbot/wizards/__init__.py
+++ b/runbot/wizards/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import multi_build_wizard

--- a/runbot/wizards/multi_build_wizard.py
+++ b/runbot/wizards/multi_build_wizard.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api
+
+
+class MultiBuildWizard(models.TransientModel):
+
+    _name = 'runbot.build.config.multi.wizard'
+
+    base_name = fields.Char('Generic name', required=True)
+    config_multi_name = fields.Char('Config name')
+    step_create_multi_name = fields.Char('Create multi step name')
+    config_single_name = fields.Char('Config only name')
+    config_single_extra_params = fields.Char('Extra cmd args')
+    config_single_test_tags = fields.Char('Test tags', default='')
+    config_single_test_enable = fields.Boolean('Enable tests', default=True)
+    step_single_name = fields.Char('Only step name')
+    number_builds = fields.Integer('Number of multi builds', default=10)
+    modules = fields.Char('Modules to install', default='')
+
+    @api.onchange('base_name')
+    def _onchange_name(self):
+        if self.base_name:
+            name = '%s %s' % (self.env.user.login.split('@')[0], self.base_name.capitalize())
+            step_name = name.replace(' ', '_').lower()
+
+            self.config_multi_name = '%s Multi' % name
+            self.step_create_multi_name = '%s_create_multi' % step_name
+            self.config_single_name = '%s Single' % name
+            self.step_single_name = '%s_single' % step_name
+
+    def generate(self):
+        if self.base_name:
+            # Create the "only" step and config
+            step_single = self.env['runbot.build.config.step'].create({
+                'name': self.step_single_name,
+                'job_type': 'install_odoo',
+                'test_tags': self.config_single_test_tags,
+                'extra_params': self.config_single_extra_params,
+                'test_enable': self.config_single_test_enable,
+            })
+            config_single = self.env['runbot.build.config'].create({'name': self.config_single_name})
+
+            self.env['runbot.build.config.step.order'].create({
+                'sequence': 10,
+                'config_id': config_single.id,
+                'step_id': step_single.id
+            })
+
+            # Create the multiple builds step and config
+            step_create_multi = self.env['runbot.build.config.step'].create({
+                'name': self.step_create_multi_name,
+                'job_type': 'create_build',
+                'create_config_ids': [(4, config_single.id)],
+                'number_builds': self.number_builds,
+                'hide_build': True,
+                'force_build': True
+            })
+
+            config_multi = self.env['runbot.build.config'].create({'name': self.config_multi_name})
+
+            config_multi.group = config_multi
+            step_create_multi.group = config_multi
+            config_single.group = config_multi
+            step_single.group = config_multi
+
+            self.env['runbot.build.config.step.order'].create({
+                'sequence': 10,
+                'config_id': config_multi.id,
+                'step_id': step_create_multi.id
+            })

--- a/runbot/wizards/mutli_build_wizard_views.xml
+++ b/runbot/wizards/mutli_build_wizard_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+        <record model="ir.ui.view" id="runbot_multi_build_wizard_form">
+            <field name="name">runbot_multi_build_wizard</field>
+            <field name="model">runbot.build.config.multi.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Send Mail">
+                    <group>
+                        <field name="base_name"/>
+                        <field name="config_multi_name"/>
+                        <field name="step_create_multi_name"/>
+                        <field name="config_single_name"/>
+                        <field name="step_single_name"/>
+                        <field name="number_builds"/>
+                        <field name="config_single_test_tags"/>
+                        <field name="modules"/>
+                        <field name="config_single_extra_params"/>
+                        <field name="config_single_test_enable"/>
+                    </group>
+                    <footer>
+                        <button name="generate" string="Create" type="object" class="btn-primary"/>
+                        <button string="Cancel" special="cancel" class="btn-default"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="runbot_multi_build_wizard_action">
+            <field name="name">Generate Multi Build Config</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">runbot.build.config.multi.wizard</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="runbot_multi_build_wizard_form"/>
+            <field name="target">new</field>
+        </record>
+
+        <menuitem
+            name="Multi Build Wizard"
+            id="runbot_menu_multi_wizard"
+            parent="runbot_menu_configs"
+            sequence="30"
+            action="runbot_multi_build_wizard_action"
+            />
+
+</odoo>


### PR DESCRIPTION
Creating multi builds configs can be tedious. One must create 2 build
configs and 2 build config steps in the right order.

With this commit, a simple wizard is added that creates those 4
configurations by simply filling 4 fields.