### PR TITLE
[FIX] runbot: fix container cli tests

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -74,7 +74,7 @@ def docker_build(log_path, build_dir):
     dbuild.wait()
 
 
-def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None, cpu_limit=None, preexec_fn=None, ro_volumes=None):
+def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None, cpu_limit=None, preexec_fn=None, ro_volumes=None, env_variables=None):
     """Run tests in a docker container
     :param run_cmd: command string to run in container
     :param log_path: path to the logfile that will contain odoo stdout and stderr
@@ -101,6 +101,10 @@ def docker_run(run_cmd, log_path, build_dir, container_name, exposed_ports=None,
         for dest, source in ro_volumes.items():
             logs.write("Adding readonly volume '%s' pointing to %s \n" % (dest, source))
             docker_command.append('--volume=%s:/data/build/%s:ro' % (source, dest))
+
+    if env_variables:
+        for var in env_variables:
+            docker_command.append('-e=%s' % var)
 
     serverrc_path = os.path.expanduser('~/.openerp_serverrc')
     odoorc_path = os.path.expanduser('~/.odoorc')

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -353,8 +353,7 @@ class ConfigStep(models.Model):
         zip_path = '/data/build/logs/%s.zip' % db_name
         cmd.finals.append(['pg_dump', db_name, '>', sql_dest])
         cmd.finals.append(['cp', '-r', filestore_path, filestore_dest])
-        cmd.finals.append(['cd', dump_dir])
-        cmd.finals.append(['zip', '-rqm9', zip_path, '*'])
+        cmd.finals.append(['cd', dump_dir, '&&', 'zip', '-rmq9', zip_path, '*'])
         infos = '{\n    "db_name": "%s",\n    "build_id": %s,\n    "shas": [%s]\n}' % (db_name, build.id, ', '.join(['"%s"' % commit for commit in build._get_all_commit()]))
         build.write_file('logs/%s/info.json' % db_name, infos)
 

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -60,7 +60,9 @@
                         <field name="coverage"/>
                         <field name="test_enable"/>
                         <field name="test_tags"/>
+                        <field name="enable_auto_tags"/>
                         <field name="extra_params"/>
+                        <field name="additionnal_env"/>
                     </group>
                     <group string="Create settings" attrs="{'invisible': [('job_type', 'not in', ('python', 'create_build'))]}">
                         <field name="create_config_ids" widget="many2many_tags" options="{'no_create': True}" />


### PR DESCRIPTION
Since 81fefee, the container.py CLI does not work as expected.

With this commit, the CLI is working, a new arg was added to test
flamegraphs and the dump is adapted to mimic the runbot.

Also, a small issue is fixed in the zip file creation. Before the zip
creation, the directory is changed, if the directory change fails, the
zip is created from the current directory which is removed by zip at the
end of the process. That could lead to the deletion of the build dir.