### PR TITLE
[IMP] runbot: add ocrmypdf package to Dockerfile

### DIFF
--- a/runbot/data/Dockerfile
+++ b/runbot/data/Dockerfile
@@ -18,6 +18,7 @@ RUN set -x ; \
     libsasl2-dev \
     libxslt1-dev \
     node-less \
+    ocrmypdf \
     python \
     python-dev \
     python-pip \


### PR DESCRIPTION
The ocrmypdf suite of tools are needed by task #2238654.

Altough this package will be optional for Odoo users, it has to be
usable by dev's in order to test and/or fix the feature.