### PR TITLE
[FIX] runbot: correctly get number type value from icp

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -736,7 +736,7 @@ class BuildResult(models.Model):
             self._log('Preparing', 'Using Dockerfile Tag %s' % kwargs['image_tag'])
         containers_memory_limit = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_memory', 0)
         if containers_memory_limit and 'memory' not in kwargs:
-            kwargs['memory'] = containers_memory_limit * 1024 ** 3
+            kwargs['memory'] = float(containers_memory_limit) * 1024 ** 3
         docker_run(**kwargs)
 
     def _path(self, *l, **kw):


### PR DESCRIPTION
If set `containers_memory_limit = 2.0`
In row:

> 
> containers_memory_limit = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_memory', 0)
>  kwargs['memory'] = containers_memory_limit * 1024 ** 3

I get `"2.02.02.02.02.02.02.02.02.02.02.02.02.02.0...."`