### PR TITLE
[IMP] runbot: add coverage xml export

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -270,7 +270,7 @@ def tests(args):
     if args.coverage:
         omit = ['--omit', '*__manifest__.py']
         python_params = [ '-m', 'coverage', 'run', '--branch', '--source', '/data/build'] + omit
-        posts = [['python%s' % py_version, "-m", "coverage", "html", "-d", "/data/build/coverage", "--ignore-errors"]]
+        posts = [['python%s' % py_version, "-m", "coverage", "html", "-d", "/data/build/coverage", "--ignore-errors"], ['python%s' % py_version, "-m", "coverage", "xml", "--ignore-errors"]]
         os.makedirs(os.path.join(args.build_dir, 'coverage'), exist_ok=True)
     elif args.flamegraph:
         flame_log = '/data/build/logs/flame.log'

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -92,12 +92,10 @@ class TestBuildConfigStep(RunbotCase):
         })
 
         def docker_run(cmd, log_path, *args, **kwargs):
-            cmds = cmd.build().split(' && ')
-            dest = self.parent_build.dest
             self.assertEqual(cmd.pres, [['sudo', 'pip3', 'install', '-r', 'bar/requirements.txt']])
             self.assertEqual(cmd.cmd[:10], ['python3', '-m', 'coverage', 'run', '--branch', '--source', '/data/build', '--omit', '*__manifest__.py', 'bar/server.py'])
-            #['bar/server.py', '--addons-path', 'bar', '--no-xmlrpcs', '--no-netrpc', '-d', '08732-master-d0d0ca-coverage', '--test-enable', '--stop-after-init', '--log-level=test', '--max-cron-threads=0']
-            self.assertEqual(cmd.posts, [['python3', '-m', 'coverage', 'html', '-d', '/data/build/coverage', '--ignore-errors']])
+            self.assertIn(['python3', '-m', 'coverage', 'html', '-d', '/data/build/coverage', '--ignore-errors'], cmd.posts)
+            self.assertIn(['python3', '-m', 'coverage', 'xml', '-o', '/data/build/logs/coverage.xml', '--ignore-errors'], cmd.posts)
             self.assertEqual(log_path, 'dev/null/logpath')
 
         self.patchers['docker_run'].side_effect = docker_run


### PR DESCRIPTION
When coverage is computed, a post command is used to generate the HTML
report. In order to use the coverage result locally the HTML report is
not enough.

With this commit, an XML report is also generated. It's a single xml
file, downloadable from the build result web page.

The _post_install_command method is renamed into its plural form because
it was useless to return only one command.