### PR TITLE
[FIX] runbot: mis-migrated test

### DIFF
--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -153,7 +153,7 @@ class Test_Repo(RunbotCase):
 
     @skip('This test is for performances. It needs a lot of real branches in DB to mean something')
     def test_repo_perf_find_new_commits(self):
-        mock_root.return_value = '/tmp/static'
+        self.mock_root.return_value = '/tmp/static'
         repo = self.env['runbot.repo'].search([('name', '=', 'blabla')])
 
         self.commit_list = []


### PR DESCRIPTION
73f720a55c8d2c3b3f867e293ff5cb6fb93281a7 refactored the runbot tests, and amongst other things created a single patch point for the "mock root" as a testcase attribute.

One of the tests was missed during that refactoring, likely because it's skipped by default.