### PR TITLE
[IMP] runbot: add extra parameters and environment variables to build config step

### DIFF
--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -72,9 +72,9 @@
                         <field name="test_tags"/>
                         <field name="enable_auto_tags"/>
                         <field name="sub_command"/>
-                        <field name="extra_params" groups="base.group_no_one"/>
                     </group>
-                    <group string="Test settings" attrs="{'invisible': [('job_type', 'not in', ('python', 'install_odoo', 'test_upgrade'))]}">
+                    <group string="Extra Parameters" attrs="{'invisible': [('job_type', 'not in', ('python', 'install_odoo', 'test_upgrade', 'run_odoo'))]}">
+                        <field name="extra_params"/>
                         <field name="additionnal_env"/>
                     </group>
                     <group string="Create settings" attrs="{'invisible': [('job_type', 'not in', ('python', 'create_build'))]}">


### PR DESCRIPTION
Currently there is no way that I can see to configure extra parameters or environment variables to run_odoo build config steps. It is possible on install steps, but not on run steps. This PR adds that capability.

This is useful in cases where a module needs to be run as a server wide module. For example [OCA/queue](https://github.com/OCA/queue/tree/13.0/queue_job).