### PR TITLE
[IMP] runbot: add to_upgrade option

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -33,6 +33,7 @@ class Bundle(models.Model):
     is_base = fields.Boolean('Is base', index=True)
     defined_base_id = fields.Many2one('runbot.bundle', 'Forced base bundle', domain="[('project_id', '=', project_id), ('is_base', '=', True)]")
     base_id = fields.Many2one('runbot.bundle', 'Base bundle', compute='_compute_base_id', store=True)
+    to_upgrade = fields.Boolean('To upgrade', compute='_compute_to_upgrade', store=True, index=False)
 
     version_id = fields.Many2one('runbot.version', 'Version', compute='_compute_version_id', store=True)
     version_number = fields.Char(related='version_id.number', store=True, index=True)
@@ -75,6 +76,11 @@ class Bundle(models.Model):
     def _compute_sticky(self):
         for bundle in self:
             bundle.sticky = bundle.is_base
+
+    @api.depends('is_base')
+    def _compute_to_upgrade(self):
+        for bundle in self:
+            bundle.to_upgrade = bundle.is_base
 
     @api.depends('name', 'is_base', 'defined_base_id', 'base_id.is_base', 'project_id')
     def _compute_base_id(self):

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -25,6 +25,7 @@
                     <field name="name"/>
                     <field name="project_id"/>
                     <field name="sticky" readonly="0"/>
+                    <field name="to_upgrade" readonly="0"/>
                     <field name="is_base"/>
                     <field name="base_id"/>
                     <field name="defined_base_id"/>
@@ -70,6 +71,7 @@
                 <field name="version_number"/>
                 <field name="is_base"/>
                 <field name="sticky"/>
+                <field name="to_upgrade"/>
                 <field name="no_build"/>
                 <field name="branch_ids"/>
                 <field name="version_id"/>


### PR DESCRIPTION
For now, the sticky flag is used to define bundle to use as target to upgrade.
The plan for future is to continue to test upgrade, even if the bundle is not sticky anymore.
This new flag will allow to remove sticky for old branche.
This will also allow to disable upgrda tests for still sticky branches when needed.

This commit also filter source bundle based on this flag
(before that all base bundle where used as source, even if not sticky)