### PR TITLE
[IMP] runbot: improve build order

### DIFF
--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -136,7 +136,7 @@ class Runbot(models.AbstractModel):
                             WHERE
                                 %s
                             ORDER BY
-                                array_position(array['normal','rebuild','indirect','scheduled']::varchar[], runbot_build.build_type) ASC
+                                parent_path
                             FOR UPDATE OF runbot_build SKIP LOCKED
                             LIMIT %%s
                         )


### PR DESCRIPTION
The old order based on status is not really needed anymore:

- Scheduled builds have a special condition and already have a low priority.
- Indirect builds don't exist anymore
- It is actually questionnable to postpone rebuild. Sometimes they are needed but stuck.

This new proposition will keep subbuild scheduling close to parent build. Some build may take 2 hours
because they are parallelized and children are stuck. Priority should be defined by top parent.