### PR TITLE
[FIX] runbot: _compute_host_id

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -54,7 +54,7 @@ class Bundle(models.Model):
     def _compute_host_id(self):
         assigned_only = None
         runbots = {}
-        for bundle in self:
+        for bundle in self.filtered('name'):
             elems = bundle.name.split('-')
             for elem in elems:
                 if elem.startswith('runbot'):


### PR DESCRIPTION
If you try to manually create bundle, Odoo will crash, because it will
try to use `name` value that is not set yet. For that we start computing
host_id once `name` is entered.

Particularly, you would get this error:

```python
Traceback (most recent call last):
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 624, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 310, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/home/oerp/odoo13/odoo/odoo/tools/pycompat.py", line 14, in reraise
    raise value
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 669, in dispatch
    result = self._call_function(**self.params)
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 350, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/oerp/odoo13/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 915, in __call__
    return self.method(*args, **kw)
  File "/home/oerp/odoo13/odoo/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/home/oerp/odoo13/odoo/addons/web/controllers/main.py", line 1327, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/oerp/odoo13/odoo/addons/web/controllers/main.py", line 1319, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/oerp/odoo13/odoo/odoo/api.py", line 387, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/oerp/odoo13/odoo/odoo/api.py", line 374, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/oerp/odoo13/odoo/odoo/models.py", line 6235, in onchange
    value = record[name]
  File "/home/oerp/odoo13/odoo/odoo/models.py", line 5731, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/oerp/odoo13/odoo/odoo/fields.py", line 2333, in __get__
    return super().__get__(records, owner)
  File "/home/oerp/odoo13/odoo/odoo/fields.py", line 999, in __get__
    self.compute_value(recs)
  File "/home/oerp/odoo13/odoo/odoo/fields.py", line 1113, in compute_value
    records._compute_field_value(self)
  File "/home/oerp/odoo13/odoo/odoo/models.py", line 4003, in _compute_field_value
    getattr(self, field.compute)()
  File "/home/oerp/odoo13/src/runbot/runbot/models/bundle.py", line 58, in _compute_host_id
    elems = bundle.name.split('-')
AttributeError: 'bool' object has no attribute 'split'
```