### PR TITLE
[FIX] runbot: use proxy-mode for running instances

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -311,6 +311,9 @@ class ConfigStep(models.Model):
         # we need to have at least one job of type install_odoo to run odoo, take the last one for db_name.
         cmd += ['-d', '%s-%s' % (build.dest, db_name)]
 
+        if grep(build._server("tools/config.py"), "proxy-mode") and build.repo_id.nginx:
+            cmd += ["--proxy-mode"]
+
         if grep(build._server("tools/config.py"), "db-filter"):
             if build.repo_id.nginx:
                 cmd += ['--db-filter', '%d.*$']

--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -25,10 +25,16 @@ autoindex on;
 gzip on;
 gzip_types text/css text/plain application/xml application/json application/javascript;
 
+map $http_x_forwarded_proto $real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 proxy_temp_path <t t-esc="nginx_dir"/>;
 proxy_read_timeout 600;
 proxy_connect_timeout 600;
 proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Proto $real_scheme;
 proxy_set_header Host $host;
 
 server {


### PR DESCRIPTION
When deployed behind nginx reverse proxy and https, the Odoo proxy-mode
must be enabled.