### PR TITLE
[ADD] forwardport: ability to skip CI when forward porting

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -118,7 +118,7 @@ class Project(models.Model):
             except Exception:
                 _logger.exception(
                     "Error while trying to change the tags of %s#%s from %s to %s",
-                    repo.name, pr.display_name, remove, add,
+                    repo.name, pr, remove, add,
                 )
             else:
                 to_remove.extend(ids)


### PR DESCRIPTION
Provides a `skipci` command to PR reviewers. This makes it so the
followup PRs (after the first one) get created immediately, without
waiting for CI to succeed on a given forward-port PR.

This can be useful if for some reason a change *must* be merged in
branch N+1 before it can be merged in branch N.

Fixes #363