### PR TITLE
[IMP] runbot: add relation between branches

### DIFF
--- a/runbot/views/branch_views.xml
+++ b/runbot/views/branch_views.xml
@@ -10,6 +10,7 @@
             <sheet>
               <group name="branch_group">
                 <field name="repo_id"/>
+                <field name="duplicate_repo_id" invisible='1'/>
                 <field name="name"/>
                 <field name="branch_name"/>
                 <field name="branch_url"/>
@@ -21,6 +22,10 @@
                 <field name="modules"/>
                 <field name="config_id"/>
                 <field name="no_build"/>
+                <field name="closest_sticky"/>
+                <field name="defined_sticky" domain="[('sticky', '=', True), ('repo_id', 'in', [repo_id, duplicate_repo_id])]"/>
+                <field name="previous_version"/>
+                <field name="intermediate_stickies" widget="many2many_tags"/>
               </group>
             </sheet>
           </form>


### PR DESCRIPTION
Migration tests comming on runbot, it will be usefull to have quick
way to obtain branches related to current build.

This commit adds a field for the colsest sticky branch, previous version
and intermediates stickies.

Example when last sticky is saas-13.2:
branch_name: master-test-tri
closest_sticky: master
previous_version: 13.0
intermediate_stickies: saas-13.1, saas-13.2