### PR TITLE
Add support for freezes to forwardbot

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -84,7 +84,7 @@ def _set_socket_timeout():
     """ Avoid unlimited wait on standard sockets during tests, this is mostly
     an issue for non-trivial cron calls
     """
-    socket.setdefaulttimeout(60.0)
+    socket.setdefaulttimeout(120.0)
 
 @pytest.fixture(scope="session")
 def config(pytestconfig):
@@ -961,6 +961,9 @@ class Model:
 
     def __repr__(self):
         return "{}({})".format(self._model, ', '.join(str(id_) for id_ in self._ids))
+
+    def browse(self, ids):
+        return Model(self._env, self._model, ids)
 
     def exists(self):
         ids = self._env(self._model, 'exists', self._ids)

--- a/conftest.py
+++ b/conftest.py
@@ -996,6 +996,8 @@ class Model:
         return Model(self._env, self._model, ids, fields=self._fields)
 
     def __getattr__(self, fieldname):
+        if fieldname in ['__dataclass_fields__', '__attrs_attrs__']:
+            raise AttributeError('%r is invalid on %s' % (fieldname, self._model))
         if not self._ids:
             return False
 
@@ -1003,7 +1005,10 @@ class Model:
         if fieldname == 'id':
             return self._ids[0]
 
-        val = self.read([fieldname])[0][fieldname]
+        try:
+            val = self.read([fieldname])[0][fieldname]
+        except Exception:
+            raise AttributeError('%r is invalid on %s' % (fieldname, self._model))
         field_description = self._fields[fieldname]
         if field_description['type'] in ('many2one', 'one2many', 'many2many'):
             val = val or []

--- a/conftest.py
+++ b/conftest.py
@@ -67,6 +67,7 @@ NGROK_CLI = [
 def pytest_addoption(parser):
     parser.addoption('--addons-path')
     parser.addoption("--no-delete", action="store_true", help="Don't delete repo after a failed run")
+    parser.addoption('--log-github', action='store_true')
 
     parser.addoption(
         '--tunnel', action="store", type="choice", choices=['ngrok', 'localtunnel'], default='ngrok',
@@ -290,10 +291,14 @@ def port():
 
 @pytest.fixture
 def server(request, db, port, module):
+    opts = ['--log-handler', 'github_requests:WARNING']
+    if request.config.getoption('--log-github'):
+        opts = []
+
     p = subprocess.Popen([
         'odoo', '--http-port', str(port),
         '--addons-path', request.config.getoption('--addons-path'),
-        '-d', db,
+        '-d', db, *opts,
         '--max-cron-threads', '0', # disable cron threads (we're running crons by hand)
     ])
 

--- a/forwardport/models/project.py
+++ b/forwardport/models/project.py
@@ -343,22 +343,22 @@ class PullRequests(models.Model):
             # otherwise check if we already have a pending forward port
             _logger.info("%s %s %s", pr, batch, batch.prs)
             if self.env['forwardport.batches'].search_count([('batch_id', '=', batch.id)]):
-                _logger.warn('-> already recorded')
+                _logger.warning('-> already recorded')
                 continue
 
             # check if batch-mate are all valid
             mates = batch.prs
             # wait until all of them are validated or ready
             if any(pr.state not in ('validated', 'ready') for pr in mates):
-                _logger.warn("-> not ready (%s)", [(pr.number, pr.state) for pr in mates])
+                _logger.warning("-> not ready (%s)", [(pr.number, pr.state) for pr in mates])
                 continue
 
             # check that there's no weird-ass state
             if not all(pr.parent_id for pr in mates):
-                _logger.warn("Found a batch (%s) with only some PRs having parents, ignoring", mates)
+                _logger.warning("Found a batch (%s) with only some PRs having parents, ignoring", mates)
                 continue
             if self.search_count([('parent_id', 'in', mates.ids)]):
-                _logger.warn("Found a batch (%s) with only some of the PRs having children", mates)
+                _logger.warning("Found a batch (%s) with only some of the PRs having children", mates)
                 continue
 
             _logger.info('-> ok')

--- a/forwardport/tests/test_weird.py
+++ b/forwardport/tests/test_weird.py
@@ -405,3 +405,147 @@ class TestNotAllBranches:
                             " next branch 'b'." % (a.name, pr_a.number)
             )
         ]
+
+def test_new_intermediate_branch(env, config, make_repo):
+    """ In the case of a freeze / release a new intermediate branch appears in
+    the sequence. New or ongoing forward ports should pick it up just fine (as
+    the "next target" is decided when a PR is ported forward) however this is
+    an issue for existing yet-to-be-merged sequences e.g. given the branches
+    1.0, 2.0 and master, if a branch 3.0 is forked off from master and inserted
+    before it, we need to create a new *intermediate* forward port PR
+    """
+    def validate(commit):
+        prod.post_status(commit, 'success', 'ci/runbot')
+        prod.post_status(commit, 'success', 'legal/cla')
+    project, prod, _ = make_basic(env, config, make_repo, fp_token=True, fp_remote=True)
+    original_c_tree = prod.read_tree(prod.commit('c'))
+    prs = []
+    with prod:
+        for i in ['0', '1', '2']:
+            prod.make_commits('a', Commit(i, tree={i:i}), ref='heads/branch%s' % i)
+            pr = prod.make_pr(target='a', head='branch%s' % i)
+            prs.append(pr)
+            validate(pr.head)
+            pr.post_comment('hansen r+', config['role_reviewer']['token'])
+        # cancel validation of PR2
+        prod.post_status(prs[2].head, 'failure', 'ci/runbot')
+        # also add a PR targeting b forward-ported to c, in order to check
+        # for an insertion right after the source
+        prod.make_commits('b', Commit('x', tree={'x': 'x'}), ref='heads/branchx')
+        prx = prod.make_pr(target='b', head='branchx')
+        validate(prx.head)
+        prx.post_comment('hansen r+', config['role_reviewer']['token'])
+    env.run_crons()
+    with prod:
+        validate('staging.a')
+        validate('staging.b')
+    env.run_crons()
+
+    # should have merged pr1, pr2 and prx and created their forward ports, now
+    # validate pr0's FP so the c-targeted FP is created
+    PRs = env['runbot_merge.pull_requests']
+    pr0_id = PRs.search([
+        ('repository.name', '=', prod.name),
+        ('number', '=', prs[0].number),
+    ])
+    pr0_fp_id = PRs.search([
+        ('source_id', '=', pr0_id.id),
+    ])
+    assert pr0_fp_id
+    assert pr0_fp_id.target.name == 'b'
+    with prod:
+        validate(pr0_fp_id.head)
+    env.run_crons()
+    original0 = PRs.search([('parent_id', '=', pr0_fp_id.id)])
+    assert original0, "Could not find FP of PR0 to C"
+    assert original0.target.name == 'c'
+
+    # also check prx's fp
+    prx_id = PRs.search([('repository.name', '=', prod.name), ('number', '=', prx.number)])
+    prx_fp_id = PRs.search([('source_id', '=', prx_id.id)])
+    assert prx_fp_id
+    assert prx_fp_id.target.name == 'c'
+
+    # NOTE: the branch must be created on git(hub) first, probably
+    # create new branch forked from the "current master" (c)
+    c = prod.commit('c').id
+    with prod:
+        prod.make_ref('heads/new', c)
+    currents = {branch.name: branch.id for branch in project.branch_ids}
+    # insert a branch between "b" and "c"
+    project.write({
+        'branch_ids': [
+            (1, currents['a'], {'fp_sequence': 3}),
+            (1, currents['b'], {'fp_sequence': 2}),
+            (0, False, {'name': 'new', 'fp_sequence': 1, 'fp_target': True}),
+            (1, currents['c'], {'fp_sequence': 0})
+        ]
+    })
+    env.run_crons()
+    descendants = PRs.search([('source_id', '=', pr0_id.id)])
+    new0 = descendants - pr0_fp_id - original0
+    assert len(new0) == 1
+    assert new0.parent_id == pr0_fp_id
+    assert original0.parent_id == new0
+
+    descx = PRs.search([('source_id', '=', prx_id.id)])
+    newx = descx - prx_fp_id
+    assert len(newx) == 1
+    assert newx.parent_id == prx_id
+    assert prx_fp_id.parent_id == newx
+
+    # finish up: merge pr1 and pr2, ensure all the content is present in both
+    # "new" (the newly inserted branch) and "c" (the tippity tip)
+    with prod: # validate pr2
+        prod.post_status(prs[2].head, 'success', 'ci/runbot')
+    env.run_crons()
+    # merge pr2
+    with prod:
+        validate('staging.a')
+    env.run_crons()
+    # ci on pr1/pr2 fp to b
+    sources = [
+        env['runbot_merge.pull_requests'].search([
+            ('repository.name', '=', prod.name),
+            ('number', '=', pr.number),
+        ]).id
+        for pr in prs
+    ]
+    sources.append(prx_id.id)
+    # CI all the forward port PRs (shouldn't hurt to re-ci the forward port of
+    # prs[0] to b aka pr0_fp_id
+    for target in ['b', 'new', 'c']:
+        fps = PRs.search([('source_id', 'in', sources), ('target.name', '=', target)])
+        with prod:
+            for fp in fps:
+                validate(fp.head)
+        env.run_crons()
+    # now fps should be the last PR of each sequence, and thus r+-able
+    with prod:
+        for pr in fps:
+            assert pr.target.name == 'c'
+            prod.get_pr(pr.number).post_comment(
+                '%s r+' % project.fp_github_name,
+                config['role_reviewer']['token'])
+    assert all(p.state == 'merged' for p in PRs.browse(sources)), \
+        "all sources should be merged"
+    assert all(p.state == 'ready' for p in PRs.search([('id', 'not in', sources)])),\
+        "All PRs except sources should be ready"
+    env.run_crons()
+    with prod:
+        for target in ['b', 'new', 'c']:
+            validate('staging.' + target)
+    env.run_crons()
+    assert all(p.state == 'merged' for p in PRs.search([])), \
+        "All PRs should be merged now"
+
+    assert prod.read_tree(prod.commit('c')) == {
+        **original_c_tree,
+        '0': '0', '1': '1', '2': '2', # updates from PRs
+        'x': 'x',
+    }, "check that C got all the updates"
+    assert prod.read_tree(prod.commit('new')) == {
+        **original_c_tree,
+        '0': '0', '1': '1', '2': '2', # updates from PRs
+        'x': 'x',
+    }, "check that new got all the updates (should be in the same state as c really)"

--- a/runbot_merge/github.py
+++ b/runbot_merge/github.py
@@ -158,7 +158,7 @@ class GH(object):
             if _is_json(r.response):
                 body = r.response.json()
                 if any(e.message == 'User is blocked' for e in (body.get('errors') or [])):
-                    _logger.warning("comment(%s:%s) failed: user likely blocked", self._repo, pr)
+                    _logger.warning("comment(%s#%s) failed: user likely blocked", self._repo, pr)
                     return
             raise
         _logger.debug('comment(%s, %s, %s)', self._repo, pr, shorten(message))


### PR DESCRIPTION
And various tangentially-related-at-best improvements.

The meat of it is (hopefully) the fixing of #262 by hooking into updates to the project and scheduling the generation of new intermediate forward port PRs IF a branch is created within the existing sequence (rather than at either end) and there are "live" (not merged) forward-ports which span over the new branch.

ping @d-fence I guess?