### PR TITLE
[IMP] conftest: reduce log spam in test results

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,8 @@ Configuration:
   ``role_reviewer``, ``role_self_reviewer`` and ``role_other``
     - name (optional, used as partner name when creating that, otherwise github
       login gets used)
+    - email (optional, used as partner email when creating that, otherwise
+      github email gets used, reviewer and self-reviewer must have an email)
     - token, a personal access token with the ``public_repo`` scope (otherwise
       the API can't leave comments), maybe eventually delete_repo (for personal
       forks)
@@ -44,6 +46,7 @@ import collections
 import configparser
 import contextlib
 import copy
+import functools
 import http.client
 import itertools
 import os
@@ -136,14 +139,16 @@ def rolemap(request, config):
 
 @pytest.fixture
 def partners(env, config, rolemap):
-    m = dict.fromkeys(rolemap.keys(), env['res.partner'])
+    m = {}
     for role, u in rolemap.items():
         if role in ('user', 'other'):
             continue
 
         login = u['login']
+        conf = config['role_' + role]
         m[role] = env['res.partner'].create({
-            'name': config['role_' + role].get('name', login),
+            'name': conf.get('name', login),
+            'email': conf.get('email') or u['email'] or False,
             'github_login': login,
         })
     return m

--- a/conftest.py
+++ b/conftest.py
@@ -1120,17 +1120,18 @@ class Model:
     def __getattr__(self, fieldname):
         if fieldname in ['__dataclass_fields__', '__attrs_attrs__']:
             raise AttributeError('%r is invalid on %s' % (fieldname, self._model))
+
+        field_description = self._fields.get(fieldname)
+        if field_description is None:
+            return functools.partial(self._call, fieldname)
+
         if not self._ids:
             return False
 
-        assert len(self._ids) == 1
         if fieldname == 'id':
             return self._ids[0]
 
-        try:
-            val = self.read([fieldname])[0][fieldname]
-        except Exception:
-            raise AttributeError('%r is invalid on %s' % (fieldname, self._model))
+        val = self.read([fieldname])[0][fieldname]
         field_description = self._fields[fieldname]
         if field_description['type'] in ('many2one', 'one2many', 'many2many'):
             val = val or []

--- a/forwardport/__init__.py
+++ b/forwardport/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import controllers

--- a/forwardport/changelog/2021-09/authorship-dedup.md
+++ b/forwardport/changelog/2021-09/authorship-dedup.md
@@ -1,0 +1,1 @@
+FIX: the deduplication of authorship in case of conflicts in multi-commit PRs

--- a/forwardport/changelog/2021-09/authorship.md
+++ b/forwardport/changelog/2021-09/authorship.md
@@ -1,0 +1,1 @@
+FIX: loss of authorship on conflicts in multi-commit PRs, such conflicts now generate a commit with no authorship information, which can not be merged

--- a/forwardport/changelog/2021-09/conflict-view.md
+++ b/forwardport/changelog/2021-09/conflict-view.md
@@ -1,0 +1,1 @@
+ADD: better localisation of conflicts in multi-PR commits, list all the commits in the comment and add an arrow pointing to the one which broke

--- a/forwardport/changelog/2021-09/draft.md
+++ b/forwardport/changelog/2021-09/draft.md
@@ -1,0 +1,1 @@
+REM: creation of forward ports in draft mode

--- a/forwardport/changelog/2021-09/feedback-missing-login.md
+++ b/forwardport/changelog/2021-09/feedback-missing-login.md
@@ -1,0 +1,1 @@
+FIX: some feedback messages didn't correctly ping the person being replied to

--- a/forwardport/changelog/2021-09/followup-conflict.md
+++ b/forwardport/changelog/2021-09/followup-conflict.md
@@ -1,0 +1,1 @@
+IMP: properly notify the user when an update to a pull request causes a conflict when impacted on the followup

--- a/forwardport/changelog/2021-09/fp-remote-view.md
+++ b/forwardport/changelog/2021-09/fp-remote-view.md
@@ -1,0 +1,1 @@
+IMP: add the forward-port remote to the repository view, so it can be set via the UI

--- a/forwardport/changelog/2021-09/fwbot-rplus-error.md
+++ b/forwardport/changelog/2021-09/fwbot-rplus-error.md
@@ -1,0 +1,1 @@
+IMP: error messages when trying to `@fw-bot r+` on pull requests not under its purview

--- a/forwardport/changelog/2021-09/outstanding.md
+++ b/forwardport/changelog/2021-09/outstanding.md
@@ -1,0 +1,1 @@
+ADD: list of outstanding forward-ports

--- a/forwardport/changelog/2021-10/delegate-followup.md
+++ b/forwardport/changelog/2021-10/delegate-followup.md
@@ -1,0 +1,1 @@
+FIX: allow delegate reviewers *on forward ports* to approve the followups, it worked fine for delegates on the original pull request but a delegation on a forward port would only work for that specific PR (note: only works if the followups don't already exist)

--- a/forwardport/changelog/2021-10/followupdate-race.md
+++ b/forwardport/changelog/2021-10/followupdate-race.md
@@ -1,0 +1,1 @@
+FIX: rare condition where updating a forwardport would then require all followups to be individually approved

--- a/forwardport/changelog/2021-10/fw-reapproval.md
+++ b/forwardport/changelog/2021-10/fw-reapproval.md
@@ -1,0 +1,1 @@
+FIX: don't trigger an error message when using `fw-bot r+` and some of the PRs were already approved

--- a/forwardport/changelog/2021-10/outstanding-layout.md
+++ b/forwardport/changelog/2021-10/outstanding-layout.md
@@ -1,0 +1,1 @@
+IMP: layout and features of the "outstanding forward port" page, show the oldest-merged PRs first and allow filtering by reviewer

--- a/forwardport/controllers.py
+++ b/forwardport/controllers.py
@@ -1,0 +1,15 @@
+import pathlib
+
+from odoo.addons.runbot_merge.controllers.dashboard import MergebotDashboard
+
+class Dashboard(MergebotDashboard):
+    def _entries(self):
+        changelog = pathlib.Path(__file__).parent / 'changelog'
+        if not changelog.is_dir():
+            return super()._entries()
+
+        return super()._entries() + [
+            (d.name, [f.read_text(encoding='utf-8') for f in d.iterdir() if f.is_file()])
+            for d in changelog.iterdir()
+        ]
+

--- a/forwardport/data/views.xml
+++ b/forwardport/data/views.xml
@@ -13,7 +13,7 @@
                     ('source_id', '!=', False),
                     ('state', 'not in', ['merged', 'closed']),
                 ])"/>
-                <div t-if="outstanding != 0" class="alert col-md-12 bg-warning">
+                <div t-if="outstanding != 0" class="alert col-md-12 alert-warning mb-0">
                     <a href="/forwardport/outstanding">
                         <t t-esc="outstanding"/> outstanding forward-ports
                     </a>

--- a/forwardport/data/views.xml
+++ b/forwardport/data/views.xml
@@ -39,31 +39,51 @@
         <field name="arch" type="xml">
             <t name="Outstanding forward ports" t-name="forwardport.outstanding_fp">
                 <t t-call="website.layout">
+                    <t t-set="hof" t-value="env['runbot_merge.pull_requests']._hall_of_shame()"/>
                     <div id="wrap" class="oe_structure oe_empty"><div class="container-fluid">
+                        <ul class="alert bg-light list-inline">
+                            <span t-foreach="hof.reviewers" t-as="count" class="list-inline-item">
+                                <a t-attf-href="?reviewer={{count[0].id}}"
+                                   t-field="count[0].display_name"
+                                   t-att-title="count[1]"
+                                />
+                            </span>
+                        </ul>
                         <h1>List of pull requests with outstanding forward ports</h1>
-                        <dl><t t-foreach="env['runbot_merge.pull_requests']._outstanding()" t-as="x">
+                        <t t-set="reviewer" t-value="env['res.partner'].browse(int(request.params.get('reviewer') or 0))"/>
+                        <form method="get" action="" id="reset-filter"/>
+                        <h2 t-if="reviewer" class="text-muted">
+                            merged by <span t-field="reviewer.display_name" t-attf-title="@{{reviewer.github_login}}"/>
+                            <button form="reset-filter" type="submit"
+                                    name="reviewer" value=""
+                                    title="See All" class="btn fa fa-times"/>
+                        </h2>
+                        <dl><t t-foreach="hof.outstanding" t-as="x">
                             <t t-set="source" t-value="x[0]"/>
-                            <t t-set="prs" t-value="x[1]"/>
-                            <dt>
-                                <a t-att-href="source.url"><span t-field="source.display_name"/></a>
-                                by <span t-field="source.author.display_name"
-                                         t-attf-title="@{{source.author.github_login}}"/>
-                                merged <span t-field="source.merge_date"
-                                             t-options="{'widget': 'relative'}"
-                                             t-att-title="source.merge_date"/>
-                                by <span t-field="source.reviewed_by.display_name"
-                                         t-attf-title="@{{source.reviewed_by.github_login}}"/>
-                            </dt>
-                            <dd>
-                                Outstanding forward-ports:
-                                <ul>
-                                    <li t-foreach="prs" t-as="p">
-                                        <a t-att-href="p.url"><span t-field="p.display_name"/></a>
-                                        (<span t-field="p.state"/>)
-                                        targeting <span t-field="p.target.name"/>
-                                    </li>
-                                </ul>
-                            </dd>
+                            <t t-if="not reviewer or source.reviewed_by == reviewer">
+                                <dt>
+                                    <a t-att-href="source.url"><span t-field="source.display_name"/></a>
+                                    by <span t-field="source.author.display_name"
+                                             t-attf-title="@{{source.author.github_login}}"/>
+                                    merged <span t-field="source.merge_date"
+                                                 t-options="{'widget': 'relative'}"
+                                                 t-att-title="source.merge_date"/>
+                                    <t t-if="not reviewer">
+                                        by <span t-field="source.reviewed_by.display_name"
+                                                 t-attf-title="@{{source.reviewed_by.github_login}}"/>
+                                    </t>
+                                </dt>
+                                <dd>
+                                    Outstanding forward-ports:
+                                    <ul>
+                                        <li t-foreach="x.prs" t-as="p">
+                                            <a t-att-href="p.url"><span t-field="p.display_name"/></a>
+                                            (<span t-field="p.state"/>)
+                                            targeting <span t-field="p.target.name"/>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </t>
                         </t></dl>
                     </div></div>
                 </t>
@@ -78,6 +98,8 @@
                 <dd>
                     <span t-field="pr.merge_date" t-options="{'widget': 'relative'}"
                           t-att-title="pr.merge_date"/>
+                    by <span t-field="pr.reviewed_by.display_name"
+                             t-attf-title="@{{pr.reviewed_by.github_login}}"/>
                 </dd>
             </t>
             <t t-if="pr.source_id">

--- a/forwardport/models/project.py
+++ b/forwardport/models/project.py
@@ -34,6 +34,7 @@ from odoo.exceptions import UserError
 from odoo.tools import topological_sort, groupby
 from odoo.tools.appdirs import user_cache_dir
 from odoo.addons.runbot_merge import utils
+from odoo.addons.runbot_merge.models.pull_requests import RPLUS
 
 footer = '\nMore info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port\n'
 
@@ -339,7 +340,7 @@ class PullRequests(models.Model):
                     continue
                 merge_bot = self.repository.project_id.github_prefix
                 # don't update the root ever
-                for pr in filter(lambda p: p.parent_id, self._iter_ancestors()):
+                for pr in (p for p in self._iter_ancestors() if p.parent_id if p.state in RPLUS):
                     # only the author is delegated explicitely on the
                     pr._parse_commands(author, {**comment, 'body': merge_bot + ' r+'}, login)
             elif token == 'close':

--- a/forwardport/tests/test_simple.py
+++ b/forwardport/tests/test_simple.py
@@ -499,6 +499,81 @@ def signoff(conf, message):
     raise AssertionError("Failed to find signoff by %s in %s" % (conf, message))
 
 
+def test_delegate_fw(env, config, make_repo, users):
+    """If a user is delegated *on a forward port* they should be able to approve
+    *the followup*.
+    """
+    prod, _ = make_basic(env, config, make_repo)
+    # create a partner for `other` so we can put an email on it
+    env['res.partner'].create({
+        'name': users['other'],
+        'github_login': users['other'],
+        'email': 'other@example.org',
+    })
+    author_token = config['role_self_reviewer']['token']
+    fork = prod.fork(token=author_token)
+    with prod, fork:
+        [c] = fork.make_commits('a', Commit('c_0', tree={'y': '0'}), ref='heads/accessrights')
+        pr = prod.make_pr(
+            target='a', title='my change',
+            head=users['self_reviewer'] + ':accessrights',
+            token=author_token,
+        )
+        prod.post_status(c, 'success', 'legal/cla')
+        prod.post_status(c, 'success', 'ci/runbot')
+        pr.post_comment('hansen r+', token=config['role_reviewer']['token'])
+    env.run_crons()
+
+    with prod:
+        prod.post_status('staging.a', 'success', 'legal/cla')
+        prod.post_status('staging.a', 'success', 'ci/runbot')
+    env.run_crons()
+
+    # ensure pr1 has to be approved to be forward-ported
+    _, pr1_id = env['runbot_merge.pull_requests'].search([], order='number')
+    # detatch from source
+    pr1_id.parent_id = False
+    with prod:
+        prod.post_status(pr1_id.head, 'success', 'legal/cla')
+        prod.post_status(pr1_id.head, 'success', 'ci/runbot')
+    env.run_crons()
+    pr1 = prod.get_pr(pr1_id.number)
+    # delegate review to "other" consider PR fixed, and have "other" approve it
+    with prod:
+        pr1.post_comment('hansen delegate=' + users['other'],
+                         token=config['role_reviewer']['token'])
+        prod.post_status(pr1_id.head, 'success', 'ci/runbot')
+        pr1.post_comment('hansen r+', token=config['role_other']['token'])
+    env.run_crons()
+
+    with prod:
+        prod.post_status('staging.b', 'success', 'legal/cla')
+        prod.post_status('staging.b', 'success', 'ci/runbot')
+    env.run_crons()
+
+    _, _, pr2_id = env['runbot_merge.pull_requests'].search([], order='number')
+    pr2 = prod.get_pr(pr2_id.number)
+    # make "other" also approve this one
+    with prod:
+        prod.post_status(pr2_id.head, 'success', 'ci/runbot')
+        prod.post_status(pr2_id.head, 'success', 'legal/cla')
+        pr2.post_comment('hansen r+', token=config['role_other']['token'])
+    env.run_crons()
+
+    assert pr2.comments == [
+        seen(env, pr2, users),
+        (users['user'], '''Ping @{self_reviewer}, @{reviewer}
+This PR targets c and is the last of the forward-port chain.
+
+To merge the full chain, say
+> @{user} r+
+
+More info at https://github.com/odoo/odoo/wiki/Mergebot#forward-port
+'''.format_map(users)),
+        (users['other'], 'hansen r+')
+    ]
+
+
 def test_redundant_approval(env, config, make_repo, users):
     """If a forward port sequence has been partially approved, fw-bot r+ should
     not perform redundant approval as that triggers warning messages.

--- a/mergebot_test_utils/utils.py
+++ b/mergebot_test_utils/utils.py
@@ -8,7 +8,7 @@ MESSAGE_TEMPLATE = """{message}
 
 closes {repo}#{number}
 
-{headers}Signed-off-by: {name} <{login}@users.noreply.github.com>"""
+{headers}Signed-off-by: {name} <{email}>"""
 # target branch '-' source branch '-' base64 unique '-fw'
 REF_PATTERN = r'{target}-{source}-[a-zA-Z0-9_-]{{4}}-fw'
 

--- a/runbot_merge/changelog/2021-09/conflict_authorship.md
+++ b/runbot_merge/changelog/2021-09/conflict_authorship.md
@@ -1,0 +1,1 @@
+ADD: refuse merging commits without an email set, this is mostly to be used by the forwardport-bot

--- a/runbot_merge/changelog/2021-09/different_project_link.md
+++ b/runbot_merge/changelog/2021-09/different_project_link.md
@@ -1,0 +1,1 @@
+FIX: two PRs with the same label in different projects should not be considered linked anymore

--- a/runbot_merge/changelog/2021-09/drafts.md
+++ b/runbot_merge/changelog/2021-09/drafts.md
@@ -1,0 +1,1 @@
+ADD: mergebot should not accept merging draft PR anymore

--- a/runbot_merge/changelog/2021-09/fetch_closed.md
+++ b/runbot_merge/changelog/2021-09/fetch_closed.md
@@ -1,0 +1,1 @@
+FIX: when fetching an unknown PR and it's closed, don't lose that information

--- a/runbot_merge/changelog/2021-09/persistent_linked_prs.md
+++ b/runbot_merge/changelog/2021-09/persistent_linked_prs.md
@@ -1,0 +1,1 @@
+IMP: keep showing linked PRs after a PR has been merged

--- a/runbot_merge/changelog/2021-09/rebase_tagging.md
+++ b/runbot_merge/changelog/2021-09/rebase_tagging.md
@@ -1,0 +1,1 @@
+ADD: when integrating a PR via rebasing, tag all the commits with the source PR so they're easier to find

--- a/runbot_merge/changelog/2021-09/staging_failure_message.md
+++ b/runbot_merge/changelog/2021-09/staging_failure_message.md
@@ -1,0 +1,1 @@
+FIX: when a PR fails at staging, link the correct status in the message posted on the PR

--- a/runbot_merge/changelog/2021-09/timestamps.md
+++ b/runbot_merge/changelog/2021-09/timestamps.md
@@ -1,0 +1,1 @@
+IMP: cleanup timestamp displays, always show the tzoffset, UTC on hover in the main page (easier to relate to logs), local in the per-branch listing

--- a/runbot_merge/changelog/2021-10/changelog.md
+++ b/runbot_merge/changelog/2021-10/changelog.md
@@ -1,0 +1,1 @@
+ADD: a changelog feature you can now see here

--- a/runbot_merge/changelog/2021-10/commit-title-edition.md
+++ b/runbot_merge/changelog/2021-10/commit-title-edition.md
@@ -1,0 +1,1 @@
+FIX: don't rewrite commit titles, this can lead to odd effects when it's incorrectly formatted and interpreted as a pseudo-header

--- a/runbot_merge/changelog/2021-10/pr_description_up_to_date.md
+++ b/runbot_merge/changelog/2021-10/pr_description_up_to_date.md
@@ -1,0 +1,1 @@
+FIX: ensure the merge message matches the up-to-date PR descriptions, the two could desync if we'd missed an update

--- a/runbot_merge/changelog/2021-10/pr_errors.md
+++ b/runbot_merge/changelog/2021-10/pr_errors.md
@@ -1,0 +1,1 @@
+FIX: correctly display the error message when a PR is in error

--- a/runbot_merge/changelog/2021-10/pr_page.md
+++ b/runbot_merge/changelog/2021-10/pr_page.md
@@ -1,0 +1,1 @@
+IMP: add reviewer and direct link to backend in PR pages

--- a/runbot_merge/changelog/2021-10/review-without-email.md
+++ b/runbot_merge/changelog/2021-10/review-without-email.md
@@ -1,0 +1,1 @@
+CHG: reject reviewers without an email configured, the fallback to `@users.noreply.github.com` turns out to be confusing

--- a/runbot_merge/changelog/2021-10/reviewer-merge-methods.md
+++ b/runbot_merge/changelog/2021-10/reviewer-merge-methods.md
@@ -1,0 +1,1 @@
+IMP: allow delegate reviewers to set merge methods

--- a/runbot_merge/changelog/2021-10/squash.md
+++ b/runbot_merge/changelog/2021-10/squash.md
@@ -1,0 +1,1 @@
+ADD: squash-mode, currently only for single-commit PRs to make it easier to edit commit messages when they're incorrectly formatted

--- a/runbot_merge/controllers/dashboard.py
+++ b/runbot_merge/controllers/dashboard.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
+import collections
 import json
+import pathlib
 
+import markdown
+import markupsafe
 import werkzeug.exceptions
+from lxml import etree
+from lxml.builder import ElementMaker
 
 from odoo.http import Controller, route, request
 
+A = ElementMaker(namespace="http://www.w3.org/2005/Atom")
 LIMIT = 20
 class MergebotDashboard(Controller):
     @route('/runbot_merge', auth="public", type="http", website=True)
@@ -24,6 +31,29 @@ class MergebotDashboard(Controller):
             'branch': request.env['runbot_merge.branch'].browse(branch_id).sudo(),
             'stagings': stagings[:LIMIT],
             'next': stagings[-1].staged_at if len(stagings) > LIMIT else None,
+        })
+
+    def _entries(self):
+        changelog = pathlib.Path(__file__).parent.parent / 'changelog'
+        if changelog.is_dir():
+            return [
+                (d.name, [f.read_text(encoding='utf-8') for f in d.iterdir() if f.is_file()])
+                for d in changelog.iterdir()
+            ]
+        return []
+
+    def entries(self, item_converter):
+        entries = collections.OrderedDict()
+        for key, items in sorted(self._entries(), reverse=True):
+            entries.setdefault(key, []).extend(map(item_converter, items))
+        return entries
+
+    @route('/runbot_merge/changelog', auth='public', type='http', website=True)
+    def changelog(self):
+        md = markdown.Markdown(extensions=['nl2br'], output_format='html5')
+        entries = self.entries(lambda t: markupsafe.Markup(md.convert(t)))
+        return request.render('runbot_merge.changelog', {
+            'entries': entries,
         })
 
     @route('/<org>/<repo>/pull/<int(min=1):pr>', auth='public', type='http', website=True)

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -1005,12 +1005,14 @@ class PullRequests(models.Model):
                 elif param and is_reviewer:
                     oldstate = self.state
                     newstate = RPLUS.get(self.state)
-                    if newstate:
+                    if not author.email:
+                        msg = "I must know your email before you can review PRs. Please contact an administrator."
+                    elif not newstate:
+                        msg = "This PR is already reviewed, reviewing it again is useless."
+                    else:
                         self.state = newstate
                         self.reviewed_by = author
                         ok = True
-                    else:
-                        msg = "This PR is already reviewed, reviewing it again is useless."
                     _logger.debug(
                         "r+ on %s by %s (%s->%s) status=%s message? %s",
                         self.display_name, author.github_login,

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -534,15 +534,13 @@ class Branch(models.Model):
             try:
                 staged |= Batch.stage(meta, batch)
             except exceptions.MergeError as e:
+                pr = e.args[0]
+                _logger.exception("Failed to merge %s into staging branch", pr.display_name)
                 if first or isinstance(e, exceptions.Unmergeable):
-                    pr = e.args[0]
                     if len(e.args) > 1 and e.args[1]:
                         message = e.args[1]
                     else:
                         message = "Unable to stage PR (%s)" % e.__context__
-                        _logger.exception(
-                            "Failed to merge %s into staging branch",
-                            pr.display_name)
                     pr.state = 'error'
                     self.env['runbot_merge.pull_requests.feedback'].create({
                         'repository': pr.repository.id,

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -2232,7 +2232,9 @@ class Message:
         msg, handle_break = (msg, False) if isinstance(msg, str) else (msg.message, True)
         headers = []
         body = []
-        for line in reversed(msg.splitlines()):
+        # don't process the title (first line) of the commit message
+        msg = msg.splitlines()
+        for line in reversed(msg[1:]):
             if maybe_setex:
                 # NOTE: actually slightly more complicated: it's a SETEX heading
                 #       only if preceding line(s) can be interpreted as a
@@ -2268,6 +2270,10 @@ class Message:
             body.append(line)
             in_headers = False
 
+        # if there are non-title body lines, add a separation after the title
+        if body and body[-1]:
+            body.append('')
+        body.append(msg[0])
         return cls('\n'.join(reversed(body)), Headers(reversed(headers)))
 
     def __init__(self, body, headers=None):

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -1064,7 +1064,7 @@ class PullRequests(models.Model):
                             author.github_login, self.target.name,
                         )
             elif command == 'method':
-                if is_admin:
+                if is_reviewer:
                     self.merge_method = param
                     ok = True
                     explanation = next(label for value, label in type(self).merge_method.selection if value == param)

--- a/runbot_merge/models/res_partner.py
+++ b/runbot_merge/models/res_partner.py
@@ -1,5 +1,9 @@
+import random
 from email.utils import parseaddr
+
 from odoo import fields, models, tools, api
+
+from .. import github
 
 class CIText(fields.Char):
     type = 'char'
@@ -31,6 +35,14 @@ class Partner(models.Model):
             else:
                 email = ''
             partner.formatted_email = '%s <%s>' % (partner.name, email)
+
+    def fetch_github_email(self):
+        # this requires a token in order to fetch the email field, otherwise
+        # it's just not returned, select a random project to fetch
+        gh = github.GH(random.choice(self.env['runbot_merge.project'].search([])).github_token, None)
+        for p in self.filtered(lambda p: p.github_login and p.email is False):
+            p.email = gh.user(p.github_login)['email'] or False
+        return False
 
 class PartnerMerge(models.TransientModel):
     _inherit = 'base.partner.merge.automatic.wizard'

--- a/runbot_merge/tests/test_oddities.py
+++ b/runbot_merge/tests/test_oddities.py
@@ -19,7 +19,7 @@ def test_partner_merge(env):
         'state': 'selection',
         'partner_ids': (p_src + p_dest).ids,
         'dst_partner_id': p_dest.id,
-    })._call('action_merge')
+    }).action_merge()
     assert not p_src.exists()
     assert p_dest.name == 'Partner P. Partnersson'
     assert p_dest.github_login == 'xxx'

--- a/runbot_merge/views/res_partner.xml
+++ b/runbot_merge/views/res_partner.xml
@@ -18,6 +18,14 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <header>
+                    <button type="object" name="fetch_github_email"
+                            string="Fetch Github Email" class="oe_highlight"
+                            attrs="{'invisible': ['|', ('email', '!=', False), ('github_login', '=', False)]}"
+                    />
+                </header>
+            </xpath>
             <xpath expr="//notebook" position="inside">
                 <page string="Mergebot" groups="runbot_merge.group_admin">
                     <group>

--- a/runbot_merge/views/templates.xml
+++ b/runbot_merge/views/templates.xml
@@ -393,9 +393,13 @@
     <template id="view_pull_request">
         <t t-call="website.layout">
             <div id="wrap"><div class="container-fluid">
-                <a t-att-href="pr.github_url">
-                    <h1 t-field="pr.display_name"/>
+                <h1>
+                <a t-att-href="pr.github_url" t-field="pr.display_name">
                 </a>
+                <a t-attf-href="/web#view_type=form&amp;model=runbot_merge.pull_requests&amp;id={{pr.id}}"
+                    class="btn btn-sm btn-secondary align-top float-right"
+                    groups="base.group_user">View in backend</a>
+                </h1>
                 <h6>Created by <span t-field="pr.author.display_name"/></h6>
                 <t t-set="tmpl">
                     <t t-if="pr.state in ('merged', 'closed', 'error')"><t t-esc="pr.state"/></t>

--- a/runbot_merge/views/templates.xml
+++ b/runbot_merge/views/templates.xml
@@ -14,12 +14,15 @@
         <t t-call="website.layout">
             <div id="wrap"><div class="container-fluid">
                 <div id="alerts" class="row text-center">
+                    <div class="alert alert-light col-md-12 h6 mb-0">
+                        <a href="/runbot_merge/changelog">Changelog</a>
+                    </div>
                     <t t-set="stagingcron" t-value="env(user=1).ref('runbot_merge.staging_cron')"/>
-                    <div t-if="not stagingcron.active" class="alert alert-warning col-12" role="alert">
+                    <div t-if="not stagingcron.active" class="alert alert-warning col-12 mb-0" role="alert">
                         Staging is disabled, "ready" pull requests will not be staged.
                     </div>
                     <t t-set="mergecron" t-value="env(user=1).ref('runbot_merge.merge_cron')"/>
-                    <div t-if="not mergecron.active" class="alert alert-warning col-12" role="alert">
+                    <div t-if="not mergecron.active" class="alert alert-warning col-12 mb-0" role="alert">
                         Merging is disabled, stagings will not be disabled.
                     </div>
                 </div>
@@ -297,6 +300,21 @@
                         Next >
                     </a>
                 </t>
+            </div></div>
+        </t>
+    </template>
+    <template id="changelog" name="mergebot changelog">
+        <t t-call="website.layout">
+            <div id="wrap"><div class="container-fluid">
+                <h1>Changelog</h1>
+                <section t-foreach="entries" t-as="entry">
+                    <h3 t-if="not entry_first" t-esc="entry"/>
+                    <ul>
+                        <li t-foreach="sorted(entry_value)" t-as="item">
+                            <t t-raw="item"/>
+                        </li>
+                    </ul>
+                </section>
             </div></div>
         </t>
     </template>


### PR DESCRIPTION
Avoid logging below warning during the creation of the template db,
and don't emit `odoo.modules.loading` during tests.

That reduces log-spam a lot and makes tests results way more
readable (in case of failure, where the logs of the subprocess get
printed out).