### PR TITLE
[REM] runbot: remove reverse dependency build feature

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -367,21 +367,7 @@ class runbot_repo(models.Model):
                     if builds_to_skip:
                         build_info['sequence'] = builds_to_skip[0].sequence
 
-                new_build = Build.create(build_info)
-                # create a reverse dependency build if needed
-                if branch.sticky:
-                    for rev_repo in self.search([('dependency_ids', 'in', self.id), ('no_build', '=', False)]):
-                        # find the latest build with the same branch name
-                        latest_rev_build = Build.search([('build_type', '=', 'normal'), ('hidden', '=', False), ('repo_id.id', '=', rev_repo.id), ('branch_id.branch_name', '=', branch.branch_name)], order='id desc', limit=1)
-                        if latest_rev_build:
-                            _logger.debug('Reverse dependency build %s forced in repo %s by commit %s', latest_rev_build.dest, rev_repo.name, sha[:6])
-                            indirect = latest_rev_build._force(message='Rebuild from dependency %s commit %s' % (self.name, sha[:6]))
-                            if not indirect:
-                                _logger.exception('Failed to create indirect for %s from %s in repo %s', new_build, latest_rev_build, rev_repo)
-                            else:
-                                indirect.build_type = 'indirect'
-                                new_build.revdep_build_ids += indirect
-
+                Build.create(build_info)
 
     def _create_pending_builds(self):
         """ Find new commits in physical repos"""

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -24,22 +24,6 @@
             <t t-if="bu.global_result=='manually_killed'"><i class="text-danger fa fa-times"/> manually killed</t>
           </t>
         </t>
-        <t t-if="bu.revdep_build_ids">
-            <small class="pull-right">Dep builds:
-                <t t-foreach="bu.sorted_revdep_build_ids()" t-as="rbu">
-                            <a t-attf-href="/runbot/build/{{rbu['id']}}" aria-label="Build details" data-toggle="tooltip" t-attf-title="{{rbu['repo_id']['name']}}">
-                            <t t-if="rbu.global_result=='ok'"><i class="text-success fa fa-thumbs-up"/></t>
-                            <t t-if="rbu.global_result=='ko'"><i class="text-danger fa fa-thumbs-down"/></t>
-                            <t t-if="rbu.global_result=='warn'"><i class="text-warning fa fa-warning"/></t>
-                            <t t-if="rbu.global_result=='skipped'"><i class="text-danger fa fa-ban"/></t>
-                            <t t-if="rbu.global_result=='killed'"><i class="text-danger fa fa-times"/>&#x1f480;</t>
-                            <t t-if="rbu.global_result=='manually_killed'"><i class="text-danger fa fa-times"/>&#x1f52b;</t>
-                            <t t-if="rbu.global_state=='pending'"><i class="fa fa-pause" style="color: #666666;"/></t>
-                            <t t-if="rbu.global_state in ('testing', 'waiting')"><i class="fa fa-spinner fa-spin" style="color: #666666;"/></t>
-                            </a>
-                </t>
-            </small>
-        </t>
     </template>
     <template id="runbot.build_button">
         <div t-attf-class="pull-right">


### PR DESCRIPTION
When a new commit is found, a rebuild is forced on sticky branches
builds in repositories that depends on the new commit repository.

If one of the repo is protected by groups, the main page gives access
errors for public users and finally leads to a CPU overload.

With this commit, the feature is removed as it will be re-implemented in
custom config steps.