### PR TITLE
[IMP] forwardport: reliability of PR reminders

### DIFF
--- a/forwardport/__manifest__.py
+++ b/forwardport/__manifest__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'forward port bot',
+    'version': '1.1',
     'summary': "A port which forward ports successful PRs.",
     'depends': ['runbot_merge'],
     'data': [

--- a/forwardport/migrations/13.0.1.1/post-reminder-date.py
+++ b/forwardport/migrations/13.0.1.1/post-reminder-date.py
@@ -1,0 +1,10 @@
+def migrate(cr, version):
+    """ Set the merge_date field to the current write_date, and reset
+    the backoff to its default so we reprocess old PRs properly.
+    """
+    cr.execute("""
+        UPDATE runbot_merge_pull_requests
+           SET merge_date = write_date,
+               reminder_backoff_factor = -4
+         WHERE state = 'merged'
+    """)

--- a/forwardport/migrations/13.0.1.1/pre-tagging.py
+++ b/forwardport/migrations/13.0.1.1/pre-tagging.py
@@ -1,0 +1,2 @@
+def migrate(cr, version):
+    cr.execute("delete from ir_model where model = 'forwardport.tagging'")

--- a/forwardport/models/forwardport.py
+++ b/forwardport/models/forwardport.py
@@ -141,7 +141,7 @@ class DeleteBranches(models.Model, Queue):
     def _search_domain(self):
         cutoff = self.env.context.get('forwardport_merged_before') \
              or fields.Datetime.to_string(datetime.now() - MERGE_AGE)
-        return [('pr_id.write_date', '<', cutoff)]
+        return [('pr_id.merge_date', '<', cutoff)]
 
     def _process_item(self):
         _deleter.info(


### PR DESCRIPTION
The exponential backoff offsets from the write_date of the children
PRs, however it doesn't reset, so the offsetting gets bumped up way
more than originally expected or designed if the child PRs are under
active development for some reason.

Fix this by adding a field to specifically record the date of merge of
a PR, and check that feature against the backoff offset. This should
provide more regular and reliable backoff.

Fixes #369