### PR TITLE
[IMP] runbot: call docker_run outside steps

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -121,7 +121,7 @@ def docker_run(*args, **kwargs):
     return _docker_run(*args, **kwargs)
 
 
-def _docker_run(run_cmd, log_path, build_dir, container_name, image_tag=False, exposed_ports=None, cpu_limit=None, preexec_fn=None, ro_volumes=None, env_variables=None):
+def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, preexec_fn=None, ro_volumes=None, env_variables=None):
     """Run tests in a docker container
     :param run_cmd: command string to run in container
     :param log_path: path to the logfile that will contain odoo stdout and stderr
@@ -133,6 +133,8 @@ def _docker_run(run_cmd, log_path, build_dir, container_name, image_tag=False, e
     :params ro_volumes: dict of dest:source volumes to mount readonly in builddir
     :params env_variables: list of environment variables
     """
+    assert cmd and log_path and build_dir and container_name
+    run_cmd = cmd
     image_tag = image_tag or 'odoo:DockerDefault'
     container_name = sanitize_container_name(container_name)
     if isinstance(run_cmd, Command):

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -720,13 +720,13 @@ class BuildResult(models.Model):
                     build._log("run", message, level='ERROR')
                     build._kill(result='ko')
 
-    def _docker_run(self, *args, **kwargs):
+    def _docker_run(self, **kwargs):
         self.ensure_one()
         if 'image_tag' not in kwargs:
             kwargs.update({'image_tag': self.params_id.dockerfile_id.image_tag})
         if kwargs['image_tag'] != 'odoo:DockerDefault':
             self._log('Preparing', 'Using Dockerfile Tag %s' % kwargs['image_tag'])
-        docker_run(*args, **kwargs)
+        docker_run(**kwargs)
 
     def _path(self, *l, **kw):
         """Return the repo build path"""


### PR DESCRIPTION
When calling a step from a python step, it is impossible to alter some parameter, the only solution is to copy all step code.
With this change, python step are now able to override docker_run parameter of another step by modifying the dict returned by run_* steps
and assigning the result to "docker_params".

This will mainly be used to set the correct docker_image for migration pre and post test. This can also be used to alter a command,
like removing the pip install or adding extra pre/post operation on the command.