### PR TITLE
[FIX] runbot: fix child errors too

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -59,6 +59,10 @@ class RunbotBuildError(models.Model):
         })
         return super().create(vals)
 
+    @api.onchange('active')
+    def _onchange_active(self):
+        self.child_ids.write({'active': self.active})
+
     def write(self, vals):
         if 'active' in vals:
             for build_error in self:


### PR DESCRIPTION
When a build error is marked as fixed, the children are left as not
fixed. If a new error arrise and is the same as one of the child, the
build error is linked to the child. The new error is the hidden in the
backend.

With this commit, when the active field is changed on the parent, the
children field is modified too.