### PR TITLE
[IMP] runbot: add auto-test-tags-management.

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -336,8 +336,9 @@ class Runbot(Controller):
             'pending_level': pending[1],
             'glances_data': glances_ctx,
             'hosts_data': hosts_data,
-            'last_monitored': last_monitored  # nightly
-
+            'last_monitored': last_monitored,  # nightly
+            'auto_tags': request.env['runbot.build.error'].disabling_tags(),
+            'build_errors': request.env['runbot.build.error'].search([('random', '=', True)])
         }
         return request.render("runbot.monitoring", qctx)
 

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -109,6 +109,7 @@ class ConfigStep(models.Model):
     flamegraph = fields.Boolean('Allow Flamegraph', default=False, track_visibility='onchange')
     test_enable = fields.Boolean('Test enable', default=True, track_visibility='onchange')
     test_tags = fields.Char('Test tags', help="comma separated list of test tags")
+    enable_auto_tags = fields.Boolean('Allow auto tag', default=True)
     extra_params = fields.Char('Extra cmd args', track_visibility='onchange')
     # python
     python_code = fields.Text('Python code', track_visibility='onchange', default=PYTHON_DEFAULT)
@@ -325,6 +326,9 @@ class ConfigStep(models.Model):
             if grep(config_path, "test-tags"):
                 if not test_tags_in_extra:
                     test_tags = self.test_tags.replace(' ', '')
+                    if self.enable_auto_tags:
+                        auto_tags = self.env['runbot.build.error'].disabling_tags()
+                        test_tags = ','.join(test_tags.split(',') + auto_tags)
                     cmd.extend(['--test-tags', test_tags])
             else:
                 build._log('test_all', 'Test tags given but not supported')


### PR DESCRIPTION
A typical use case when an error is detected is to disable
this test by adding a negated test-tags on config
step 'all' and 'split_all'. This commit will help
to do that by adding a test_tags management on build error.

The user define a test_tag that will only execute failling test.
if a config step has the flag enable_auto_tags, the test tag will
be negated and added to config test-tags.