### PR TITLE
[FIX] runbot_merge: add migration for draft column

### DIFF
--- a/runbot_merge/__manifest__.py
+++ b/runbot_merge/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'merge bot',
-    'version': '1.6',
+    'version': '1.7',
     'depends': ['contacts', 'website'],
     'data': [
         'security/security.xml',

--- a/runbot_merge/migrations/13.0.1.7/pre-migration.py
+++ b/runbot_merge/migrations/13.0.1.7/pre-migration.py
@@ -1,0 +1,6 @@
+def migrate(cr, version):
+    """ Create draft column manually because the v13 orm can't handle the power
+    of adding new required columns
+    """
+    cr.execute("ALTER TABLE runbot_merge_pull_requests"
+               " ADD COLUMN draft BOOLEAN NOT NULL DEFAULT false")


### PR DESCRIPTION
Draft was added in 82174ae66ee15fa5fdb4d1ad6057c4670e7e2ea8 but turns
out the v13 ORM is not able to create a required column (even when
given a default value), at least for booleans.

So create it by hand.