### PR TITLE
[IMP] runbot: check git repos on hosts

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -166,6 +166,14 @@ class runbot_repo(models.Model):
         # TODO get result and fallback on cleaing in case of problem
         return export_path
 
+    def _git_read_gc_log(self):
+        """ Returns content of a potential gc.log file in repo """
+        self.ensure_one()
+        gc_path = os.path.join(self.path, 'gc.log')
+        if os.path.exists(gc_path):
+            return open(gc_path, 'r').read()
+        return ''
+
     def _hash_exists(self, commit_hash):
         """ Verify that a commit hash exists in the repo """
         self.ensure_one()
@@ -620,6 +628,7 @@ class runbot_repo(models.Model):
         if host.last_exception:
             host.last_exception = ""
             host.exception_count = 0
+        host._check_repos()
         host.last_end_loop = fields.Datetime.now()
 
     def _source_cleanup(self):

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -7,4 +7,4 @@ from . import test_schedule
 from . import test_cron
 from . import test_build_config_step
 from . import test_event
-
+from . import test_host

--- a/runbot/tests/test_host.py
+++ b/runbot/tests/test_host.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+from odoo.tests import common
+
+
+class TestHost(common.TransactionCase):
+
+    @patch('odoo.addons.runbot.models.host.fqdn')
+    def test_get_current(self, mock_fqdn):
+        expected_name = 'runbotxxx.somewhere.com'
+        mock_fqdn.return_value = expected_name
+        host = self.env['runbot.host']._get_current()
+        self.assertEqual(host.name, expected_name)
+        self.assertEqual(host.display_name, expected_name)
+
+    @patch('odoo.addons.runbot.models.repo.runbot_repo._git_read_gc_log')
+    def test_check_repos(self, mock_read_gc_log):
+        mock_read_gc_log.return_value = 'error: Could not read 2b660ddbdb4494b2637e0d2574d3fc89093d6b11'
+        host = self.env['runbot.host'].create({'name': 'host_foo'})
+        self.assertFalse(host.assigned_only)
+        self.env['runbot.repo'].create({'name': 'bla@example.com:foo/bar'})
+        with self.assertLogs(logger='odoo.addons.runbot.models.host') as assert_log:
+            host._check_repos()
+            self.assertTrue(host.assigned_only)
+            self.assertIn('gc.log file found in repo', assert_log.output[0])
+            self.assertIn('error: Could not read', host.last_exception)


### PR DESCRIPTION
From time to time, a git repository is found corrupted on a runbot.
In that case, it can lead to various unpredictable resulsts.

For example, git archive fails or a commit is unreachable, leading to a
runbot build with no Odoo server. Even worse, the git archive can lead
to a partial extract of the tree with some files missing and to wrong
failure interpretation.

With this commit, at the end of the fetch_and_build cron, each active
repo is searched on the host to find a "gc.log" file.
If found, the last_exception field is used to store the content of the
gc.log file and the host is reserved, that way the host will not starts
new builds until manually fixed.

Note:
As a further improvement, a repo._reclone method could be executed to
reclone the repo from scratch in such a case and unreserve the host at
the end of the process.