### PR TITLE
[FIX] runbot: fix _is_docker_step to incidentallly fix log menu

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -295,7 +295,7 @@ class ConfigStep(models.Model):
         if not self:
             return False
         self.ensure_one()
-        return self.job_type in ('install_odoo', 'run_odoo', 'restore', 'test_upgrade') or (self.job_type == 'python' and ('docker_run(' in self.python_code or '_run_' in self.python_code))
+        return self.job_type in ('install_odoo', 'run_odoo', 'restore', 'test_upgrade') or (self.job_type == 'python' and ('docker_params =' in self.python_code or '_run_' in self.python_code))
 
     def _run_run_odoo(self, build, log_path, force=False):
         if not force:


### PR DESCRIPTION
Since 3657a65b20 docker_run is called outside of the step and python
steps have to set the `docker_params` variable. This breaks the computed
`log_list` because the string `docker_run(` is searched in python
steps code to determine if it's a docker_step.

With this commit, the `docker_params = ` is searched instead.