### PR TITLE
Repository-level customisations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,6 @@ NGROK_CLI = [
 
 def pytest_addoption(parser):
     parser.addoption('--addons-path')
-    parser.addoption('--db', help="DB to run the tests against", default='template_%s' % uuid.uuid4())
     parser.addoption("--no-delete", action="store_true", help="Don't delete repo after a failed run")
 
     parser.addoption(
@@ -76,9 +75,6 @@ def pytest_addoption(parser):
              "queries per minute, free is 40, multi-repo batching tests will "
              "blow through the former); localtunnel has no rate-limiting but "
              "the servers are way less reliable")
-
-def pytest_report_header(config):
-    return 'Running against database ' + config.getoption('--db')
 
 @pytest.fixture(scope='session', autouse=True)
 def _set_socket_timeout():
@@ -216,26 +212,36 @@ def tunnel(pytestconfig, port):
     else:
         raise ValueError("Unsupported %s tunnel method" % tunnel)
 
+class DbDict(dict):
+    def __init__(self, adpath):
+        super().__init__()
+        self._adpath = adpath
+    def __missing__(self, module):
+        db = 'template_%s' % uuid.uuid4()
+        subprocess.run([
+            'odoo', '--no-http',
+            '--addons-path', self._adpath,
+            '-d', db, '-i', module,
+            '--max-cron-threads', '0',
+            '--stop-after-init'
+        ])
+        self[module] = db
+        return db
+
 @pytest.fixture(scope='session')
-def dbcache(request, module):
+def dbcache(request):
     """ Creates template DB once per run, then just duplicates it before
     starting odoo and running the testcase
     """
-    db = request.config.getoption('--db')
-    subprocess.run([
-        'odoo', '--no-http',
-        '--addons-path', request.config.getoption('--addons-path'),
-        '-d', db, '-i', module,
-        '--max-cron-threads', '0',
-        '--stop-after-init'
-    ], check=True)
-    yield db
-    subprocess.run(['dropdb', db], check=True)
+    dbs = DbDict(request.config.getoption('--addons-path'))
+    yield dbs
+    for db in dbs.values():
+        subprocess.run(['dropdb', db], check=True)
 
 @pytest.fixture
-def db(request, dbcache):
+def db(request, module, dbcache):
     rundb = str(uuid.uuid4())
-    subprocess.run(['createdb', '-T', dbcache, rundb], check=True)
+    subprocess.run(['createdb', '-T', dbcache[module], rundb], check=True)
 
     yield rundb
 

--- a/forwardport/tests/conftest.py
+++ b/forwardport/tests/conftest.py
@@ -60,7 +60,7 @@ def _cleanup_cache(config, users):
     for login in users.values():
         rmtree(cache_root / login, ignore_errors=True)
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def module():
     """ When a test function is (going to be) run, selects the containing
     module (as needing to be installed)

--- a/forwardport/tests/test_weird.py
+++ b/forwardport/tests/test_weird.py
@@ -25,7 +25,6 @@ def make_basic(env, config, make_repo, *, fp_token, fp_remote):
             'github_token': config['github']['token'],
             'github_prefix': 'hansen',
             'fp_github_token': fp_token and config['github']['token'],
-            'required_statuses': 'legal/cla,ci/runbot',
             'branch_ids': [
                 (0, 0, {'name': 'a', 'fp_sequence': 2, 'fp_target': True}),
                 (0, 0, {'name': 'b', 'fp_sequence': 1, 'fp_target': True}),
@@ -59,6 +58,7 @@ def make_basic(env, config, make_repo, *, fp_token, fp_remote):
     project.write({
         'repo_ids': [(0, 0, {
             'name': prod.name,
+            'required_statuses': 'legal/cla,ci/runbot',
             'fp_remote_target': fp_remote and other.name,
         })],
     })

--- a/forwardport/tests/utils.py
+++ b/forwardport/tests/utils.py
@@ -55,7 +55,6 @@ def make_basic(env, config, make_repo, *, reponame='proj', project_name='myproje
             'github_token': config['github']['token'],
             'github_prefix': 'hansen',
             'fp_github_token': config['github']['token'],
-            'required_statuses': 'legal/cla,ci/runbot',
             'branch_ids': [
                 (0, 0, {'name': 'a', 'fp_sequence': 2, 'fp_target': True}),
                 (0, 0, {'name': 'b', 'fp_sequence': 1, 'fp_target': True}),
@@ -89,6 +88,7 @@ def make_basic(env, config, make_repo, *, reponame='proj', project_name='myproje
     project.write({
         'repo_ids': [(0, 0, {
             'name': prod.name,
+            'required_statuses': 'legal/cla,ci/runbot',
             'fp_remote_target': other.name,
         })],
     })

--- a/runbot_merge/__manifest__.py
+++ b/runbot_merge/__manifest__.py
@@ -1,5 +1,6 @@
 {
     'name': 'merge bot',
+    'version': '1.1',
     'depends': ['contacts', 'website'],
     'data': [
         'security/security.xml',

--- a/runbot_merge/migrations/11.0.1.1/pre-migration.py
+++ b/runbot_merge/migrations/11.0.1.1/pre-migration.py
@@ -1,0 +1,17 @@
+def migrate(cr, version):
+    """ Moved the required_statuses field from the project to the repository so
+    different repos can have different CI requirements within a project
+    """
+    # create column on repo
+    cr.execute("ALTER TABLE runbot_merge_repository ADD COLUMN required_statuses varchar")
+    # copy data from project
+    cr.execute("""
+    UPDATE runbot_merge_repository r 
+    SET required_statuses = (
+        SELECT required_statuses 
+        FROM runbot_merge_project 
+        WHERE id = r.project_id
+    )
+    """)
+    # drop old column on project
+    cr.execute("ALTER TABLE runbot_merge_project DROP COLUMN required_statuses")

--- a/runbot_merge/tests/conftest.py
+++ b/runbot_merge/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-@pytest.fixture(scope='session')
+@pytest.fixture()
 def module():
     return 'runbot_merge'
 

--- a/runbot_merge/tests/conftest.py
+++ b/runbot_merge/tests/conftest.py
@@ -36,5 +36,4 @@ def project(env, config):
         'github_token': config['github']['token'],
         'github_prefix': 'hansen',
         'branch_ids': [(0, 0, {'name': 'master'})],
-        'required_statuses': 'legal/cla,ci/runbot',
     })

--- a/runbot_merge/tests/test_basic.py
+++ b/runbot_merge/tests/test_basic.py
@@ -15,7 +15,10 @@ from test_utils import re_matches, get_partner, _simple_init
 @pytest.fixture
 def repo(project, make_repo):
     r = make_repo('repo')
-    project.write({'repo_ids': [(0, 0, {'name': r.name})]})
+    project.write({'repo_ids': [(0, 0, {
+        'name': r.name,
+        'required_statuses': 'legal/cla,ci/runbot'
+    })]})
     return r
 
 def test_trivial_flow(env, repo, page, users, config):
@@ -937,7 +940,7 @@ def test_reopen_state(env, repo):
 def test_no_required_statuses(env, repo, config):
     """ check that mergebot can work on a repo with no CI at all
     """
-    env['runbot_merge.project'].search([]).required_statuses = ''
+    env['runbot_merge.repository'].search([('name', '=', repo.name)]).required_statuses = ''
     with repo:
         m = repo.make_commit(None, 'initial', None, tree={'0': '0'})
         repo.make_ref('heads/master', m)

--- a/runbot_merge/views/mergebot.xml
+++ b/runbot_merge/views/mergebot.xml
@@ -19,9 +19,6 @@
                         <group>
                             <field name="github_prefix" string="bot name"/>
                         </group>
-                        <group>
-                            <field name="required_statuses"/>
-                        </group>
                     </group>
                     <group>
                         <group>
@@ -38,6 +35,7 @@
                     <field name="repo_ids">
                         <tree editable="bottom">
                             <field name="name"/>
+                            <field name="required_statuses"/>
                         </tree>
                     </field>
                     <separator string="Branches"/>


### PR DESCRIPTION
* move the required statuses (CI jobs) from the project to the repository so it's possible to co-develop repos with different CI sets / requirements and keep them coherent (e.g. doc in a different repo or something)
* make it possible to whitelist/blacklist branches on repositories, branches remain linked to a project but can further be restricted to not apply to some repos