### PR TITLE
[FIX] runbot: set default result before github

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -753,10 +753,10 @@ class runbot_build(models.Model):
 
             build.write(build_values)
             if ending_build:
-                build._github_status()
                 if not build.local_result:  # Set 'ok' result if no result set (no tests job on build)
                     build.local_result = 'ok'
                     build._logger("No result set, setting ok by default")
+                build._github_status()
             build._run_job()
 
     def _run_job(self):


### PR DESCRIPTION
Set the default 'ok' to local_result before calling github.
This will prevent making all builds fail when testing isn't enabled.

We only use runbot to make sure there is no "hard" errors, also testing is a resource intensive task.
Currently all our builds are marked as failed in github. This did fix it for me.