### PR TITLE
Enable unaccent switching to run mode

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -324,7 +324,7 @@ def tests(args):
             '--db-filter', '%s.*$' % args.db_name, '--addons-path=/data/build/addons',
             '-r %s' % os.getlogin(), '-i', 'web',  '--max-cron-threads=1',
             '--data-dir', '/data/build/datadir', '--workers', '2',
-            '--longpolling-port', '8070']
+            '--longpolling-port', '8070', '--unaccent']
         smtp_host = docker_get_gateway_ip()
         if smtp_host:
             odoo_cmd.extend(['--smtp', smtp_host])


### PR DESCRIPTION
Currently runbot runs with unaccent installed (always) but apparently not *enabled* via the CLI flag.

According to @tbe-odoo and @amigrave both the saas and pass run with `--unaccent` explicitly set in the CLI. It would therefore be logical to do the same for runbot. Might be that we

*Alternatively* we could just deprecate and ignore the `--unaccent` flag: the features of base which use  it [go through the has_unaccent registry flag](https://github.com/odoo/odoo/blob/c8e79869a37b87101d64e4703401f409358a2099/odoo/modules/registry.py#L144-L148) (or [`get_unaccent_wrapper` which uses it](https://github.com/odoo/odoo/blob/9ce78bff5fb084de67034bf54a814d1f30ffda46/odoo/osv/expression.py#L460-L463)), which both checks the cli/config flag *and* checks if the extension is installed in the database.

So unless there are specific unsafeties in unaccent and use cases where we'd specifically want to run without it, it'd make sense (and would be safe) to run with unaccent being enabled based solely on the database state, not on the CLI.