### PR TITLE
[IMP] runbot: update docker default for focal

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -135,7 +135,7 @@ class Batch(models.Model):
         if not bundle.version_id:
             _logger.error('No version found on bundle %s in project %s', bundle.name, project.name)
 
-        dockerfile_id = bundle.dockerfile_id or bundle.base_id.dockerfile_id or bundle.version_id.dockerfile_id
+        dockerfile_id = bundle.dockerfile_id or bundle.base_id.dockerfile_id or bundle.version_id.dockerfile_id or bundle.project_id.dockerfile_id
         if not dockerfile_id:
             _logger.error('No dockerfile found !')
 

--- a/runbot/models/dockerfile.py
+++ b/runbot/models/dockerfile.py
@@ -20,6 +20,7 @@ class Dockerfile(models.Model):
     version_ids = fields.One2many('runbot.version', 'dockerfile_id', string='Versions')
     description = fields.Text('Description')
     view_ids = fields.Many2many('ir.ui.view', compute='_compute_view_ids')
+    project_ids = fields.One2many('runbot.project', 'dockerfile_id', string='Default for Projects')
     bundle_ids = fields.One2many('runbot.bundle', 'dockerfile_id', string='Used in Bundles')
 
     _sql_constraints = [('runbot_dockerfile_name_unique', 'unique(name)', 'A Dockerfile with this name already exists')]

--- a/runbot/models/dockerfile.py
+++ b/runbot/models/dockerfile.py
@@ -20,6 +20,7 @@ class Dockerfile(models.Model):
     version_ids = fields.One2many('runbot.version', 'dockerfile_id', string='Versions')
     description = fields.Text('Description')
     view_ids = fields.Many2many('ir.ui.view', compute='_compute_view_ids')
+    bundle_ids = fields.One2many('runbot.bundle', 'dockerfile_id', string='Used in Bundles')
 
     _sql_constraints = [('runbot_dockerfile_name_unique', 'unique(name)', 'A Dockerfile with this name already exists')]
 

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -9,6 +9,7 @@ class Project(models.Model):
     group_ids = fields.Many2many('res.groups', string='Required groups')
 
     trigger_ids = fields.One2many('runbot.trigger', 'project_id', string='Triggers')
+    dockerfile_id = fields.Many2one('runbot.dockerfile', index=True, help="Project Default Dockerfile")
 
 
 class Category(models.Model):

--- a/runbot/templates/dockerfile.xml
+++ b/runbot/templates/dockerfile.xml
@@ -17,7 +17,7 @@ RUN set -x ; \
     </template>
 
     <template id="runbot.docker_install_chrome">
-      <t t-set="chrome_distrib" t-value="values['chrome_distrib']"/>
+      <t t-set="chrome_distrib" t-value="values.get('chrome_distrib')"/>
       <t t-set="chrome_version" t-value="values['chrome_version']"/>
       <t t-set="chrome_source" t-value="values.get('chrome_source')"/>
 # Install Google Chrome
@@ -95,18 +95,24 @@ RUN apt-get update \
 
     <template id="runbot.docker_install_odoo_python_requirements">
 ADD https://raw.githubusercontent.com/odoo/odoo/<t t-esc="values['odoo_branch']"/>/requirements.txt /root/requirements.txt
-RUN <t t-esc="values['python_version']"/> -m pip install setuptools wheel &amp;&amp; \
+RUN <t t-esc="values['python_version']"/> -m pip install --no-cache-dir setuptools wheel &amp;&amp; \
     <t t-esc="values['python_version']"/> -m pip install --no-cache-dir -r /root/requirements.txt &amp;&amp; \
-    <t t-esc="values['python_version']"/> -m pip install <t t-esc="values['additional_pip']"/>
+    <t t-esc="values['python_version']"/> -m pip install --no-cache-dir <t t-esc="values['additional_pip']"/>
     </template>
+
+    <template id="runbot.docker_install_runbot_python_requirements">
+RUN <t t-esc="values['python_version']"/> -m pip install --no-cache-dir setuptools wheel &amp;&amp; \
+    <t t-esc="values['python_version']"/> -m pip install <t t-esc="values['runbot_pip']"/>
+    </template>
+
 
     <template id="runbot.docker_base">
       <t t-set="default" t-value="{
-'from': 'ubuntu:bionic',
+'from': 'ubuntu:focal',
 'odoo_branch': 'master',
-'chrome_distrib': 'bionic',
-'chrome_version': '80.0.3987.116-1',
-'node_packages': 'rtlcss es-check',
+'chrome_source': 'google',
+'chrome_version': '90.0.4430.93-1',
+'node_packages': 'rtlcss es-check eslint',
 'node_version': '15',
 'psql_version': '12',
 'wkhtml_url': 'https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb',
@@ -114,10 +120,11 @@ RUN <t t-esc="values['python_version']"/> -m pip install setuptools wheel &amp;&
 'phantom': False,
 'do_requirements': True,
 'python_version': 'python3',
-'deb_packages_python': 'python3 python3-dev python3-pip python3-setuptools python3-wheel python3-markdown libpq-dev',
-'deb_package_default': 'apt-transport-https build-essential ca-certificates curl ffmpeg file fonts-freefont-ttf fonts-noto-cjk gawk gnupg libldap2-dev libsasl2-dev libxslt1-dev lsb-release node-less ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev',
-'additional_pip': 'coverage==4.5.4 websocket-client astroid==2.4.2 pylint==2.5.0 phonenumbers pyCrypto dbfread==2.0.7 firebase-admin==2.17.0 flamegraph pdfminer.six==20200720 pdf417gen==0.7.1'
-              }"/>
+'deb_packages_python': 'python3 python3-dbfread python3-dev python3-pip python3-setuptools python3-wheel python3-markdown python3-mock python3-phonenumbers python3-vatnumber python3-websocket libpq-dev',
+'deb_package_default': 'apt-transport-https build-essential ca-certificates curl ffmpeg file fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release node-less ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev',
+'additional_pip': 'ebaysdk==2.1.5 pdf417gen==0.7.1',
+'runbot_pip': 'coverage==4.5.4 astroid==2.4.2 pylint==2.5.0 flamegraph'
+}"/>
       <t t-set="values" t-value="default"/>
       <t t-set="dummy" t-value="values.update(custom_values)" t-if="custom_values" />
 
@@ -134,6 +141,7 @@ RUN <t t-esc="values['python_version']"/> -m pip install setuptools wheel &amp;&
       <t t-call="runbot.docker_install_node_packages"/>
       <t t-call="runbot.docker_install_flamegraph"/>
       <t t-call="runbot.docker_install_odoo_debs"/>
+      <t t-call="runbot.docker_install_runbot_python_requirements"/>
       <t t-call="runbot.docker_install_psql"/>
       <t t-if="values['chrome']" t-call="runbot.docker_install_chrome"/>
       <t t-if="values['phantom']" t-call="runbot.docker_install_phantomjs"/>

--- a/runbot/tests/test_dockerfile.py
+++ b/runbot/tests/test_dockerfile.py
@@ -18,6 +18,7 @@ class TestDockerfile(RunbotCase, HttpCase):
       'from': 'ubuntu:focal',
       'phantom': True,
       'additional_pip': 'babel==2.8.0',
+      'chrome_source': 'odoo',
       'chrome_version': '86.0.4240.183-1',
     }"/>
 </t>
@@ -40,7 +41,7 @@ class TestDockerfile(RunbotCase, HttpCase):
         self.assertTrue(dockerfile.dockerfile.startswith('FROM ubuntu:focal'))
         self.assertIn(' apt-get install -y -qq google-chrome-stable=86.0.4240.183-1', dockerfile.dockerfile)
         self.assertIn('# Install phantomjs', dockerfile.dockerfile)
-        self.assertIn('pip install babel==2.8.0', dockerfile.dockerfile)
+        self.assertIn('pip install --no-cache-dir babel==2.8.0', dockerfile.dockerfile)
 
         # test view update
         xml_content = xml_content.replace('86.0.4240.183-1', '87.0-1')

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -7,6 +7,7 @@
             <form string="Projects">
                 <group>
                     <field name="name"/>
+                    <field name="dockerfile_id"/>
                     <field name="group_ids"/>
                     <field name="trigger_ids"/>
                 </group>

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -32,6 +32,14 @@
                     </tree>
                   </field>
                 </page>
+                <page string="Bundles">
+                  <field name="bundle_ids" widget="one2many">
+                    <tree>
+                      <field name="project_id"/>
+                      <field name="name"/>
+                    </tree>
+                  </field>
+                </page>
               </notebook>
             </sheet>
             <div class="oe_chatter">
@@ -51,6 +59,7 @@
             <field name="image_tag"/>
             <field name="to_build"/>
             <field name="version_ids" widget="many2many_tags"/>
+            <field name="bundle_ids"/>
             <field name="dockerfile" invisible="True"/>
           </tree>
         </field>

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -12,6 +12,7 @@
                 <field name="image_tag"/>
                 <field name="to_build"/>
                 <field name="version_ids" widget="many2many_tags"/>
+                <field name="project_ids" widget="many2many_tags"/>
                 <field name="template_id"/>
               </group>
               <group>
@@ -59,6 +60,7 @@
             <field name="image_tag"/>
             <field name="to_build"/>
             <field name="version_ids" widget="many2many_tags"/>
+            <field name="project_ids" widget="many2many_tags"/>
             <field name="bundle_ids"/>
             <field name="dockerfile" invisible="True"/>
           </tree>


### PR DESCRIPTION
Since Odoo 14.0, the recommended Ubuntu LTS release is Focal, the
default Docker should be updated accordingly.

A custom template with bionic have to be manually created on runbot
instances that still build Odoo < 14.0.

* Upgrade Chrome version to 90.0.4430.93-1 as this one is currently in
  use on our current runbot instance. Just keep in mind that the Odoo
  screencast feature does not work anymore since Chrome 88.

* This new Default Docker will not install requirements.txt from the
  github odoo master branch anymore. We expect Odoo to run fully with
  deb packages only.

... to be continued

TODO check the necessity of:

- [x] pyCrypto [blame](https://github.com/odoo/runbot/commit/4791c3a82e25a593af1c40b35c78a8500a488329)  was used for a module that [disappeared](https://github.com/odoo/odoo/commit/2738341c21ec2e2df355bf8d4c98eab0a96cc21d). Not any `Crypto` traces from 12.0 to master
- [x] firebase-admin==2.17.0 [blame](https://github.com/odoo/runbot/commit/a2a8fe31f1a732df377e1c48739bda8e22effd8c). Still [used](https://github.com/odoo/enterprise/blob/13.0/social_push_notifications/tests/test_social_push_notifications.py) in a test.
Awa created a task to remove it.
- [ ] pdfminer.six==20200720 [blame](https://github.com/odoo/runbot/commit/e2675335136b45ed414f815fcea3781f48372f06)
Did not exists in Stretch nor Bionic ... now exists in [Buster](https://packages.debian.org/buster/python3-pdfminer) and [Focal](https://packages.ubuntu.com/focal/python3-pdfminer)
- [ ] pdf417gen==0.7.1 (Used in l10n_cl_edi since 13.0 up to master)

Also

- [ ] is it better to get the deb packages from `master`or `14.0`
