### PR TITLE
[IMP] runbot: Improve stats display

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -426,7 +426,7 @@ class Runbot(Controller):
             return request.not_found()
 
         builds_domain = [
-            ('global_result', '=', 'ok'), ('slot_ids.batch_id.bundle_id', '=', bundle_id), ('params_id.trigger_id', '=', trigger.id),
+            ('global_state', 'in', ('running', 'done')), ('global_result', '=', 'ok'), ('slot_ids.batch_id.bundle_id', '=', bundle_id), ('params_id.trigger_id', '=', trigger.id),
         ]
 
         if max_build_id:

--- a/runbot/static/src/css/runbot.scss
+++ b/runbot/static/src/css/runbot.scss
@@ -200,3 +200,31 @@ body, .table{
         }
     }
 }
+.chart-legend {
+    max-height: calc(100vh - 160px);
+    overflow-y: scroll;
+    overflow-x: hidden;
+    cursor: pointer;
+    padding: 5px;
+
+    .label {
+        margin-left: 5px;
+        font-weight: bold;
+    }
+    .disabled{
+        .color {
+            visibility: hidden;
+        }
+        .label {
+            font-weight: normal;
+            text-decoration: line-through;
+            margin-left: 5px;
+        }
+    }
+
+    ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+    }
+}

--- a/runbot/templates/build_stats.xml
+++ b/runbot/templates/build_stats.xml
@@ -75,34 +75,51 @@
               <select id="key_category_selector" class="form-select" aria-label="Stat Category">
                 <option t-foreach="stats_categories" t-as="category" t-attf-value="{{category}}"><t t-esc="category.replace('_',' ').title()"/></option>
               </select>
-              <b>Mode: </b>
-              <select id="mode_selector" class="form-select" aria-label="Display mode">
-                <option title="Real Values" selected="selected" value="normal">Normal</option>
-                <option title="Delta With Reference Build Values" value="difference">Difference</option>
-              </select>
               <b>Nb of builds:</b>
               <select id="limit_selector" class="form-select" aria-label="Number Of Builds">
                 <option value="10">10</option>
                 <option value="25">25</option>
                 <option value="50">50</option>
-                <option selected="selected" value="100">100</option>
-                <option value="150">250</option>
+                <option value="100">100</option>
+                <option value="250">250</option>
               </select>
-              <b>Nb datasets:</b>
-              <select id="nb_dataset_selector" class="form-select" aria-label="Number Of Builds">
-                <option value="10">10</option>
-                <option value="20">20</option>
-                <option value="50">50</option>
-                <option selected="selected" value="100">100</option>
-              </select>
-
-              <button id="fast_backward_button" class="btn btn-default" title="Previous Builds" aria-label="Previous Builds">
-                <i t-attf-class="fa  fa-fast-backward"/>
+              <button id="backward_button" class="btn btn-default" title="Previous Builds" aria-label="Previous Builds">
+                <i t-attf-class="fa fa-backward"/>
+              </button>
+              <button id="forward_button" class="btn btn-default" title="Previous Builds" aria-label="Previous Builds">
+                <i t-attf-class="fa fa-forward"/>
+              </button>
+              <button id="fast_forward_button" class="btn btn-default" title="Previous Builds" aria-label="Previous Builds">
+                <i t-attf-class="fa fa-fast-forward"/>
               </button>
               <i id="chart_spinner" class="fa fa-2x fa-circle-o-notch fa-spin"/>
             </div>
           </nav>
-        <canvas id="canvas"></canvas>
+          <div class="row">
+            <div class="col-xs-9 col-md-10 col-lg-11"><canvas id="canvas"></canvas></div>
+            <div class="col-xs-3 col-md-2 col-lg-1">
+                <b>Mode:</b>
+                <select id="mode_selector" class="form-select" aria-label="Display mode">
+                  <option title="Real Values ordered by value" selected="selected" value="normal">Value</option>
+                  <option title="Real Values ordered by name" selected="selected" value="alpha">Alphabetical</option>
+                  <option title="Delta With Reference Build Values" value="difference">Difference</option>
+                  <option title="Bigger # of datapoint varying from previous one" value="change_count">Noisy</option>
+                </select>
+
+                <b>Display:</b>
+                <select id="nb_dataset_selector" class="form-select" aria-label="Number Of Builds">
+                  <option value="-1">Custom</option>
+                  <option value="0">0</option>
+                  <option value="10">Top 10</option>
+                  <option value="20">Top 20</option>
+                  <option value="50">Top 50</option>
+                </select>
+                <div id="js-legend" class="chart-legend">
+                
+                </div>
+            
+            </div>
+          </div>
         </div>
       </t>
       <script type="text/javascript" src="/runbot/static/src/js/stats.js"></script>


### PR DESCRIPTION
- Adds a complete legend enabelling to display a custom subset of modules.
This is mainly to enable a vertical scroll on list since chart-js default
legend will be displayed on multiple column.

- Adds a "Noisy" order mode to find non-deterministic modules.

- Changes the build selection mode to a center one to easylly center
build of interrest and add a forward button.

- Small ui tweaks/fix to match new selection logic.

![image](https://user-images.githubusercontent.com/35262360/114428114-172e4f80-9bbc-11eb-9b4c-ac6bbe66e7bf.png)
