### PR TITLE
[FIX] runbot: allow a runbot admin to create runbot batch log

### DIFF
--- a/runbot/security/ir.model.access.csv
+++ b/runbot/security/ir.model.access.csv
@@ -118,6 +118,7 @@ access_runbot_category_runbot_user,access_runbot_category_runbot_user,runbot.mod
 access_runbot_category_runbot_admin,access_runbot_category_runbot_admin,runbot.model_runbot_category,runbot.group_runbot_admin,1,1,1,1
 
 access_runbot_batch_log_runbot_user,access_runbot_batch_log_runbot_user,runbot.model_runbot_batch_log,runbot.group_user,1,0,0,0
+access_runbot_batch_log_runbot_admin,access_runbot_batch_log_runbot_admin,runbot.model_runbot_batch_log,runbot.group_runbot_admin,1,1,1,1
 
 access_runbot_warning_user,access_runbot_warning_user,runbot.model_runbot_warning,runbot.group_user,1,0,0,0
 access_runbot_warning_admin,access_runbot_warning_admin,runbot.model_runbot_warning,runbot.group_runbot_admin,1,1,1,1

--- a/runbot/tests/test_batch.py
+++ b/runbot/tests/test_batch.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 
 from odoo import fields
+from odoo.exceptions import AccessError
+from odoo.tests.common import new_test_user
 
 from .common import RunbotCase
 
@@ -18,3 +20,29 @@ class TestBatch(RunbotCase):
         batch.last_update = fields.Datetime.now() - timedelta(seconds=120)
         batch._process()
         self.assertEqual(batch.state, 'ready')
+
+class TestBatchLog(RunbotCase):
+
+    def test_batch_log_write(self):
+        """ test that a runbot manager can write a batch log """
+        self.additionnal_setup()
+
+        create_context = {'no_reset_password': True, 'mail_create_nolog': True, 'mail_create_nosubscribe': True, 'mail_notrack': True}
+        simple_user = new_test_user(self.env, login='simple', name='simple', password='simple', context=create_context)
+        runbot_admin = new_test_user(self.env, groups='runbot.group_runbot_admin,base.group_user', login='runbot_admin', name='runbot_admin', password='admin', context=create_context)
+
+        # Ensure that a simple user cannot interfere in batch logs
+        with self.assertRaises(AccessError):
+            self.env['runbot.batch.log'].with_user(simple_user).create({
+                'batch_id': self.branch_server.bundle_id.last_batch.id,
+                'message': 'test_message',
+                'level': 'INFO'
+            })
+
+        test_batch_log = self.env['runbot.batch.log'].with_user(runbot_admin).create({
+                'batch_id': self.branch_server.bundle_id.last_batch.id,
+                'message': 'test_message',
+                'level': 'INFO'
+            })
+
+        self.assertEqual(test_batch_log.message, 'test_message')


### PR DESCRIPTION
When a runbot admin creates a cron for e.g. nightly builds, the cron may
fails if a runbot.batch.log is written.

With this commit, a runbot admin can create such a log.