### PR TITLE
Handle fetch failure

### DIFF
--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -103,3 +103,11 @@ class RunboHost(models.Model):
 
     def _total_workers(self):
         return sum(host.get_nb_worker() for host in self)
+
+    def disable(self):
+        """ Reserve host if possible """
+        self.ensure_one()
+        nb_hosts = self.env['runbot.host'].search_count([])
+        nb_reserved = self.env['runbot.host'].search_count([('assigned_only', '=', True)])
+        if nb_reserved < (nb_hosts / 2):
+            self.assigned_only = True


### PR DESCRIPTION
From time to time, a git repo gets corrupted. When it happens, the fetch fails but the runbot still tries to run builds.

This PR is an attempt to catch those failures and auto-disable the runbot host on which the repo is corrupted.

TODO:
* verify that there are still enough runbot host before disabling the failing host
* verify where to catch the Exception