### PR TITLE
[IMP] runbot: allow to install Chrome from google

### DIFF
--- a/runbot/templates/dockerfile.xml
+++ b/runbot/templates/dockerfile.xml
@@ -112,10 +112,11 @@ RUN <t t-esc="values['python_version']"/> -m pip install setuptools wheel &amp;&
 'wkhtml_url': 'https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb',
 'chrome': True,
 'phantom': False,
+'do_requirements': True,
 'python_version': 'python3',
 'deb_packages_python': 'python3 python3-dev python3-pip python3-setuptools python3-wheel python3-markdown libpq-dev',
 'deb_package_default': 'apt-transport-https build-essential ca-certificates curl ffmpeg file fonts-freefont-ttf fonts-noto-cjk gawk gnupg libldap2-dev libsasl2-dev libxslt1-dev lsb-release node-less ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev',
-'additional_pip': 'coverage==4.5.4 websocket-client astroid==2.4.2 pylint==2.6.0 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph pdfminer.six==20200720 pdf417gen==0.7.1'
+'additional_pip': 'coverage==4.5.4 websocket-client astroid==2.4.2 pylint==2.5.0 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph pdfminer.six==20200720 pdf417gen==0.7.1'
               }"/>
       <t t-set="values" t-value="default"/>
       <t t-set="dummy" t-value="values.update(custom_values)" t-if="custom_values" />
@@ -136,7 +137,7 @@ RUN <t t-esc="values['python_version']"/> -m pip install setuptools wheel &amp;&
       <t t-call="runbot.docker_install_psql"/>
       <t t-if="values['chrome']" t-call="runbot.docker_install_chrome"/>
       <t t-if="values['phantom']" t-call="runbot.docker_install_phantomjs"/>
-      <t t-call="runbot.docker_install_odoo_python_requirements"/>
+      <t t-if="values['do_requirements']" t-call="runbot.docker_install_odoo_python_requirements"/>
     </template>
   </data>
 </odoo>

--- a/runbot/templates/dockerfile.xml
+++ b/runbot/templates/dockerfile.xml
@@ -19,12 +19,21 @@ RUN set -x ; \
     <template id="runbot.docker_install_chrome">
       <t t-set="chrome_distrib" t-value="values['chrome_distrib']"/>
       <t t-set="chrome_version" t-value="values['chrome_version']"/>
+      <t t-set="chrome_source" t-value="values.get('chrome_source')"/>
 # Install Google Chrome
+      <t t-if="chrome_source == 'google'">
+RUN curl -sSL https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_<t t-esc="chrome_version"/>_amd64.deb -o /tmp/chrome.deb \
+    &amp;&amp; apt-get update \
+    &amp;&amp; apt-get -y install --no-install-recommends /tmp/chrome.deb \
+    &amp;&amp; rm /tmp/chrome.deb
+      </t>
+      <t t-else="">
 RUN curl -sSL http://nightly.odoo.com/odoo.key | apt-key add - \
     &amp;&amp; echo "deb http://nightly.odoo.com/deb/<t t-esc="chrome_distrib"/> ./" > /etc/apt/sources.list.d/google-chrome.list \
     &amp;&amp; apt-get update \
     &amp;&amp; apt-get install -y -qq google-chrome-stable=<t t-esc="chrome_version"/> \
     &amp;&amp; rm -rf /var/lib/apt/lists/*
+      </t>
     </template>
 
     <template id="runbot.docker_install_phantomjs">


### PR DESCRIPTION
When choosing to install Chrome in a Dockerfile, the chrome version is
downloaded from Odoo nightly server. This make it difficult to test
with different versions of Chrome.

With this commit, we allow to install from Google in Docker files.

By default, the install remains from Odoo Nightly server but if the key
`custom_values['chrome_source']` is set to 'google' in a Dockerfile,
the specified version will be downloaded from Google servers when the
Docker image is built.

This PR also contains a feature to disable the installation of `requirements.txt` file in Dockerfile.