### PR TITLE
[FIX] runbot_merge: stuck feedback cron

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -133,7 +133,7 @@ class Project(models.Model):
                 if f.close:
                     gh.close(f.pull_request)
                     try:
-                        data = json.loads(message)
+                        data = json.loads(message or '')
                     except json.JSONDecodeError:
                         pass
                     else:


### PR DESCRIPTION
When using @fw-bot close, a feedback would be created without a
message (rather than e.g. with an empty one). As a result, the
feedback-sending cron would crash, but not before having closed the
corresponding PR.

This would lead to closing the PR in a loop & spamming the logs with
tracebacks.