### PR TITLE
[FIX] runbot_merge: correct Linked PRs URLs

### DIFF
--- a/runbot_merge/views/templates.xml
+++ b/runbot_merge/views/templates.xml
@@ -358,7 +358,7 @@
                 <ul class="todo">
                     <t t-foreach="linked_prs" t-as="linked">
                         <li t-att-class="'ok' if linked._ready else 'fail'">
-                            <a t-attf-href="linked.url" t-field="linked.display_name"/>
+                            <a t-att-href="linked.url" t-field="linked.display_name"/>
                         </li>
                     </t>
                 </ul>


### PR DESCRIPTION
It was not evaluated and rendered to something like
  https://mergebot.odoo.com/odoo/odoo/pull/linked.url

Courtesy of Xavier Dollé (xdo)