### PR TITLE
Make statuses more flexible

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -777,6 +777,15 @@ class Repo:
             self.reset = reset
 MakeCommit = Repo.Commit
 ct = itertools.count()
+
+class Comment(tuple):
+    def __new__(cls, c):
+        self = super(Comment, cls).__new__(cls, (c['user']['login'], c['body']))
+        self._c = c
+        return self
+    def __getitem__(self, item):
+        return self._c[item]
+
 class PR:
     def __init__(self, repo, number):
         self.repo = repo
@@ -815,10 +824,7 @@ class PR:
     def comments(self):
         r = self.repo._session.get('https://api.github.com/repos/{}/issues/{}/comments'.format(self.repo.name, self.number))
         assert 200 <= r.status_code < 300, r.json()
-        return [
-            (c['user']['login'], c['body'])
-            for c in r.json()
-        ]
+        return [Comment(c) for c in r.json()]
 
     @property
     def ref(self):

--- a/conftest.py
+++ b/conftest.py
@@ -1087,7 +1087,6 @@ class Model:
         return self._env(self._model, name, self._ids, *args, **kwargs)
 
     def __setattr__(self, fieldname, value):
-        assert self._fields[fieldname]['type'] not in ('many2one', 'one2many', 'many2many')
         self._env(self._model, 'write', self._ids, {fieldname: value})
 
     def __iter__(self):

--- a/forwardport/data/views.xml
+++ b/forwardport/data/views.xml
@@ -47,7 +47,12 @@
         <field name="model">runbot_merge.pull_requests</field>
         <field name="arch" type="xml">
             <xpath expr="//sheet/group[2]" position="after">
-                <separator string="Forwardported" attrs="{'invisible': [('source_id', '=', False)]}"/>
+                <separator string="Forward Port" attrs="{'invisible': [('source_id', '=', False)]}"/>
+                <group attrs="{'invisible': [('source_id', '!=', False)]}">
+                    <group>
+                        <field string="Policy" name="fw_policy"/>
+                    </group>
+                </group>
                 <group attrs="{'invisible': [('source_id', '=', False)]}">
                     <group>
                         <field string="Original PR" name="source_id"/>

--- a/forwardport/models/project.py
+++ b/forwardport/models/project.py
@@ -280,12 +280,12 @@ class PullRequests(models.Model):
 
         tokens = [
             token
-            for line in re.findall('^\s*[@|#]?{}:? (.*)$'.format(self.repository.project_id.fp_github_name), comment, re.MULTILINE | re.IGNORECASE)
+            for line in re.findall('^\s*[@|#]?{}:? (.*)$'.format(self.repository.project_id.fp_github_name), comment['body'] or '', re.MULTILINE | re.IGNORECASE)
             for token in line.split()
         ]
         if not tokens:
             _logger.info("found no commands in comment of %s (%s) (%s)", author.github_login, author.display_name,
-                 utils.shorten(comment, 50)
+                 utils.shorten(comment['body'] or '', 50)
             )
             return
 
@@ -323,7 +323,7 @@ class PullRequests(models.Model):
                 # don't update the root ever
                 for pr in filter(lambda p: p.parent_id, self._iter_ancestors()):
                     # only the author is delegated explicitely on the
-                    pr._parse_commands(author, merge_bot + ' r+', login)
+                    pr._parse_commands(author, {**comment, 'body': merge_bot + ' r+'}, login)
             elif token == 'close':
                 msg = "I'm sorry, @{}. I can't close this PR for you."
                 if self.source_id._pr_acl(author).is_reviewer:

--- a/runbot_merge/__manifest__.py
+++ b/runbot_merge/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'merge bot',
-    'version': '1.3',
+    'version': '1.4',
     'depends': ['contacts', 'website'],
     'data': [
         'security/security.xml',

--- a/runbot_merge/migrations/13.0.1.4/pre-migration.py
+++ b/runbot_merge/migrations/13.0.1.4/pre-migration.py
@@ -1,0 +1,35 @@
+import re
+
+def migrate(cr, version):
+    """ required_statuses is now a separate object in its own table
+    """
+    # apparently the DDL has already been updated but the reflection gunk
+    cr.execute("""
+        DELETE FROM ir_model_fields
+        WHERE model = 'runbot_merge.pull_requests.tagging'
+          AND name in ('state_from', 'state_to')
+    """)
+
+    cr.execute("""
+    CREATE TABLE runbot_merge_repository_status (
+        id SERIAL NOT NULL PRIMARY KEY,
+        context VARCHAR NOT NULL,
+        repo_id INTEGER NOT NULL REFERENCES runbot_merge_repository (id) ON DELETE CASCADE,
+        prs BOOLEAN,
+        stagings BOOLEAN
+    )
+    """)
+    cr.execute("""
+    CREATE TABLE runbot_merge_repository_status_branch (
+        status_id INTEGER NOT NULL REFERENCES runbot_merge_repository_status (id) ON DELETE CASCADE,
+        branch_id INTEGER NOT NULL REFERENCES runbot_merge_branch (id) ON DELETE CASCADE
+    )
+    """)
+
+    cr.execute('select id, required_statuses from runbot_merge_repository')
+    for repo, statuses in cr.fetchall():
+        for st in re.split(r',\s*', statuses):
+            cr.execute("""
+                INSERT INTO runbot_merge_repository_status (context, repo_id, prs, stagings)
+                VALUES (%s, %s, true, true)
+            """, [st, repo])

--- a/runbot_merge/models/res_partner.py
+++ b/runbot_merge/models/res_partner.py
@@ -13,6 +13,7 @@ class Partner(models.Model):
     delegate_reviewer = fields.Many2many('runbot_merge.pull_requests')
     formatted_email = fields.Char(string="commit email", compute='_rfc5322_formatted')
     review_rights = fields.One2many('res.partner.review', 'partner_id')
+    override_rights = fields.One2many('res.partner.override', 'partner_id')
 
     def _auto_init(self):
         res = super(Partner, self)._auto_init()
@@ -72,3 +73,17 @@ class ReviewRights(models.Model):
 
     def name_search(self, name='', args=None, operator='ilike', limit=100):
         return self.search(args + [('repository_id.name', operator, name)], limit=limit).name_get()
+
+class OverrideRights(models.Model):
+    _name = 'res.partner.override'
+    _description = 'lints which the partner can override'
+
+    partner_id = fields.Many2one('res.partner', required=True, ondelete='cascade')
+    repository_id = fields.Many2one('runbot_merge.repository', required=True)
+    context = fields.Char(required=True)
+
+    def name_get(self):
+        return [
+            (r.id, f'{r.repository.name}: {r.context}')
+            for r in self
+        ]

--- a/runbot_merge/security/ir.model.access.csv
+++ b/runbot_merge/security/ir.model.access.csv
@@ -12,8 +12,11 @@ access_runbot_merge_batch_admin,Admin access to batches,model_runbot_merge_batch
 access_runbot_merge_fetch_job_admin,Admin access to fetch jobs,model_runbot_merge_fetch_job,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_pull_requests_feedback_admin,Admin access to feedback,model_runbot_merge_pull_requests_feedback,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_review_rights,Admin access to review permissions,model_res_partner_review,runbot_merge.group_admin,1,1,1,1
+access_runbot_merge_review_override,Admin access to override permissions,model_res_partner_override,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_project,User access to project,model_runbot_merge_project,base.group_user,1,0,0,0
 access_runbot_merge_repository,User access to repo,model_runbot_merge_repository,base.group_user,1,0,0,0
 access_runbot_merge_branch,User access to branches,model_runbot_merge_branch,base.group_user,1,0,0,0
 access_runbot_merge_pull_requests,User access to PR,model_runbot_merge_pull_requests,base.group_user,1,0,0,0
 access_runbot_merge_pull_requests_feedback,Users have no reason to access feedback,model_runbot_merge_pull_requests_feedback,,0,0,0,0
+access_runbot_merge_review_rights_2,Users can see partners,model_res_partner_review,base.group_user,1,0,0,0
+access_runbot_merge_review_override_2,Users can see partners,model_res_partner_override,base.group_user,1,0,0,0

--- a/runbot_merge/security/ir.model.access.csv
+++ b/runbot_merge/security/ir.model.access.csv
@@ -1,6 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_runbot_merge_project_admin,Admin access to project,model_runbot_merge_project,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_repository_admin,Admin access to repo,model_runbot_merge_repository,runbot_merge.group_admin,1,1,1,1
+access_runbot_merge_repository_status_admin,Admin access to repo statuses,model_runbot_merge_repository_status,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_branch_admin,Admin access to branches,model_runbot_merge_branch,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_pull_requests_admin,Admin access to PR,model_runbot_merge_pull_requests,runbot_merge.group_admin,1,1,1,1
 access_runbot_merge_pull_requests_tagging_admin,Admin access to tagging,model_runbot_merge_pull_requests_tagging,runbot_merge.group_admin,1,1,1,1

--- a/runbot_merge/tests/test_basic.py
+++ b/runbot_merge/tests/test_basic.py
@@ -982,7 +982,7 @@ class TestNoRequiredStatus:
     def test_basic(self, env, repo, config):
         """ check that mergebot can work on a repo with no CI at all
         """
-        env['runbot_merge.repository'].search([('name', '=', repo.name)]).required_statuses = False
+        env['runbot_merge.repository'].search([('name', '=', repo.name)]).status_ids = False
         with repo:
             m = repo.make_commit(None, 'initial', None, tree={'0': '0'})
             repo.make_ref('heads/master', m)
@@ -1004,7 +1004,7 @@ class TestNoRequiredStatus:
         assert pr.state == 'merged'
 
     def test_updated(self, env, repo, config):
-        env['runbot_merge.repository'].search([('name', '=', repo.name)]).required_statuses = False
+        env['runbot_merge.repository'].search([('name', '=', repo.name)]).status_ids = False
         with repo:
             m = repo.make_commit(None, 'initial', None, tree={'0': '0'})
             repo.make_ref('heads/master', m)

--- a/runbot_merge/tests/test_by_branch.py
+++ b/runbot_merge/tests/test_by_branch.py
@@ -1,0 +1,96 @@
+import pytest
+
+from utils import Commit
+
+
+@pytest.fixture
+def repo(env, project, make_repo, users, setreviewers):
+    r = make_repo('repo')
+    project.write({
+        'repo_ids': [(0, 0, {
+            'name': r.name,
+            'status_ids': [
+                (0, 0, {'context': 'ci'}),
+                # require the lint status on master
+                (0, 0, {
+                    'context': 'lint',
+                    'branch_ids': [(4, project.branch_ids.id, False)]
+                }),
+            ]
+        })],
+    })
+    setreviewers(*project.repo_ids)
+    return r
+
+def test_status_applies(env, repo, config):
+    """ If branches are associated with a repo status, only those branch should
+    require the status on their PRs & stagings
+    """
+    with repo:
+        m = repo.make_commits(None, Commit('root', tree={'a': '1'}), ref='heads/master')
+
+        [c] = repo.make_commits(m, Commit('pr', tree={'a': '2'}), ref='heads/change')
+        pr = repo.make_pr(target='master', title="super change", head='change')
+    pr_id = env['runbot_merge.pull_requests'].search([
+        ('repository.name', '=', repo.name),
+        ('number', '=', pr.number)
+    ])
+    assert pr_id.state == 'opened'
+
+    with repo:
+        repo.post_status(c, 'success', 'ci')
+    env.run_crons('runbot_merge.process_updated_commits')
+    assert pr_id.state == 'opened'
+
+    with repo:
+        repo.post_status(c, 'success', 'lint')
+    env.run_crons('runbot_merge.process_updated_commits')
+    assert pr_id.state == 'validated'
+
+    with repo:
+        pr.post_comment('hansen r+', config['role_reviewer']['token'])
+    env.run_crons()
+
+    st = env['runbot_merge.stagings'].search([])
+    assert st.state == 'pending'
+    with repo:
+        repo.post_status('staging.master', 'success', 'ci')
+    env.run_crons('runbot_merge.process_updated_commits')
+    assert st.state == 'pending'
+    with repo:
+        repo.post_status('staging.master', 'success', 'lint')
+    env.run_crons('runbot_merge.process_updated_commits')
+    assert st.state == 'success'
+
+def test_status_skipped(env, project, repo, config):
+    """ Branches not associated with a repo status should not require the status
+    on their PRs or stagings
+    """
+    # add a second branch for which the lint status doesn't apply
+    project.write({'branch_ids': [(0, 0, {'name': 'maintenance'})]})
+    with repo:
+        m = repo.make_commits(None, Commit('root', tree={'a': '1'}), ref='heads/maintenance')
+
+        [c] = repo.make_commits(m, Commit('pr', tree={'a': '2'}), ref='heads/change')
+        pr = repo.make_pr(target='maintenance', title="super change", head='change')
+    pr_id = env['runbot_merge.pull_requests'].search([
+        ('repository.name', '=', repo.name),
+        ('number', '=', pr.number)
+    ])
+    assert pr_id.state == 'opened'
+
+    with repo:
+        repo.post_status(c, 'success', 'ci')
+    env.run_crons('runbot_merge.process_updated_commits')
+    assert pr_id.state == 'validated'
+
+    with repo:
+        pr.post_comment('hansen r+', config['role_reviewer']['token'])
+    env.run_crons()
+
+    st = env['runbot_merge.stagings'].search([])
+    assert st.state == 'pending'
+    with repo:
+        repo.post_status('staging.maintenance', 'success', 'ci')
+    env.run_crons('runbot_merge.process_updated_commits')
+    assert st.state == 'success'

--- a/runbot_merge/tests/test_oddities.py
+++ b/runbot_merge/tests/test_oddities.py
@@ -1,3 +1,8 @@
+import json
+
+from utils import Commit
+
+
 def test_partner_merge(env):
     p_src = env['res.partner'].create({
         'name': 'kfhsf',
@@ -20,3 +25,66 @@ def test_partner_merge(env):
     assert not p_src.exists()
     assert p_dest.name == 'Partner P. Partnersson'
     assert p_dest.github_login == 'xxx'
+
+def test_override(env, project, make_repo, users, setreviewers, config):
+    """
+    Test that we can override a status on a PR:
+
+    * @mergebot override context=status
+    * target url should be the comment (?)
+    * description should be overridden by <user>
+    """
+    repo = make_repo('repo')
+    repo_id = env['runbot_merge.repository'].create({
+        'project_id': project.id,
+        'name': repo.name,
+        'status_ids': [(0, 0, {'context': 'l/int'})]
+    })
+    setreviewers(*project.repo_ids)
+    # "other" can override the lint
+    env['res.partner'].create({
+        'name': config['role_other'].get('name', 'Other'),
+        'github_login': users['other'],
+        'override_rights': [(0, 0, {
+            'repository_id': repo_id.id,
+            'context': 'l/int',
+        })]
+    })
+
+    with repo:
+        m = repo.make_commits(None, Commit('root', tree={'a': '1'}), ref='heads/master')
+
+        repo.make_commits(m, Commit('pr', tree={'a': '2'}), ref='heads/change')
+        pr = repo.make_pr(target='master', title='super change', head='change')
+        pr.post_comment('hansen r+', config['role_reviewer']['token'])
+    env.run_crons()
+
+    pr_id = env['runbot_merge.pull_requests'].search([
+        ('repository.name', '=', repo.name),
+        ('number', '=', pr.number)
+    ])
+    assert pr_id.state == 'approved'
+
+    with repo:
+        pr.post_comment('hansen override=l/int', config['role_reviewer']['token'])
+    env.run_crons()
+    assert pr_id.state == 'approved'
+
+    with repo:
+        pr.post_comment('hansen override=l/int', config['role_other']['token'])
+    env.run_crons()
+    assert pr_id.state == 'ready'
+
+    comments = pr.comments
+    assert comments == [
+        (users['reviewer'], 'hansen r+'),
+        (users['reviewer'], 'hansen override=l/int'),
+        (users['user'], "I'm sorry, @{}. You are not allowed to do that.".format(users['reviewer'])),
+        (users['other'], "hansen override=l/int"),
+    ]
+    assert pr_id.statuses == '{}'
+    assert json.loads(pr_id.overrides) == {'l/int': {
+        'state': 'success',
+        'target_url': comments[-1]['html_url'],
+        'description': 'Overridden by @{}'.format(users['other']),
+    }}

--- a/runbot_merge/views/mergebot.xml
+++ b/runbot_merge/views/mergebot.xml
@@ -151,6 +151,7 @@
                         <group colspan="4">
                             <field name="head"/>
                             <field name="statuses"/>
+                            <field name="overrides"/>
                         </group>
                     </group>
                     <group>

--- a/runbot_merge/views/mergebot.xml
+++ b/runbot_merge/views/mergebot.xml
@@ -65,6 +65,8 @@
                         <tree editable="bottom">
                             <field name="context"/>
                             <field name="branch_ids" widget="many2many_tags"/>
+                            <field name="prs"/>
+                            <field name="stagings"/>
                         </tree>
                     </field>
                 </sheet>

--- a/runbot_merge/views/mergebot.xml
+++ b/runbot_merge/views/mergebot.xml
@@ -5,13 +5,6 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-                    <!--
-                    <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" name="action_see_attachments" type="object" icon="fa-book" attrs="{'invisible': ['|', ('state', '=', 'confirmed'), ('type', '=', 'routing')]}">
-                            <field string="Attachments" name="mrp_document_count" widget="statinfo"/>
-                        </button>
-                    </div>
-                    -->
                     <div class="oe_title">
                         <h1><field name="name" placeholder="Name"/></h1>
                     </div>
@@ -33,11 +26,11 @@
 
                     <separator string="Repositories"/>
                     <field name="repo_ids">
-                        <tree editable="bottom">
+                        <tree>
                             <field name="sequence" widget="handle"/>
                             <field name="name"/>
-                            <field name="required_statuses"/>
                             <field name="branch_filter"/>
+                            <field name="status_ids" widget="many2many_tags"/>
                         </tree>
                     </field>
                     <separator string="Branches"/>
@@ -46,6 +39,32 @@
                             <field name="sequence" widget="handle" />
                             <field name="name"/>
                             <field name="active"/>
+                        </tree>
+                    </field>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="form_repository" model="ir.ui.view">
+        <field name="name">Repository form</field>
+        <field name="model">runbot_merge.repository</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_title">
+                        <h1><field name="name"/></h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="branch_filter"/>
+                        </group>
+                    </group>
+                    <separator string="Required Statuses"/>
+                    <field name="status_ids">
+                        <tree editable="bottom">
+                            <field name="context"/>
+                            <field name="branch_ids" widget="many2many_tags"/>
                         </tree>
                     </field>
                 </sheet>

--- a/runbot_merge/views/res_partner.xml
+++ b/runbot_merge/views/res_partner.xml
@@ -35,6 +35,9 @@
                                 </tree>
                             </field>
                         </group>
+                        <group colspan="4">
+                            <field name="override_rights" widget="many2many_tags"/>
+                        </group>
                     </group>
                     <group>
                         <group colspan="4" string="Delegate On">


### PR DESCRIPTION
* split statuses into their own object which can be filtered on a per-branch basis
* further allow statuses to be filtered on being required for PRs or stagings (or both, or none though that's not very useful)
* add support for overriding statuses