### PR TITLE
[FIX] runbot: fix keep_running, and relve log_access on stats

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -209,7 +209,7 @@ class BuildResult(models.Model):
 
     build_url = fields.Char('Build url', compute='_compute_build_url', store=False)
     build_error_ids = fields.Many2many('runbot.build.error', 'runbot_build_error_ids_runbot_build_rel', string='Errors')
-    keep_running = fields.Boolean('Keep running', help='Keep running')
+    keep_running = fields.Boolean('Keep running', help='Keep running', index=True)
     log_counter = fields.Integer('Log Lines counter', default=100)
 
     slot_ids = fields.One2many('runbot.batch.slot', 'build_id')

--- a/runbot/models/build_stat.py
+++ b/runbot/models/build_stat.py
@@ -8,6 +8,7 @@ _logger = logging.getLogger(__name__)
 class BuildStat(models.Model):
     _name = "runbot.build.stat"
     _description = "Statistics"
+
     _sql_constraints = [
         (
             "build_config_key_unique",

--- a/runbot/models/build_stat.py
+++ b/runbot/models/build_stat.py
@@ -8,6 +8,7 @@ _logger = logging.getLogger(__name__)
 class BuildStat(models.Model):
     _name = "runbot.build.stat"
     _description = "Statistics"
+    _log_access = False
 
     _sql_constraints = [
         (

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -88,9 +88,9 @@ class Runbot(models.AbstractModel):
         running_max = host.get_running_max()
         domain_host = self.build_domain_host(host)
         Build = self.env['runbot.build']
-        cannot_be_killed_ids = Build.search(domain_host + [('keep_running', '!=', True)]).ids
+        cannot_be_killed_ids = Build.search(domain_host + [('keep_running', '=', True)]).ids
         sticky_bundles = self.env['runbot.bundle'].search([('sticky', '=', True)])
-        cannot_be_killed_ids = [
+        cannot_be_killed_ids += [
             build.id
             for build in sticky_bundles.mapped('last_batchs.slot_ids.build_id')
             if build.host == host.name


### PR DESCRIPTION
Keep running was broken for since 5.0.
This PR fixes the broken logic and adds an index

This PR also remove useless log_access on stats.