### PR TITLE
[IMP] runbot: show red slots in batch tile

### DIFF
--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -94,7 +94,7 @@
           <div class="batch_slots">
             <t t-foreach="batch.slot_ids" t-as="slot">
               <t t-if="slot.build_id">
-                <div t-if="not slot.trigger_id.manual and ((not slot.trigger_id.hide and trigger_display is None) or (trigger_display and slot.trigger_id.id in trigger_display))"
+                <div t-if="not slot.trigger_id.manual and ((not slot.trigger_id.hide and trigger_display is None) or (trigger_display and slot.trigger_id.id in trigger_display))or slot.build_id.global_result == 'ko'"
                   t-call="runbot.slot_button" class="slot_container"/>
               </t>
             </t>


### PR DESCRIPTION
When a build slot is hidden in the batch tile but is responsible of the
batch failure, the failure reason may not be obvious for the user.

With this commit, an hidden slot appears if the slot build is in
failure.