### PR TITLE
[IMP] use random order of module installation

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -812,7 +812,7 @@ class BuildResult(models.Model):
         modules_to_install = filter_patterns(self.params_id.modules, modules_to_install, available_modules)
         modules_to_install = filter_patterns(modules_patterns, modules_to_install, available_modules)
 
-        return sorted(modules_to_install)
+        return modules_to_install
 
     def _local_pg_dropdb(self, dbname):
         with local_pgadmin_cursor() as local_cr:

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -3,6 +3,7 @@ import glob
 import json
 import logging
 import fnmatch
+import random
 import re
 import shlex
 import time
@@ -815,7 +816,9 @@ class ConfigStep(models.Model):
             build._log('end_job', message, log_type='markdown')
 
     def _modules_to_install(self, build):
-        return set(build._get_modules_to_test(modules_patterns=self.install_modules))
+        mods = list(build._get_modules_to_test(modules_patterns=self.install_modules))
+        random.shuffle(mods)
+        return mods
 
     def _post_install_commands(self, build, modules_to_install, py_version=None):
         cmds = []

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -215,15 +215,15 @@ class TestBuildResult(RunbotCase):
         self.repo_addons.modules = '-*'
 
         modules_to_test = build._get_modules_to_test(modules_patterns='')
-        self.assertEqual(modules_to_test, sorted(['good_module', 'hwgood', 'other_good', 'hw_explicit']))
+        self.assertEqual(sorted(modules_to_test), sorted(['good_module', 'hwgood', 'other_good', 'hw_explicit']))
 
         modules_to_test = build._get_modules_to_test(modules_patterns='-*, l10n_be')
-        self.assertEqual(modules_to_test, sorted(['l10n_be']))
+        self.assertEqual(sorted(modules_to_test), sorted(['l10n_be']))
         modules_to_test = build._get_modules_to_test(modules_patterns='l10n_be')
-        self.assertEqual(modules_to_test, sorted(['good_module', 'hwgood', 'other_good', 'hw_explicit', 'l10n_be']))
+        self.assertEqual(sorted(modules_to_test), sorted(['good_module', 'hwgood', 'other_good', 'hw_explicit', 'l10n_be']))
         # star to get all available mods
         modules_to_test = build._get_modules_to_test(modules_patterns='*, -hw_*, hw_explicit')
-        self.assertEqual(modules_to_test, sorted(['good_module', 'bad_module', 'other_good', 'l10n_be', 'hwgood', 'hw_explicit', 'other_mod_1', 'other_mod_2']))
+        self.assertEqual(sorted(modules_to_test), sorted(['good_module', 'bad_module', 'other_good', 'l10n_be', 'hwgood', 'hw_explicit', 'other_mod_1', 'other_mod_2']))
 
     def test_build_cmd_log_db(self, ):
         """ test that the logdb connection URI is taken from the .odoorc file """


### PR DESCRIPTION
Some errors could be caught only on installing modules in specific order. It's
better to see them randomly than to don't see the errors at all