### PR TITLE
[FIX] runbot: update matplotlib to focal version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-matplotlib==3.0.2
+matplotlib==3.1.2
 unidiff


### PR DESCRIPTION
Matplotlib 3.0.2 cannot be `pip installed` on Focal.