### PR TITLE
FIX: display of error message on PR pages

### DIFF
--- a/runbot_merge/views/templates.xml
+++ b/runbot_merge/views/templates.xml
@@ -327,7 +327,9 @@
     <template id="view_pull_request_info_error">
         <div class="alert alert-danger">
             Error:
-            <p t-field="pr.staging_id.reason"/>
+            <span t-esc="pr.with_context(active_test=False).batch_ids[-1:].staging_id.reason">
+                Unable to stage PR
+            </span>
         </div>
     </template>
     <template id="view_pull_request_info_staging">


### PR DESCRIPTION
When a PR is in error, the page only shows "Error:" (well, not right now as a fix to the view was deployed but the fix is not complete so some pages still show that, mostly when a PR can't be staged in the first place).

This is unintended, the page is supposed to report the reason for the PR being in error (mostly the staging failure reason).