### PR TITLE
[IMP] runbot: add pdf417 library

### DIFF
--- a/runbot/data/Dockerfile
+++ b/runbot/data/Dockerfile
@@ -98,4 +98,5 @@ ADD https://raw.githubusercontent.com/odoo/odoo/master/requirements.txt /root/p3
 ADD https://raw.githubusercontent.com/odoo/odoo/10.0/requirements.txt /root/p2-requirements.txt
 RUN pip install --no-cache-dir -r /root/p2-requirements.txt coverage flanker==0.4.38 pylint==1.7.2 phonenumbers redis \
     && pip3 install --no-cache-dir -r /root/p3-requirements.txt coverage==4.5.4 websocket-client astroid==2.0.4 \
-    pylint==1.7.2 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph pdfminer.six==20181108
+    pylint==1.7.2 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph pdfminer.six==20181108 \
+    pdf417gen==0.7.1


### PR DESCRIPTION
The pdf417 python library is needed for the l10n_cl_edi. As this module
is not mandatory, the library was not added in the requirements.txt
file.

In order to test the feature on the runbot, this commit adds the library
in the Docker container.

Related work:
    odoo/odoo#54995
    odoo/enterprise#12080
    odoo/enterprise@8290bfaf