### PR TITLE
[FIX] runbot: fix typo in data_dir/data-dir

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -56,7 +56,7 @@ class Command():
         return self.cmd[key]
 
     def __add__(self, l):
-        return Command(self.pres, self.cmd + l, self.posts, self.finals)
+        return Command(self.pres, self.cmd + l, self.posts, self.finals, self.config_tuples)
 
     def __str__(self):
         return ' '.join(self)
@@ -74,6 +74,7 @@ class Command():
         return ' ; '.join(cmd_chain)
 
     def add_config_tuple(self, option, value):
+        assert '-' not in option
         self.config_tuples.append((option, value))
 
     def get_config(self, starting_config=''):
@@ -250,7 +251,7 @@ def tests(args):
         python_params = ['-m', 'flamegraph', '-o', flame_log]
     odoo_cmd = ['python%s' % py_version ] + python_params + ['/data/build/odoo-bin', '-d %s' % args.db_name, '--addons-path=/data/build/addons', '-i', args.odoo_modules,  '--test-enable', '--stop-after-init', '--max-cron-threads=0']
     cmd = Command(pres, odoo_cmd, posts)
-    cmd.add_config_tuple('data-dir', '/data/build/datadir')
+    cmd.add_config_tuple('data_dir', '/data/build/datadir')
     cmd.add_config_tuple('db_user', '%s' % os.getlogin())
 
     if args.dump:

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -910,24 +910,24 @@ class runbot_build(models.Model):
 
         if local_only:
             if grep(config_path, "--http-interface"):
-                command.add_config_tuple("http-interface", "127.0.0.1")
+                command.add_config_tuple("http_interface", "127.0.0.1")
             elif grep(config_path, "--xmlrpc-interface"):
-                command.add_config_tuple("xmlrpc-interface", "127.0.0.1")
+                command.add_config_tuple("xmlrpc_interface", "127.0.0.1")
 
         if grep(config_path, "log-db"):
             logdb_uri = self.env['ir.config_parameter'].get_param('runbot.runbot_logdb_uri')
             logdb = self.env.cr.dbname
             if logdb_uri and grep(build._server('sql_db.py'), 'allow_uri'):
                 logdb = '%s' % logdb_uri
-            command.add_config_tuple("log-db", "%s" % logdb)
+            command.add_config_tuple("log_db", "%s" % logdb)
             if grep(build._server('tools/config.py'), 'log-db-level'):
-                command.add_config_tuple("log-db-level", '25')
+                command.add_config_tuple("log_db_level", '25')
 
         if grep(config_path, "data-dir"):
             datadir = build._path('datadir')
             if not os.path.exists(datadir):
                 os.mkdir(datadir)
-            command.add_config_tuple("data-dir", '/data/build/datadir')
+            command.add_config_tuple("data_dir", '/data/build/datadir')
 
         return command
 

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -105,7 +105,7 @@ class Test_Build(RunbotCase):
             'port': '1234',
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('log-db = %s' % uri, cmd.get_config())
+        self.assertIn('log_db = %s' % uri, cmd.get_config())
 
     def test_build_cmd_server_path_no_dep(self):
         """ test that the server path and addons path """

--- a/runbot/tests/test_command.py
+++ b/runbot/tests/test_command.py
@@ -22,6 +22,8 @@ class Test_Command(common.TransactionCase):
 
         cmd = Command([pres], ['python3', 'odoo-bin'], [posts])
         cmd.add_config_tuple('a', 'b')
+        cmd += ['bar']
+        self.assertIn('bar', cmd.cmd)
         cmd.add_config_tuple('x', 'y')
 
         content = cmd.get_config(starting_config=CONFIG)
@@ -30,3 +32,6 @@ class Test_Command(common.TransactionCase):
         self.assertIn('foo = bar', content)
         self.assertIn('a = b', content)
         self.assertIn('x = y', content)
+
+        with self.assertRaises(AssertionError):
+            cmd.add_config_tuple('http-interface', '127.0.0.1')


### PR DESCRIPTION
When creating an .odoorc file to store configuration that are proper for
the runbot, the 'data-dir' key was used instead of data_dir.

Because of that, the data dir was created in the default dir and thus,
not included in the zip file of the dump, causing some runbot
steps to fail.