### PR TITLE
[IMP] runbot: improve local cleanup

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '4.8',
+    'version': '4.9',
     'depends': ['website', 'base'],
     'data': [
         'security/runbot_security.xml',

--- a/runbot/common.py
+++ b/runbot/common.py
@@ -97,6 +97,7 @@ def s2human(time):
         threshold=2.1,
     )
 
+
 @contextlib.contextmanager
 def local_pgadmin_cursor():
     cnx = None
@@ -107,3 +108,17 @@ def local_pgadmin_cursor():
     finally:
         if cnx:
             cnx.close()
+
+
+def list_local_dbs(additionnal_conditions=None):
+    additionnal_condition_str = ''
+    if additionnal_conditions:
+        additionnal_condition_str = 'AND (%s)' % ' OR '.join(additionnal_conditions)
+    with local_pgadmin_cursor() as local_cr:
+        local_cr.execute("""
+            SELECT datname
+                FROM pg_database
+                WHERE pg_get_userbyid(datdba) = current_user
+                %s
+        """ % additionnal_condition_str)
+        return [d[0] for d in local_cr.fetchall()]

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -366,15 +366,6 @@ class runbot_repo(models.Model):
                     builds_to_skip._skip(reason='New ref found')
                     if builds_to_skip:
                         build_info['sequence'] = builds_to_skip[0].sequence
-                    # testing builds are killed
-                    builds_to_kill = Build.search([
-                        ('branch_id', '=', branch.id),
-                        ('local_state', '=', 'testing'),
-                        ('committer', '=', committer)
-                    ])
-                    for btk in builds_to_kill:
-                        btk._log('repo._update_git', 'Build automatically killed, newer build found.', level='WARNING')
-                    builds_to_kill.write({'requested_action': 'deathrow'})
 
                 new_build = Build.create(build_info)
                 # create a reverse dependency build if needed
@@ -466,6 +457,8 @@ class runbot_repo(models.Model):
     def _scheduler(self, host):
         nb_workers = host.get_nb_worker()
 
+        self._gc_testing(host)
+        self._commit()
         for build in self._get_builds_with_requested_actions(host):
             build._process_requested_actions()
             self._commit()
@@ -546,6 +539,33 @@ class runbot_repo(models.Model):
 
         build_ids = Build.search(domain_host + [('local_state', '=', 'running'), ('id', 'not in', cannot_be_killed_ids)], order='job_start desc').ids
         Build.browse(build_ids)[running_max:]._kill()
+
+    def _gc_testing(self, host):
+        """garbage collect builds that could be killed"""
+        # decide if we need room
+        Build = self.env['runbot.build']
+        domain_host = self.build_domain_host(host)
+        testing_builds = Build.search(domain_host + [('local_state', 'in', ['testing', 'pending'])])
+        used_slots = len(testing_builds)
+        available_slots = host.get_nb_worker() - used_slots
+        nb_pending = Build.search_count([('local_state', '=', 'pending'), ('host', '=', False)])
+        if available_slots > 0 or nb_pending == 0:
+            return
+        builds_to_kill = self.env['runbot.build']
+        builds_to_skip = self.env['runbot.build']
+        for build in testing_builds:
+            top_parent = build._get_top_parent()
+            if not build.branch_id.sticky:
+                newer_candidates = Build.search([
+                    ('id', '>', build.id),
+                    ('branch_id', '=', build.branch_id.id),
+                    ('build_type', '=', 'normal'),
+                    ('parent_id', '=', False),
+                    ('hidden', '=', False),
+                    ('config_id', '=', top_parent.config_id.id)
+                ])
+                if newer_candidates:
+                    top_parent._ask_kill(message='Build automatically killed, newer build found %s.' % newer_candidates.ids)
 
     def _allocate_builds(self, host, nb_slots, domain=None):
         if nb_slots <= 0:

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -16,6 +16,7 @@ class RunbotCase(TransactionCase):
         self.Branch = self.env['runbot.branch']
 
         self.patchers = {}
+        self.patcher_objects = {}
 
         def git_side_effect(cmd):
             if cmd[:2] == ['show', '-s'] or cmd[:3] == ['show', '--pretty="%H -- %s"', '-s']:
@@ -41,17 +42,29 @@ class RunbotCase(TransactionCase):
         self.start_patcher('docker_stop', 'odoo.addons.runbot.models.repo.docker_stop')
         self.start_patcher('cr_commit', 'odoo.sql_db.Cursor.commit', None)
         self.start_patcher('repo_commit', 'odoo.addons.runbot.models.repo.runbot_repo._commit', None)
+        self.start_patcher('_local_cleanup_patcher', 'odoo.addons.runbot.models.build.runbot_build._local_cleanup')
+        self.start_patcher('_local_pg_dropdb_patcher', 'odoo.addons.runbot.models.build.runbot_build._local_pg_dropdb')
 
     def start_patcher(self, patcher_name, patcher_path, return_value=Dummy, side_effect=Dummy):
+
+        def stop_patcher_wrapper():
+            self.stop_patcher(patcher_name)
+
         patcher = patch(patcher_path)
         if not hasattr(patcher, 'is_local'):
             res = patcher.start()
-            self.addCleanup(patcher.stop)
+            self.addCleanup(stop_patcher_wrapper)
             self.patchers[patcher_name] = res
+            self.patcher_objects[patcher_name] = patcher
             if side_effect != Dummy:
                 res.side_effect = side_effect
             elif return_value != Dummy:
                 res.return_value = return_value
+
+    def stop_patcher(self, patcher_name):
+        if patcher_name in self.patcher_objects:
+            self.patcher_objects[patcher_name].stop()
+            del self.patcher_objects[patcher_name]
 
     def create_build(self, vals):
         return self.Build.create(vals)

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -99,7 +99,7 @@
                 <field name="last_seen_date" string="Last Seen"/>
                 <field name="build_count"/>
                 <field name="responsible"/>
-                <field name="fixing_commit"/>
+                <field name="test_tags"/>
             </tree>
         </field>
     </record>
@@ -122,6 +122,8 @@
           <filter string="Not Fixed" name="not_fixed_errors" domain="[('active', '=', True)]"/>
           <separator/>
           <filter string="Not Assigned" name="not_assigned_errors" domain="[('responsible', '=', False)]"/>
+          <separator/>
+          <filter string="Test Tags" name="test_tagged_errors" domain="[('test_tags', '!=', False)]"/>
         </search>
       </field>
     </record>

--- a/runbot/views/build_views.xml
+++ b/runbot/views/build_views.xml
@@ -48,6 +48,8 @@
                         <field name="hidden" groups="base.group_no_one"/>
                         <field name="build_url" widget="url" readonly="1"/>
                         <field name="keep_running"/>
+                        <field name="gc_date" readonly="1"/>
+                        <field name="gc_delay"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
When a build age reaches the gc_days parameter, its database is dropped
and its directory is removed.

With this commit, two fields are added in order to keep some builds
longer that the defined gc_days.

The gc_delay field on the build allows to add a delay (in number of
days) that is added to its gc_days to compute the gc_date.

The gc_date field is the date when the cleaning will occur.

Also, a test is added and the RunbotCase test class is improved to allow
the stop of a patcher.