### PR TITLE
[FIX] runbot: fix compute previous_version and intermediates

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -69,7 +69,7 @@ class runbot_branch(models.Model):
             if branch.closest_sticky == branch:
                 repo_ids = (branch.repo_id | branch.repo_id.duplicate_id).ids
                 domain = [('branch_name', 'like', '%.0'), ('sticky', '=', True), ('branch_name', '!=', 'master'), ('repo_id', 'in', repo_ids)]
-                if branch.branch_name != 'master':
+                if branch.branch_name != 'master' and branch.id:
                     domain += [('id', '<', branch.id)]
                 branch.previous_version = self.search(domain, limit=1, order='id desc')
             else:
@@ -84,7 +84,7 @@ class runbot_branch(models.Model):
                     continue
                 repo_ids = (branch.repo_id | branch.repo_id.duplicate_id).ids
                 domain = [('id', '>', branch.previous_version.id), ('sticky', '=', True), ('branch_name', '!=', 'master'), ('repo_id', 'in', repo_ids)]
-                if branch.closest_sticky.branch_name != 'master':
+                if branch.closest_sticky.branch_name != 'master' and branch.closest_sticky.id:
                     domain += [('id', '<', branch.closest_sticky.id)]
                 branch.intermediate_stickies = [(6, 0, self.search(domain, order='id desc').ids)]
             else:


### PR DESCRIPTION
When changing the sticky value in a branch form, it triggers the
computes of previous version and intermediate versions.

In the onchange situation, the branch.id is a NEW id and it fails with a
traceback.

With this commit, a verification is made to ensure that the id is there.