### PR TITLE
[IMP] runbot: allow 'main' as alternative to 'master' branch name

### DIFF
--- a/runbot/data/runbot_data.xml
+++ b/runbot/data/runbot_data.xml
@@ -29,7 +29,7 @@
 
     <record model="ir.config_parameter" id="runbot.runbot_is_base_regex">
         <field name="key">runbot.runbot_is_base_regex</field>
-        <field name="value">^((master)|(saas-)?\d+\.\d+)$</field>
+        <field name="value">^((master)|(main)|(saas-)?\d+\.\d+)$</field>
     </record>
 
     <record model="ir.actions.server" id="action_toggle_is_base">

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -755,11 +755,11 @@ class ConfigStep(models.Model):
             target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('version_id', 'in', self.upgrade_to_version_ids.ids)])
         else:
             if self.upgrade_to_master:
-                target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('name', '=', 'master')])
+                target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('name', 'in', ('main','master'))])
             if self.upgrade_to_all_versions:
-                target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('name', '!=', 'master')])
+                target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('name', 'not in', ('main', 'master'))])
             elif self.upgrade_to_major_versions:
-                target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('name', '!=', 'master'), ('version_id.is_major', '=', True)])
+                target_refs_bundles |= self.env['runbot.bundle'].search(sticky_domain + [('name', 'not in', ('main', 'master')), ('version_id.is_major', '=', True)])
 
         source_refs_bundles = self.env['runbot.bundle']
 

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -91,7 +91,7 @@ class Bundle(models.Model):
                 if bundle.name.startswith('%s-' % bname):
                     bundle.base_id = self.browse(bid)
                     break
-                elif bname == 'master':
+                elif bname == 'master' or bname == 'main':
                     master_base = self.browse(bid)
             else:
                 bundle.base_id = master_base

--- a/runbot/models/version.py
+++ b/runbot/models/version.py
@@ -75,7 +75,7 @@ class Version(models.Model):
                 (
                     v
                     for v in all_versions
-                    if (v.is_major or v.name == 'master') and v.number > version.number and v.sequence >= version.sequence
+                    if (v.is_major or v.name == 'master' or v.name == 'main') and v.number > version.number and v.sequence >= version.sequence
                 ), self.browse())
             if version.next_major_version_id:
                 version.next_intermediate_version_ids = all_versions.filtered(

--- a/runbot/views/error_log_views.xml
+++ b/runbot/views/error_log_views.xml
@@ -67,7 +67,7 @@
           <field name="build_id"/>
           <filter string="Failed builds" name="failed_builds" domain="[('global_state', '=', 'done'), ('global_result', '=', 'ko')]"/>
           <separator/>
-          <filter string="Master bundle" name="master_bundle" domain="[('bundle_ids.name', '=', 'master')]"/>
+          <filter string="Master bundle" name="master_bundle" domain="[('bundle_ids.name', 'in', ('master', 'main'))]"/>
           <filter string="Sticky bundles" name="sticky_bundles" domain="[('sticky', '=', True)]"/>
           <separator/>
           <!-- <filter name="filter_log_create_date" date="log_create_date" string="Log Date" default_period="last_7_days"/> -->


### PR DESCRIPTION
github is proposing "main" as a replacement to "master" for the default branch name. This PR allows runbot to consider both as equivalent. 