### PR TITLE
[IMP] runbot: custom db_names for install and run jobs.

### DIFF
--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -40,6 +40,8 @@ class RunbotCase(TransactionCase):
         self.start_patcher('docker_build', 'odoo.addons.runbot.models.build.docker_build')
         self.start_patcher('docker_ps', 'odoo.addons.runbot.models.repo.docker_ps', [])
         self.start_patcher('docker_stop', 'odoo.addons.runbot.models.repo.docker_stop')
+        self.start_patcher('docker_ps', 'odoo.addons.runbot.models.build_config.docker_get_gateway_ip', None)
+
         self.start_patcher('cr_commit', 'odoo.sql_db.Cursor.commit', None)
         self.start_patcher('repo_commit', 'odoo.addons.runbot.models.repo.runbot_repo._commit', None)
         self.start_patcher('_local_cleanup_patcher', 'odoo.addons.runbot.models.build.runbot_build._local_cleanup')


### PR DESCRIPTION
When creating a subbuild from a custom python job/cron, some data can
be given through config_data or extra_params to change another step behaviour.

An example is to give a specific -i to an install job in order to
install different modules from the parent build. Anyway since we
are using the same install step in this case, all databases will
have the same name, and the name may not be correct in regard to
the database content.
This commit allows to give a config_param on build giving the default
db_name to use in an install step.