### PR TITLE
[IMP] runbot: enhance dockerfile tree view

### DIFF
--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -46,9 +46,13 @@
         <field name="name">runbot.dockerfile.tree</field>
         <field name="model">runbot.dockerfile</field>
         <field name="arch" type="xml">
-            <tree string="Dockerfile">
-                <field name="name"/>
-            </tree>
+          <tree string="Dockerfile" decoration-danger="dockerfile == ''" decoration-warning="to_build == False">
+            <field name="name"/>
+            <field name="image_tag"/>
+            <field name="to_build"/>
+            <field name="version_ids" widget="many2many_tags"/>
+            <field name="dockerfile" invisible="True"/>
+          </tree>
         </field>
     </record>
 


### PR DESCRIPTION
When a dockerfile to_build field is False for any reason and a new
runbot is setup, it's easy to miss the point and builds that involves
this particular Dockerfile will fail on the new runbot.

With this commit, the Dockerfiles tree view is improved to easily spot
those kind of problems:

- to_build field is visible and the Falsy lines are in yellow (warning)
- the empty Dockerfile's are in red (danger)
- versions are now visible in the tree view too