### PR TITLE
[IMP] runbot: add an option to exclude paths from coverage report

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -127,6 +127,7 @@ class ConfigStep(models.Model):
     db_name = fields.Char('Db Name', compute='_compute_db_name', inverse='_inverse_db_name', tracking=True)
     cpu_limit = fields.Integer('Cpu limit', default=3600, tracking=True)
     coverage = fields.Boolean('Coverage', default=False, tracking=True)
+    paths_to_omit = fields.Char('Paths to omit from coverage', tracking=True)
     flamegraph = fields.Boolean('Allow Flamegraph', default=False, tracking=True)
     test_enable = fields.Boolean('Test enable', default=True, tracking=True)
     test_tags = fields.Char('Test tags', help="comma separated list of test tags", tracking=True)
@@ -832,6 +833,8 @@ class ConfigStep(models.Model):
 
     def _coverage_params(self, build, modules_to_install):
         pattern_to_omit = set()
+        if self.paths_to_omit:
+            pattern_to_omit = set(self.paths_to_omit.split(','))
         for commit in build.params_id.commit_ids:
             docker_source_folder = build._docker_source_folder(commit)
             for manifest_file in commit.repo_id.manifest_files.split(','):

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -68,6 +68,7 @@
                         <field name="db_name" groups="base.group_no_one"/>
                         <field name="cpu_limit" groups="base.group_no_one"/>
                         <field name="coverage"/>
+                        <field name="paths_to_omit" attrs="{'invisible': [('coverage', '!=', True)]}"/>
                         <field name="test_enable"/>
                         <field name="test_tags"/>
                         <field name="enable_auto_tags"/>


### PR DESCRIPTION
As a developer of modules on top of Odoo, I would like to exclude Odoo's files from the coverage report as I am more interested in the coverage of my own modules. By having Odoo's files listed alongside my own, the total coverage score is diluted.

This commit adds a field to the build config step to enter a comma separated list of paths to omit from coverage.

I'm not sure if it will be of any utility to Odoo SA, but will be useful for all the module developers out there and does not get in the way if not used.