### PR TITLE
[FIX] runbot: use a custom template to create db

### DIFF
--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -15,6 +15,7 @@ class ResConfigSettings(models.TransientModel):
     runbot_max_age = fields.Integer('Max branch age (in days)')
     runbot_logdb_uri = fields.Char('Runbot URI for build logs')
     runbot_update_frequency = fields.Integer('Update frequency (in seconds)')
+    runbot_template = fields.Char('Postgresql template', help="Postgresql template to use when creating DB's")
     runbot_message = fields.Text('Frontend warning message')
 
     @api.model
@@ -29,7 +30,8 @@ class ResConfigSettings(models.TransientModel):
                    runbot_max_age=int(get_param('runbot.runbot_max_age', default=30)),
                    runbot_logdb_uri=get_param('runbot.runbot_logdb_uri', default=False),
                    runbot_update_frequency=int(get_param('runbot.runbot_update_frequency', default=10)),
-                   runbot_message = get_param('runbot.runbot_message', default=''),
+                   runbot_template=get_param('runbot.runbot_db_template'),
+                   runbot_message=get_param('runbot.runbot_message', default=''),
                    )
         return res
 
@@ -44,4 +46,5 @@ class ResConfigSettings(models.TransientModel):
         set_param("runbot.runbot_max_age", self.runbot_max_age)
         set_param("runbot.runbot_logdb_uri", self.runbot_logdb_uri)
         set_param('runbot.runbot_update_frequency', self.runbot_update_frequency)
+        set_param('runbot.runbot_db_template', self.runbot_template)
         set_param('runbot.runbot_message', self.runbot_message)

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -51,8 +51,12 @@
                                   <field name="runbot_update_frequency" style="width: 30%;"/>
                                 </div>
                                 <div class="mt-16 row">
+                                  <label for="runbot_template" class="col-xs-3 o_light_label" style="width: 60%;"/>
+                                  <field name="runbot_template" style="width: 30%;"/>
+                                </div>
+                                <div class="mt-16 row">
                                   <label for="runbot_message" class="col-xs-3 o_light_label" style="width: 60%;"/>
-                                  <field name="runbot_message" style="width: 30%;"/>
+                                  <field name="runbot_message" style="width: 100%;"/>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Since cb05f2b9d8, when creating a database, the template1 is used, this
allows to customize the template and install some needed Postgress
extensions.

Unfortunately, it's also a source of build failures. For example, if the
pg_activity util is used on a runbot host, database creation may fail
with a message like this:

source database "template1" is being accessed by other users

It's because pg_activity needs a database and uses template1.

With this commit, template1 is still used by default but can be changed
with a system parameter. That way, a custom template can be created on
runbot hosts and used when creating DB in builds.