### PR TITLE
[FIX] runbot: temporarily freeze the coverage version

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -14,7 +14,7 @@ import datetime
 import io
 import json
 import logging
-from .common import os
+import os
 import shutil
 import subprocess
 import time

--- a/runbot/data/Dockerfile
+++ b/runbot/data/Dockerfile
@@ -83,4 +83,4 @@ RUN pip install -U setuptools wheel \
 ADD https://raw.githubusercontent.com/odoo/odoo/master/requirements.txt /root/p3-requirements.txt
 ADD https://raw.githubusercontent.com/odoo/odoo/10.0/requirements.txt /root/p2-requirements.txt
 RUN pip install --no-cache-dir -r /root/p2-requirements.txt coverage flanker==0.4.38 pylint==1.7.2 phonenumbers redis \
-    && pip3 install --no-cache-dir -r /root/p3-requirements.txt coverage websocket-client astroid==2.0.4 pylint==1.7.2 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph
+    && pip3 install --no-cache-dir -r /root/p3-requirements.txt coverage==4.5.4 websocket-client astroid==2.0.4 pylint==1.7.2 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph


### PR DESCRIPTION
As the Odoo requirements were recently updated, the last RUN entry in
the Docker image was rebuilt on our runbot instances.

Since that moment the coverage builds are failing with an import error.
After investigation, it appears that the latest coverage version modifies the sys.path.
A bug report was written for coverage: https://github.com/nedbat/coveragepy/issues/919

For that reason, this commit freeze the coverage version until this bug
is fixed.

Also, the os import problem in conatainer.py is fixed.