### PR TITLE
[IMP] runbot: use a config file to simplify args

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -287,7 +287,7 @@ class ConfigStep(models.Model):
         build_port = build.port
         self.env.cr.commit()  # commit before docker run to be 100% sure that db state is consistent with dockers
         self.invalidate_cache()
-        res = docker_run(cmd.build(), log_path, build_path, docker_name, exposed_ports=[build_port, build_port + 1], ro_volumes=exports)
+        res = docker_run(cmd, log_path, build_path, docker_name, exposed_ports=[build_port, build_port + 1], ro_volumes=exports)
         build.repo_id._reload_nginx()
         return res
 
@@ -335,7 +335,7 @@ class ConfigStep(models.Model):
                 build._log('test_all', 'Test tags given but not supported')
 
         if grep(config_path, "--screenshots"):
-            cmd += ['--screenshots', '/data/build/tests']
+            cmd.add_config_tuple('screenshots', '/data/build/tests')
 
         cmd.append('--stop-after-init')  # install job should always finish
         if '--log-level' not in extra_params:
@@ -363,7 +363,7 @@ class ConfigStep(models.Model):
         max_timeout = int(self.env['ir.config_parameter'].get_param('runbot.runbot_timeout', default=10000))
         timeout = min(self.cpu_limit, max_timeout)
         env_variables = self.additionnal_env.split(',') if self.additionnal_env else []
-        return docker_run(cmd.build(), log_path, build._path(), build._get_docker_name(), cpu_limit=timeout, ro_volumes=exports, env_variables=env_variables)
+        return docker_run(cmd, log_path, build._path(), build._get_docker_name(), cpu_limit=timeout, ro_volumes=exports, env_variables=env_variables)
 
     def log_end(self, build):
         if self.job_type == 'create_build':

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -7,4 +7,4 @@ from . import test_schedule
 from . import test_cron
 from . import test_build_config_step
 from . import test_event
-
+from . import test_command

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -113,7 +113,7 @@ class Test_Build(common.TransactionCase):
             'port': '1234',
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('--log-db=%s' % uri, cmd)
+        self.assertIn('log-db = %s' % uri, cmd.get_config())
 
     @patch('odoo.addons.runbot.models.build.os.path.isdir')
     @patch('odoo.addons.runbot.models.build.os.path.isfile')

--- a/runbot/tests/test_command.py
+++ b/runbot/tests/test_command.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from odoo.tests import common
+from ..container import Command
+
+
+CONFIG = """[options]
+foo = bar
+"""
+
+
+class Test_Command(common.TransactionCase):
+
+    def test_command(self):
+        pres = ['pip3', 'install', 'foo']
+        posts = ['python3', '-m', 'coverage', 'html']
+        finals = ['pgdump bar']
+        cmd = Command([pres], ['python3', 'odoo-bin'], [posts], finals=[finals])
+        self.assertEqual(str(cmd), 'python3 odoo-bin')
+
+        expected = 'pip3 install foo && python3 odoo-bin && python3 -m coverage html ; pgdump bar'
+        self.assertEqual(cmd.build(), expected)
+
+        cmd = Command([pres], ['python3', 'odoo-bin'], [posts])
+        cmd.add_config_tuple('a', 'b')
+        cmd.add_config_tuple('x', 'y')
+
+        content = cmd.get_config(starting_config=CONFIG)
+
+        self.assertIn('[options]', content)
+        self.assertIn('foo = bar', content)
+        self.assertIn('a = b', content)
+        self.assertIn('x = y', content)


### PR DESCRIPTION
When starting an odoo instance with Docker, a very long command line is
computed and appears in the logs.

With this commit, an .odoorc configuration file is written ind the build
dir and mounted in the Docker container.

Previously, the runbot .odoorc/.openerprc file was mounted to share some
parameters. Now, if that file exsists, its content is merged with build .odoorc.