### PR TITLE
[ADD] runbot_merge: automatic reviewer de-provisioning

### DIFF
--- a/runbot_merge/controllers/__init__.py
+++ b/runbot_merge/controllers/__init__.py
@@ -8,6 +8,7 @@ import werkzeug.exceptions
 from odoo.http import Controller, request, route
 
 from . import dashboard
+from . import reviewer_provisioning
 from .. import utils, github
 
 _logger = logging.getLogger(__name__)

--- a/runbot_merge/controllers/reviewer_provisioning.py
+++ b/runbot_merge/controllers/reviewer_provisioning.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from odoo import http
+from odoo.http import request
+from odoo.addons.saas_worker.util import from_role
+
+
+class MergebotReviewerProvisioning(http.Controller):
+
+    @from_role('accounts')
+    @http.route(['/runbot_merge/get_reviewers'], type='json', auth='public')
+    def fetch_reviewers(self, **kwargs):
+        partners = request.env['res.partner'].sudo().search(['|', ('self_reviewer', '=', True), ('reviewer', '=', True)])
+        return partners.mapped('github_login')
+
+    @from_role('accounts')
+    @http.route(['/runbot_merge/remove_reviewers'], type='json', auth='public', methods=['POST'])
+    def update_reviewers(self, github_logins, **kwargs):
+        partners = request.env['res.partner'].sudo().search([('github_login', 'in', github_logins)])
+
+        # remove reviewer flag from the partner
+        partners.write({
+            'reviewer': False,
+            'self_reviewer': False,
+        })
+
+        # Assign the linked users as portal users
+        partners.mapped('user_ids').write({
+            'groups_id': [(6, 0, [request.env.ref('base.group_portal').id])]
+        })


### PR DESCRIPTION
When an employee sadly leaves Odoo,
the Odoo production database (odoo.com) will call these routes
in order to remove the reviewer rights automatically.

So a user who no longer works for Odoo can't "r+" Github PRs.

This is related to odoo/internal#617