### PR TITLE
[IMP] runbot: add a data field on build

### DIFF
--- a/runbot/fields.py
+++ b/runbot/fields.py
@@ -1,0 +1,50 @@
+from odoo.fields import Field, pycompat
+import json
+from collections import MutableMapping
+from psycopg2.extras import Json
+
+
+class JsonDictField(Field):
+    type = 'jsonb'
+    column_type = ('jsonb', 'jsonb')
+    column_cast_from = ('varchar',)
+
+    def convert_to_write(self, value, record):
+        return value
+
+    def convert_to_column(self, value, record, values=None, validate=True):
+        val = self.convert_to_cache(value, record, validate=validate)
+        return Json(value) if val else val
+
+    def convert_to_cache(self, value, record, validate=True):
+        return value.dict if isinstance(value, FieldDict) else value if isinstance(value, dict) else None
+
+    def convert_to_record(self, value, record):
+        return FieldDict(value or {}, self, record)
+
+
+class FieldDict(MutableMapping):
+
+    def __init__(self, init_dict, field, record):
+        self.field = field
+        self.record = record
+        self.dict = init_dict
+
+    def __setitem__(self, key, value):
+        new = self.dict.copy()
+        new[key] = value
+        self.record[self.field.name] = new
+
+    def __getitem__(self, key):
+        return self.dict[key]
+
+    def __delitem__(self, key):
+        new = self.dict.copy()
+        del new[key]
+        self.record[self.field.name] = new
+
+    def __iter__(self):
+        return iter(self.dict)
+
+    def __len__(self):
+        return len(self.dict)

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -10,6 +10,7 @@ import time
 import datetime
 from ..common import dt2time, fqdn, now, grep, uniq_list, local_pgadmin_cursor, s2human, Commit, dest_reg, os
 from ..container import docker_build, docker_stop, docker_state, Command
+from ..fields import JsonDictField
 from odoo.addons.runbot.models.repo import RunbotException
 from odoo import models, fields, api
 from odoo.exceptions import UserError, ValidationError
@@ -53,6 +54,7 @@ class runbot_build(models.Model):
     sequence = fields.Integer('Sequence')
     log_ids = fields.One2many('ir.logging', 'build_id', string='Logs')
     error_log_ids = fields.One2many('ir.logging', 'build_id', domain=[('level', 'in', ['WARNING', 'ERROR', 'CRITICAL'])], string='Error Logs')
+    config_data = JsonDictField('Json Data')
 
     # state machine
 


### PR DESCRIPTION
When two steps in the same build needs to exchange informations, some
hacks have to be used. E.g. using the extra_params fields to store comma
separated values.

With this commit, a data field is added alongside with two helper
methods that store/retrieve the content of the field as a json string.