### PR TITLE
[ADD] runbot_merge: force reviewers to have a Github login

### DIFF
--- a/runbot_merge/models/res_partner.py
+++ b/runbot_merge/models/res_partner.py
@@ -10,6 +10,12 @@ class Partner(models.Model):
     delegate_reviewer = fields.Many2many('runbot_merge.pull_requests')
     formatted_email = fields.Char(string="commit email", compute='_rfc5322_formatted')
 
+    _sql_constraints = [
+        ('reviewer_required_fields',
+            "CHECK(coalesce(github_login, '') != '' OR (reviewer = false AND self_reviewer = false))",
+            "A reviewer must have a Github login!"),
+    ]
+
     def _auto_init(self):
         res = super(Partner, self)._auto_init()
         tools.create_unique_index(


### PR DESCRIPTION
Vincent Schippefilt (vsc) was set as reviewer
but had no Github login. How could he r+ then?

Besides, the Github provisioning would have removed
his reviewer rights automatically as his Github login
was not set / was not part of the Github logins list
of our employees on odoo.com.