### PR TITLE
[FIX] runbot: better log list

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -565,7 +565,7 @@ class ConfigStep(models.Model):
 
     def _has_log(self):
         self.ensure_one()
-        return self.job_type != 'create_build'
+        return self._is_docker_step()
 
 
 class ConfigStepOrder(models.Model):


### PR DESCRIPTION
Before intensive python steps, every build exept create build should have logs.
This is not true since now many python steps are creating build, leading
to 404 links to inexisting logs file.

Checking That a step is a docker build looks like a good heuristic since since
most of the time the log file will be the one created by docker. In all case we
can access other logs files in browsing /logs.

A future improvement would be to listdir logs to create all links.