### PR TITLE
[FIX] runbot: use database name subdomain

### DIFF
--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -223,11 +223,11 @@
                     Force Build
                 </a>
                 <t t-if="bu.local_state=='running'">
-                    <a class="dropdown-item" t-attf-href="http://{{bu.domain}}/?db={{bu.dest}}-all">
+                    <a class="dropdown-item" t-attf-href="http://{{bu.dest}}-all.{{bu.host}}/">
                         <i class="fa fa-sign-in"/>
                         Connect all
                     </a>
-                    <a class="dropdown-item" t-attf-href="http://{{bu.domain}}/?db={{bu.dest}}-base">
+                    <a class="dropdown-item" t-attf-href="http://{{bu.dest}}-base.{{bu.host}}/">
                         <i class="fa fa-sign-in"/>
                         Connect base
                     </a>


### PR DESCRIPTION
Using database name as subdomain will set the web.base.url correctly when connection for the first time using this link
This will unfortunatelly break connect all and connect base links if dns and nginx are not setup.
This won't fix the web.base.url when connecting with the Connect (database selector) button either.