### PR TITLE
[FIX] runbot: use a logging handler that loves logrotate

### DIFF
--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -6,6 +6,8 @@ import sys
 import threading
 import signal
 
+from logging.handlers import WatchedFileHandler
+
 LOG_FORMAT = '%(asctime)s %(levelname)s %(name)s: %(message)s'
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logging.getLogger('odoo.addons.runbot').setLevel(logging.DEBUG)
@@ -80,7 +82,7 @@ def run():
         if dirname and not os.path.isdir(dirname):
             os.makedirs(dirname)
 
-        handler = logging.FileHandler(args.logfile)
+        handler = WatchedFileHandler(args.logfile)
         formatter = logging.Formatter(LOG_FORMAT)
         handler.setFormatter(formatter)
         logging.getLogger().addHandler(handler)


### PR DESCRIPTION
When the linux logrotate system rename the runbot logfile used by the
new builder script, the script continues to write in the rotated file.

With this commit, the WatchedFileHandler is used. This handler is
specially crafted to handle this situation, it detects the file renaming
and automatically changes to the new file that have the old filename.