### PR TITLE
[IMP] runbot: add a pr_state field on bundle

### DIFF
--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_runbot
 from . import test_commit
 from . import test_upgrade
 from . import test_dockerfile
+from . import test_bundle

--- a/runbot/tests/test_branch.py
+++ b/runbot/tests/test_branch.py
@@ -14,21 +14,6 @@ class TestBranch(RunbotCase):
 
         self.assertEqual(branch.branch_url, 'https://example.com/base/server/tree/master')
 
-    def test_pull_request(self):
-        mock_github = self.patchers['github_patcher']
-        mock_github.return_value = {
-            'base': {'ref': 'master'},
-            'head': {'label': 'foo-dev:bar_branch', 'repo': {'full_name': 'foo-dev/bar'}},
-        }
-        pr = self.Branch.create({
-            'remote_id': self.remote_server.id,
-            'name': '12345',
-            'is_pr': True,
-        })
-        self.assertEqual(pr.name, '12345')
-        self.assertEqual(pr.branch_url, 'https://example.com/base/server/pull/12345')
-        self.assertEqual(pr.target_branch_name, 'master')
-        self.assertEqual(pr.pull_head_name, 'foo-dev:bar_branch')
 
 class TestBranchRelations(RunbotCase):
 

--- a/runbot/tests/test_bundle.py
+++ b/runbot/tests/test_bundle.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from .common import RunbotCase
+
+class TestBundle(RunbotCase):
+
+    def test_pull_request_pr_state(self):
+        # create a dev branch
+        dev_branch = self.Branch.create({
+            'remote_id': self.remote_server_dev.id,
+            'name': 'bar_branch',
+            'is_pr': False
+        })
+
+        bundle = dev_branch.bundle_id
+        self.assertEqual(bundle.name, 'bar_branch')
+        self.assertEqual(bundle.pr_state, 'nopr', 'The bundle should be in `nopr` state')
+        self.assertIn(bundle, self.Bundle.search([('pr_state', '=', 'nopr')]))
+
+        # now create a PR and check that the bundle pr_state is `open`
+        mock_github = self.patchers['github_patcher']
+        mock_github.return_value = {
+            'base': {'ref': 'master'},
+            'head': {'label': 'foo-dev:bar_branch', 'repo': {'full_name': 'dev/server'}},
+        }
+
+        pr = self.Branch.create({
+            'remote_id': self.remote_server.id,
+            'name': '12345',
+            'is_pr': True,
+            'alive': True
+        })
+
+        self.env['runbot.branch'].flush()  # Needed to test sql query in _search_pr_state
+
+        self.assertIn(pr, bundle.branch_ids)
+        self.assertEqual(bundle.pr_state, 'open')
+
+        # test the different searches operators
+        self.assertIn(bundle, self.Bundle.search([('pr_state', '=', 'open')]))
+        self.assertNotIn(bundle, self.Bundle.search([('pr_state', '=', 'done')]))
+        self.assertNotIn(bundle, self.Bundle.search([('pr_state', '!=', 'open')]))
+        self.assertIn(bundle, self.Bundle.search([('pr_state', '!=', 'done')]))
+
+        # add a new PR from another repo in the same bundle (mimic enterprise PR)
+        mock_github.return_value = {
+            'base': {'ref': 'master'},
+            'head': {'label': 'bar-dev:bar_branch', 'repo': {'full_name': 'dev/addons'}},
+        }
+
+        addons_pr = self.Branch.create({
+            'remote_id': self.remote_addons.id,
+            'name': '6789',
+            'is_pr': True,
+            'alive': True
+        })
+
+        self.assertIn(addons_pr, bundle.branch_ids)
+        self.assertEqual(bundle.pr_state, 'open')
+        self.assertIn(bundle, self.Bundle.search([('pr_state', '=', 'open')]))
+        self.assertNotIn(bundle, self.Bundle.search([('pr_state', '=', 'done')]))
+
+        # one PR is closed, the bundle pr_state should stay open
+        addons_pr.alive = False
+        self.env['runbot.branch'].flush()  # Needed to test sql query in _search_pr_state
+        self.assertEqual(bundle.pr_state, 'open')
+        self.assertIn(bundle, self.Bundle.search([('pr_state', '=', 'open')]))
+        self.assertNotIn(bundle, self.Bundle.search([('pr_state', '=', 'done')]))
+
+        # The last PR is closed so the bundle pr state should be done
+        pr.alive = False
+        self.env['runbot.branch'].flush()  # Needed to test sql query in _search_pr_state
+        self.assertEqual(bundle.pr_state, 'done')
+        self.assertNotIn(bundle, self.Bundle.search([('pr_state', '=', 'open')]))
+        self.assertIn(bundle, self.Bundle.search([('pr_state', '=', 'done')]))

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -20,6 +20,7 @@
         <field name="arch" type="xml">
             <form string="Bundles">
                 <div class="oe_button_box" name="button_box">
+                    <button name="action_open_frontend" title="Open Frontend" aria-label="Open" type="object" icon="fa-play" class="oe_link"/>
                 </div>
                 <group>
                     <field name="name"/>
@@ -65,7 +66,7 @@
     <record id="view_runbot_bundle_tree" model="ir.ui.view">
         <field name="model">runbot.bundle</field>
         <field name="arch" type="xml">
-            <tree string="Bundle">
+            <tree string="Bundle" decoration-primary="sticky == True" decoration-muted="pr_state == 'nopr'" decoration-success="pr_state == 'done'" decoration-warning="pr_state == 'open'">
                 <field name="project_id"/>
                 <field name="name"/>
                 <field name="version_number"/>
@@ -75,10 +76,24 @@
                 <field name="no_build"/>
                 <field name="branch_ids"/>
                 <field name="version_id"/>
+                <button name="action_open_frontend" title="Open Frontend" aria-label="Open" type="object" icon="fa-play" class="oe_link"/>
+                <field name="pr_state"/>
             </tree>
         </field>
     </record>
 
+    <record id="runbot_bundle_search_view" model="ir.ui.view">
+      <field name="name">runbot.bundle.filter</field>
+      <field name="model">runbot.bundle</field>
+      <field name="arch" type="xml">
+        <search string="Search regex">
+          <field name="name"/>
+          <filter string="Has Open PR" name="open_pr" domain="[('pr_state', '=', 'open')]"/>
+          <filter string="All PR Closed" name="open_pr" domain="[('pr_state', '=', 'done')]"/>
+          <filter string="Has no PR" name="nopr" domain="[('pr_state', '=', 'nopr')]"/>
+        </search>
+      </field>
+    </record>
     <record id="view_runbot_batch" model="ir.ui.view">
         <field name="model">runbot.batch</field>
         <field name="arch" type="xml">


### PR DESCRIPTION
In order to facilitate bundle filtering, a new computed field is added
that gives a state for all the PR in a bundle. This state will give an
information about the `task` state.

If all the PR in a bundle are closed, the pr_state is considered done,
on the other hand, if at least one PR is still open, the whole bundle is
considered open from the `task`point of view. A third state (`nopr`) is
used for bundles that does not have any PR.