### PR TITLE
[IMP] runbot: copy steps when duplicating a config

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -26,7 +26,7 @@ class Config(models.Model):
 
     name = fields.Char('Config name', required=True, unique=True, track_visibility='onchange', help="Unique name for config please use trigram as postfix for custom configs")
     description = fields.Char('Config description')
-    step_order_ids = fields.One2many('runbot.build.config.step.order', 'config_id')
+    step_order_ids = fields.One2many('runbot.build.config.step.order', 'config_id', copy=True)
     update_github_state = fields.Boolean('Notify build state to github', default=False, track_visibility='onchange')
     protected = fields.Boolean('Protected', default=False, track_visibility='onchange')
     group = fields.Many2one('runbot.build.config', 'Configuration group', help="Group of config's and config steps")
@@ -55,7 +55,7 @@ class Config(models.Model):
 
     def step_ids(self):
         self.ensure_one()
-        return [ordered_step.step_id for ordered_step in self.step_order_ids]
+        return [ordered_step.step_id for ordered_step in self.step_order_ids.sorted('sequence')]
 
     def _check_step_ids_order(self):
         install_job = False


### PR DESCRIPTION
When a build.config is copied, the config steps are not copied.

The steps have to be explicitly ordered otherwise it leads to a
traceback when trying to copy a 'run' step which  have to be the last
one.