### PR TITLE
[IMP] add draft pr management + multiple custom fields

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '5.0',
+    'version': '5.1',
     'depends': ['base', 'base_automation', 'website'],
     'data': [
         'templates/dockerfile.xml',

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -207,7 +207,8 @@ class Runbot(Controller):
     ], type='http', auth="user", methods=['GET', 'POST'], csrf=False)
     def force_bundle(self, bundle, auto_rebase=False, **post):
         _logger.info('user %s forcing bundle %s', request.env.user.name, bundle.name)  # user must be able to read bundle
-        batch = bundle.sudo()._force(auto_rebase=auto_rebase)
+        batch = bundle.sudo()._force()
+        batch._prepare(auto_rebase)
         return werkzeug.utils.redirect('/runbot/batch/%s' % batch.id)
 
     @route(['/runbot/batch/<int:batch_id>'], website=True, auth='public', type='http')

--- a/runbot/migrations/13.0.5.1/pre-migration.py
+++ b/runbot/migrations/13.0.5.1/pre-migration.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+def migrate(cr, _version):
+    cr.execute('ALTER TABLE runbot_branch ADD COLUMN draft BOOLEAN')

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -266,8 +266,10 @@ class Batch(models.Model):
         version_id = self.bundle_id.version_id.id
         project_id = self.bundle_id.project_id.id
         config_by_trigger = {}
+        params_by_trigger = {}
         for trigger_custom in self.bundle_id.trigger_custom_ids:
             config_by_trigger[trigger_custom.trigger_id.id] = trigger_custom.config_id
+            params_by_trigger[trigger_custom.trigger_id.id] = trigger_custom.extra_params
         for trigger in triggers:
             trigger_repos = trigger.repo_ids | trigger.dependency_ids
             if trigger_repos & missing_repos:
@@ -275,10 +277,12 @@ class Batch(models.Model):
                 continue
             # in any case, search for an existing build
             config = config_by_trigger.get(trigger.id, trigger.config_id)
-
+            if not config:
+                continue
+            extra_params = params_by_trigger.get(trigger.id, '')
             params_value = {
                 'version_id':  version_id,
-                'extra_params': '',
+                'extra_params': extra_params,
                 'config_id': config.id,
                 'project_id': project_id,
                 'trigger_id': trigger.id,  # for future reference and access rights

--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -34,6 +34,7 @@ class Branch(models.Model):
     dname = fields.Char('Display name', compute='_compute_dname', search='_search_dname')
 
     alive = fields.Boolean('Alive', default=True)
+    draft = fields.Boolean('Draft', compute='_compute_branch_infos', store=True)
 
     @api.depends('name', 'remote_id.short_name')
     def _compute_dname(self):
@@ -101,6 +102,7 @@ class Branch(models.Model):
                 pi = branch.is_pr and (pull_info or pull_info_dict.get((branch.remote_id, branch.name)) or branch._get_pull_info())
                 if pi:
                     try:
+                        branch.draft = pi.get('draft', False)
                         branch.target_branch_name = pi['base']['ref']
                         branch.pull_head_name = pi['head']['label']
                         pull_head_repo_name = False

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -211,7 +211,8 @@ class RunbotCase(TransactionCase):
 
         self.assertEqual(triggers.repo_ids + triggers.dependency_ids, self.remote_addons.repo_id + self.remote_server.repo_id)
 
-        self.branch_addons.bundle_id._force()
+        batch = self.branch_addons.bundle_id._force()
+        batch._prepare()
 
 
 class RunbotCaseMinimalSetup(RunbotCase):

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -204,6 +204,7 @@ class TestUpgradeFlow(RunbotCase):
         # create nightly
 
         batch_nigthly = bundle._force(self.nightly_category.id)
+        batch_nigthly._prepare()
         self.assertEqual(batch_nigthly.category_id, self.nightly_category)
         builds_nigthly = {}
         host = self.env['runbot.host']._get_current()
@@ -229,6 +230,7 @@ class TestUpgradeFlow(RunbotCase):
         batch_nigthly.state = 'done'
 
         batch_weekly = bundle._force(self.weekly_category.id)
+        batch_weekly._prepare()
         self.assertEqual(batch_weekly.category_id, self.weekly_category)
         builds_weekly = {}
         build = batch_weekly.slot_ids.filtered(lambda s: s.trigger_id == self.trigger_addons_weekly).build_id
@@ -245,6 +247,7 @@ class TestUpgradeFlow(RunbotCase):
         batch_weekly.state = 'done'
 
         batch_default = bundle._force()
+        batch_default._prepare()
         build = batch_default.slot_ids.filtered(lambda s: s.trigger_id == self.trigger_server).build_id
         build.local_state = 'done'
         batch_default.state = 'done'
@@ -263,6 +266,7 @@ class TestUpgradeFlow(RunbotCase):
             self.trigger_upgrade_server.flush(['upgrade_step_id'])
 
         batch = self.master_bundle._force()
+        batch._prepare()
         upgrade_current_build = batch.slot_ids.filtered(lambda slot: slot.trigger_id == self.trigger_upgrade_server).build_id
         host = self.env['runbot.host']._get_current()
         upgrade_current_build.host = host.name
@@ -328,6 +332,7 @@ class TestUpgradeFlow(RunbotCase):
         })
 
         batch = self.master_bundle._force(self.nightly_category.id)
+        batch._prepare()
         upgrade_nightly = batch.slot_ids.filtered(lambda slot: slot.trigger_id == trigger_upgrade_addons_nightly).build_id
         host = self.env['runbot.host']._get_current()
         upgrade_nightly.host = host.name
@@ -453,6 +458,7 @@ class TestUpgradeFlow(RunbotCase):
 
         # test_build_references
         batch = self.master_bundle._force()
+        batch._prepare()
         upgrade_slot = batch.slot_ids.filtered(lambda slot: slot.trigger_id == self.trigger_upgrade_server)
         self.assertTrue(upgrade_slot)
         upgrade_build = upgrade_slot.build_id
@@ -469,6 +475,7 @@ class TestUpgradeFlow(RunbotCase):
 
         self.trigger_upgrade_server.upgrade_step_id.upgrade_from_all_intermediate_version = True
         batch = self.master_bundle._force()
+        batch._prepare()
         upgrade_build = batch.slot_ids.filtered(lambda slot: slot.trigger_id == self.trigger_upgrade_server).build_id
         self.assertEqual(
             upgrade_build.params_id.builds_reference_ids,
@@ -506,6 +513,7 @@ class TestUpgradeFlow(RunbotCase):
         self.assertEqual(bundle_133.name, 'saas-13.3')
 
         batch13 = bundle_13._force()
+        batch13._prepare()
         upgrade_complement_build_13 = batch13.slot_ids.filtered(lambda slot: slot.trigger_id == trigger_upgrade_complement).build_id
         upgrade_complement_build_13.host = host.name
         self.assertEqual(upgrade_complement_build_13.params_id.config_id, config_upgrade_complement)

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -49,6 +49,7 @@
                         <tree editable="bottom">
                             <field name="trigger_id" domain="[('project_id', '=', parent.project_id)]"/>
                             <field name="config_id"/>
+                            <field name="extra_params"/>
                         </tree>
                     </field>
                     <field string="Last batches" name="last_batchs">


### PR DESCRIPTION
- Add draft pr management to avoid to trigger code owner on draft pr.
- Add check on falsy config on trigger id (avoid crash, usefull to disable trigger)
- Add extra params on custom trigger to avoid to write specific config every time.
- Trigger a new batch automaticaly when updating target/draft