### PR TITLE
[IMP] runbot: use github pull requests labels

### DIFF
--- a/runbot/security/ir.model.access.csv
+++ b/runbot/security/ir.model.access.csv
@@ -103,3 +103,6 @@ access_runbot_upgrade_exception_admin,access_runbot_upgrade_exception_admin,runb
 
 access_runbot_dockerfile_user,access_runbot_dockerfile_user,runbot.model_runbot_dockerfile,runbot.group_user,1,0,0,0
 access_runbot_dockerfile_admin,access_runbot_dockerfile_admin,runbot.model_runbot_dockerfile,runbot.group_runbot_admin,1,1,1,1
+
+access_runbot_branch_label,runbot_branch_label,runbot.model_runbot_branch_label,group_user,1,0,0,0
+access_runbot_branch_label_admin,runbot_branch_label_admin,runbot.model_runbot_branch_label,runbot.group_runbot_admin,1,1,1,1

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_runbot
 from . import test_commit
 from . import test_upgrade
 from . import test_dockerfile
+from . import test_bundle

--- a/runbot/tests/test_branch.py
+++ b/runbot/tests/test_branch.py
@@ -14,21 +14,6 @@ class TestBranch(RunbotCase):
 
         self.assertEqual(branch.branch_url, 'https://example.com/base/server/tree/master')
 
-    def test_pull_request(self):
-        mock_github = self.patchers['github_patcher']
-        mock_github.return_value = {
-            'base': {'ref': 'master'},
-            'head': {'label': 'foo-dev:bar_branch', 'repo': {'full_name': 'foo-dev/bar'}},
-        }
-        pr = self.Branch.create({
-            'remote_id': self.remote_server.id,
-            'name': '12345',
-            'is_pr': True,
-        })
-        self.assertEqual(pr.name, '12345')
-        self.assertEqual(pr.branch_url, 'https://example.com/base/server/pull/12345')
-        self.assertEqual(pr.target_branch_name, 'master')
-        self.assertEqual(pr.pull_head_name, 'foo-dev:bar_branch')
 
 class TestBranchRelations(RunbotCase):
 

--- a/runbot/tests/test_bundle.py
+++ b/runbot/tests/test_bundle.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from .common import RunbotCase
+
+class TestBundle(RunbotCase):
+
+    def test_pull_request_labels(self):
+        mock_github = self.patchers['github_patcher']
+        mock_github.return_value = {
+            'base': {'ref': 'master'},
+            'head': {'label': 'foo-dev:bar_branch', 'repo': {'full_name': 'dev/server'}},
+            'labels': [{
+                'name': 'test 14.4',
+                'color': 'ededed',
+            }, {
+                'name': 'test forwardport',
+                'color': 'a4fcde',
+            }]
+        }
+
+        # create a pre-existing label to test unique constraint
+        self.env['runbot.branch.label'].create([{'name': 'test forwardport'}])
+
+        # create a dev branch and a PR
+        dev_branch = self.Branch.create({
+            'remote_id': self.remote_server_dev.id,
+            'name': 'bar_branch',
+            'is_pr': False
+        })
+
+        pr = self.Branch.create({
+            'remote_id': self.remote_server.id,
+            'name': '12345',
+            'is_pr': True,
+        })
+        self.assertEqual(pr.name, '12345')
+        self.assertEqual(pr.branch_url, 'https://example.com/base/server/pull/12345')
+        self.assertEqual(pr.target_branch_name, 'master')
+        self.assertEqual(pr.pull_head_name, 'foo-dev:bar_branch')
+
+        # test that the bundle was created with branch and PR
+        bundle = dev_branch.bundle_id
+        self.assertIn(pr, bundle.branch_ids)
+
+        # test the labels
+        labels = self.env['runbot.branch.label'].search([('name', 'like', 'test %')])
+        self.assertEqual(len(labels), 2)
+        self.assertEqual(labels, pr.label_ids)
+        self.assertEqual(bundle.labels, pr.label_ids)
+
+        # create an addon branch and Pr
+        mock_github.return_value = {
+            'base': {'ref': 'master'},
+            'head': {'label': 'foo-dev:bar_branch', 'repo': {'full_name': 'dev/addons'}},
+            'labels': [{
+                'name': 'foo label',
+                'color': 'ededed',
+            }, {
+                'name': 'test forwardport',
+                'color': 'a4fcde',
+            }]
+        }
+
+        addon_dev_branch = self.Branch.create({
+            'remote_id': self.remote_addons_dev.id,
+            'name': 'bar_branch',
+            'is_pr': False
+        })
+        self.assertEqual(addon_dev_branch.bundle_id, bundle)
+
+        # create 2 PR to test that 2 NEW `foo label` same labels appearing at the same time
+        addon_pr, _ = self.Branch.create([{
+            'remote_id': self.remote_addons.id,
+            'name': '6789',
+            'is_pr': True}, {
+            'remote_id': self.remote_addons.id,
+            'name': '6790',
+            'is_pr': True
+        }])
+        self.assertEqual(addon_pr.bundle_id, bundle)
+        self.assertEqual(len(bundle.branch_ids), 5)
+
+        # now test that labels are correctly set on the bundle
+        self.assertEqual(3, len(bundle.labels))
+        self.assertIn('foo label', bundle.labels.mapped('name'))
+        self.assertIn('test forwardport', bundle.labels.mapped('name'))
+        self.assertIn('test 14.4', bundle.labels.mapped('name'))
+
+        # check that bundle labels can be searched
+        fw_port_bundle_ids = self.env['runbot.bundle'].search([('labels', '=', 'test forwardport')])
+        self.assertEqual(fw_port_bundle_ids, bundle)
+        test_bundle_ids = self.env['runbot.bundle'].search([('labels', 'ilike', 'test%')])
+        self.assertEqual(test_bundle_ids, bundle)
+        foo_bundle_ids = self.env['runbot.bundle'].search([('labels', 'in', ['test forwardport', 'foo label'])])
+        self.assertEqual(foo_bundle_ids, bundle)
+
+        # check labels bundle
+        fw_label = self.env['runbot.branch.label'].search([('name', '=', 'test forwardport')])
+        self.assertIn(bundle, fw_label.bundle_ids)

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -75,10 +75,24 @@
                 <field name="no_build"/>
                 <field name="branch_ids"/>
                 <field name="version_id"/>
+                <field name="labels" widget="many2many_tags" readonly="1"/>
             </tree>
         </field>
     </record>
 
+    <record id="runbot_bundle_search_view" model="ir.ui.view">
+      <field name="name">runbot.bundle.filter</field>
+      <field name="model">runbot.bundle</field>
+      <field name="arch" type="xml">
+        <search string="Search regex">
+          <field name="name"/>
+          <field name="labels"/>
+           <filter string="Has Open PR" name="open_pr" domain="[('pr_state', '=', 'open')]"/>
+           <filter string="All PR Closed" name="open_pr" domain="[('pr_state', '=', 'done')]"/>
+           <filter string="Has no PR" name="nopr" domain="[('pr_state', '=', 'nopr')]"/>
+        </search>
+      </field>
+    </record>
     <record id="view_runbot_batch" model="ir.ui.view">
         <field name="model">runbot.batch</field>
         <field name="arch" type="xml">
@@ -126,6 +140,40 @@
         </field>
     </record>
 
+    <record id="view_runbot_branch_label_form" model="ir.ui.view">
+        <field name="model">runbot.branch.label</field>
+        <field name="arch" type="xml">
+            <form string="Label">
+                <group>
+                    <field name="name"/>
+                </group>
+                <field name="bundle_ids" nolabel="1" widget="many2many" options="{'not_delete': True, 'no_create': True}">
+                    <tree string="Bundle">
+                        <field name="project_id"/>
+                        <field name="name"/>
+                        <field name="version_number"/>
+                        <field name="is_base"/>
+                        <field name="sticky"/>
+                        <field name="to_upgrade"/>
+                        <field name="no_build"/>
+                        <field name="branch_ids"/>
+                        <field name="version_id"/>
+                        <field name="labels" widget="many2many_tags" readonly="1"/>
+                        <button name="action_open_frontend" title="Open Frontend" aria-label="Open" type="object" icon="fa-play" class="oe_link"/>
+                    </tree>
+                </field>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_runbot_branch_label_tree" model="ir.ui.view">
+        <field name="model">runbot.branch.label</field>
+        <field name="arch" type="xml">
+            <tree string="Label">
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
     <record id="action_bundle" model="ir.actions.act_window">
         <field name="name">Bundles</field>
         <field name="type">ir.actions.act_window</field>
@@ -151,10 +199,17 @@
         <field name="view_mode">tree,form</field>
     </record>
 
+    <record id="action_bundle_label" model="ir.actions.act_window">
+        <field name="name">Labels</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">runbot.branch.label</field>
+        <field name="view_mode">tree,form</field>
+    </record>
     <menuitem id="menu_bundle" name="Bundle" parent="runbot_menu_root"/>
     <menuitem id="menu_bundle_bundle" action="action_bundle" parent="menu_bundle"/>
     <menuitem id="menu_bundle_project" action="action_bundle_project" parent="menu_bundle"/>
     <menuitem id="menu_bundle_version" action="action_bundle_version" parent="menu_bundle"/>
     <menuitem id="menu_bundle_batch" action="action_bundle_batch" parent="menu_bundle"/>
+    <menuitem id="menu_bundle_label" action="action_bundle_label" parent="menu_bundle"/>
   </data>
 </odoo>


### PR DESCRIPTION
In order to facilitate some filters and searches, this commit allows to
retrieve PR labels from Github. They are linked to branches and a bundle
will hold the labels from all its PR's.

They can be searched as it's the final purpose of this PR.

Although this could be done on Github, the runbot aggregates branches
from multiple repos in a bundle. So it's easier to browse and search
bundles than doing the same in multiple Github tabs.