### PR TITLE
[FIX] forwardport: update the wiki link (11.0)

### DIFF
--- a/forwardport/models/project.py
+++ b/forwardport/models/project.py
@@ -582,13 +582,13 @@ This PR targets %s and is the last of the forward-port chain%s
 To merge the full chain, say
 > @%s r+
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """ % (target.name, ' containing:' if ancestors else '.', ancestors, pr.repository.project_id.fp_github_name)
             else:
                 message = """\
 This PR targets %s and is part of the forward-port chain. Further PRs will be created up to %s.
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """ % (target.name, base.limit_id.name)
             self.env['runbot_merge.pull_requests.feedback'].create({
                 'repository': new_pr.repository.id,

--- a/forwardport/tests/test_limit.py
+++ b/forwardport/tests/test_limit.py
@@ -205,7 +205,7 @@ This PR targets b and is the last of the forward-port chain.
 To merge the full chain, say
 > @%s r+
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """ % (users['user'], users['reviewer'], users['user'])),
     ]
 
@@ -250,7 +250,7 @@ def test_limit_after_merge(env, config, make_repo, users):
         (users['user'], """\
 This PR targets b and is part of the forward-port chain. Further PRs will be created up to c.
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """),
         (users['reviewer'], bot_name + ' up to b'),
         (bot_name, "Sorry, forward-port limit can only be set on an origin PR"

--- a/forwardport/tests/test_simple.py
+++ b/forwardport/tests/test_simple.py
@@ -141,7 +141,7 @@ This PR targets c and is the last of the forward-port chain containing:
 To merge the full chain, say
 > @%s r+
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """ % (
             users['other'], users['reviewer'],
             pr1.display_name,
@@ -250,7 +250,7 @@ def test_update_pr(env, config, make_repo, users):
     fp_intermediate = (users['user'], '''\
 This PR targets b and is part of the forward-port chain. Further PRs will be created up to c.
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 ''')
     ci_warning = (users['user'], 'Ping @%(user)s, @%(reviewer)s\n\nci/runbot failed on this forward-port PR' % users)
 
@@ -841,7 +841,7 @@ def test_batched(env, config, make_repo, users):
         (users['user'], """\
 This PR targets b and is part of the forward-port chain. Further PRs will be created up to c.
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """),
     ]
     pr_remote_1b = main1.get_pr(pr1b.number)
@@ -937,7 +937,7 @@ class TestClosing:
             (users['user'], """\
 This PR targets b and is part of the forward-port chain. Further PRs will be created up to c.
 
-More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+More info at https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot#forward-port
 """)
         ]
 


### PR DESCRIPTION
On github wiki, the link changed from https://github.com/odoo/odoo/wiki/Mergebot to https://github.com/odoo/odoo/wiki/Mergebot-and-Forwardbot

Reflect these changes in the comments posted by the bot.