### PR TITLE
[IMP] runbot: add unaccent option in config file

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1034,6 +1034,9 @@ class runbot_build(models.Model):
                 os.mkdir(datadir)
             command.add_config_tuple("data_dir", '/data/build/datadir')
 
+        if grep(config_path, "--unaccent"):
+            command.add_config_tuple('unaccent', 'True')
+
         return command
 
     def _github_status_notify_all(self, status):


### PR DESCRIPTION
In 5bba39e15394d unaccent was enabled in container tests, it's now time
to enable it in runbot code.