### PR TITLE
[FIX] runbot: show connect links when build is a duplicate

### DIFF
--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -37,7 +37,7 @@
                     <li t-if="bu.global_result=='skipped'" groups="runbot.group_runbot_admin">
                         <a href="#" data-runbot="rebuild" t-att-data-runbot-build="bu['id']">Force Build <i class="fa fa-level-up"></i></a>
                     </li>
-                    <t t-if="bu.local_state=='running'">
+                    <t t-if="bu.real_build.local_state=='running'">
                         <li><a t-attf-href="http://{{bu['domain']}}/?db={{bu['real_build'].dest}}-all">Connect all <i class="fa fa-sign-in"></i></a></li>
                         <li><a t-attf-href="http://{{bu['domain']}}/?db={{bu['real_build'].dest}}-base">Connect base <i class="fa fa-sign-in"></i></a></li>
                         <li><a t-attf-href="http://{{bu['domain']}}/">Connect <i class="fa fa-sign-in"></i></a></li>


### PR DESCRIPTION
When a build is a duplicate, the connections links are not visible
because the local_state is "duplicate".