### PR TITLE
[IMP] runbot: create a separate process for cron

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -756,6 +756,11 @@ class BuildResult(models.Model):
                 self._log('_checkout', 'Multiple repo have same export path in build, some source may be missing for %s' % build_export_path, level='ERROR')
                 self._kill(result='ko')
             exports[build_export_path] = commit.export()
+
+        checkout_time = time.time() - start
+        if checkout_time > 60:
+            self._log('checkout', 'Checkout took %s seconds' % int(checkout_time))
+
         return exports
 
     def _get_available_modules(self):

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -308,8 +308,6 @@ class ConfigStep(models.Model):
                 return
 
         exports = build._checkout()
-        # update job_start AFTER checkout to avoid build being killed too soon if checkout took some time and docker take some time to start
-        build.job_start = now()
 
         # adjust job_end to record an accurate job_20 job_time
         build._log('run', 'Start running build %s' % build.dest)
@@ -358,8 +356,6 @@ class ConfigStep(models.Model):
 
     def _run_install_odoo(self, build, log_path):
         exports = build._checkout()
-        # update job_start AFTER checkout to avoid build being killed too soon if checkout took some time and docker take some time to start
-        build.job_start = now()
 
         modules_to_install = self._modules_to_install(build)
         mods = ",".join(modules_to_install)

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -72,6 +72,7 @@ class Host(models.Model):
 
     def _docker_build(self):
         """ build docker images needed by locally pending builds"""
+        _logger.info('Building docker image...')
         self.ensure_one()
         static_path = self._get_work_path()
         self.clear_caches()  # needed to ensure that content is updated on all hosts

--- a/runbot/static/src/css/runbot.scss
+++ b/runbot/static/src/css/runbot.scss
@@ -228,3 +228,28 @@ body, .table{
         padding: 0;
     }
 }
+.limited-height {
+    max-height: 180px;
+    overflow: scroll;
+
+    >hr {
+        margin: 2px 0px;
+    }
+    &:before {
+        content:'';
+        width:100%;
+        height:30px;
+        position:absolute;
+        left:0;
+        bottom:0;
+        background:linear-gradient(transparent 0px, white 27px);
+    }
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+.limited-height::-webkit-scrollbar {
+    display: none;
+}
+.limited-height-toggle:hover {
+    background-color: #DDD;
+}

--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -185,12 +185,12 @@
     </template>
 
     <template id="runbot.default_dashboard_tile_view">
-      <div class="col-sm-3">
+      <div class="col-md-3 col-lg-2 p-2">
         <div class="card">
-          <div class="card-header">
-            <t t-esc="tile.display_name"/>
+          <div class="card-header limited-height-toggle" t-attf-onclick="$('#tile_{{tile.id}}').toggleClass('limited-height')">
+            <t t-esc="tile.display_name"/> <t t-if="tile.build_ids"> (<t t-esc="len(tile.build_ids)"/>)</t>
           </div>
-          <div class="card-body">
+          <div class="card-body limited-height" t-attf-id="tile_{{tile.id}}">
             <p t-if="not tile.build_ids" class="text-success my-0">No build found 👍</p>
             <t t-foreach="tile.sticky_bundle_ids.sorted(lambda b: b.version_id.number, reverse=True)" t-as="bundle">
               <t t-set="failed_builds" t-value="tile.build_ids.filtered(lambda b: b.top_parent.slot_ids.batch_id.bundle_id == bundle)"/>
@@ -201,6 +201,7 @@
                   </a>
               </p>
             </t>
+            <hr/>
           </div>
         </div>
       </div>

--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -1,122 +1,23 @@
 #!/usr/bin/python3
-import argparse
+from tools import RunbotClient, run
 import logging
-import os
-import sys
-import threading
-import signal
-
-from logging.handlers import WatchedFileHandler
-
-LOG_FORMAT = '%(asctime)s %(levelname)s %(name)s: %(message)s'
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
-logging.getLogger('odoo.addons.runbot').setLevel(logging.DEBUG)
-logging.addLevelName(25, "!NFO")
 
 _logger = logging.getLogger(__name__)
 
+class BuilderClient(RunbotClient):
 
-class RunbotClient():
+    def on_start(self):
+        self.env['runbot.repo'].search([('mode', '!=', 'disabled')])._update()
 
-    def __init__(self, env):
-        self.env = env
-        self.ask_interrupt = threading.Event()
-
-    def main_loop(self):
-        from odoo import fields
-        signal.signal(signal.SIGINT, self.signal_handler)
-        signal.signal(signal.SIGTERM, self.signal_handler)
-        signal.signal(signal.SIGQUIT, self.dump_stack)
-        host = self.env['runbot.host']._get_current()
-        host._bootstrap()
-        count = 0
-        while True:
-            try:
-                host.last_start_loop = fields.Datetime.now()
-                count = count % 60
-                if count == 0:
-                    logging.info('Host %s running with %s slots on pid %s%s', host.name, host.nb_worker, os.getpid(), ' (assigned only)' if host.assigned_only else '')
-                    self.env['runbot.runbot']._source_cleanup()
-                    self.env['runbot.build']._local_cleanup()
-                    self.env['runbot.runbot']._docker_cleanup()
-                    host.set_psql_conn_count()
-                    _logger.info('Building docker image...')
-                    host._docker_build()
-                    _logger.info('Scheduling...')
-                count += 1
-                sleep_time = self.env['runbot.runbot']._scheduler_loop_turn(host)
-                host.last_end_loop = fields.Datetime.now()
-                self.env.cr.commit()
-                self.env.clear()
-                self.sleep(sleep_time)
-            except Exception as e:
-                _logger.exception('Builder main loop failed with: %s', e)
-                self.env.cr.rollback()
-                self.env.clear()
-                self.sleep(10)
-
-            if self.ask_interrupt.is_set():
-                return
-
-    def signal_handler(self, signal, frame):
-        if self.ask_interrupt.is_set():
-            _logger.info("Second Interrupt detected, force exit")
-            os._exit(1)
-
-        _logger.info("Interrupt detected")
-        self.ask_interrupt.set()
-
-    def dump_stack(self, signal, frame):
-        import odoo
-        odoo.tools.misc.dumpstacks()
-
-    def sleep(self, t):
-        self.ask_interrupt.wait(t)
-
-
-def run():
-    # parse args
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--odoo-path', help='Odoo sources path')
-    parser.add_argument('--db_host', default='127.0.0.1')
-    parser.add_argument('--db_port', default='5432')
-    parser.add_argument('--db_user')
-    parser.add_argument('--db_password')
-    parser.add_argument('-d', '--database', default='runbot', help='name of runbot db')
-    parser.add_argument('--logfile', default=False)
-    args = parser.parse_args()
-    if args.logfile:
-        dirname = os.path.dirname(args.logfile)
-        if dirname and not os.path.isdir(dirname):
-            os.makedirs(dirname)
-
-        handler = WatchedFileHandler(args.logfile)
-        formatter = logging.Formatter(LOG_FORMAT)
-        handler.setFormatter(formatter)
-        logging.getLogger().addHandler(handler)
-
-    # configure odoo
-    sys.path.append(args.odoo_path)
-    import odoo
-    _logger.info("Starting scheduler on database %s", args.database)
-    odoo.tools.config['db_host'] = args.db_host
-    odoo.tools.config['db_port'] = args.db_port
-    odoo.tools.config['db_user'] = args.db_user
-    odoo.tools.config['db_password'] = args.db_password
-    addon_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
-    config_addons_path = odoo.tools.config['addons_path']
-    odoo.tools.config['addons_path'] = ','.join([config_addons_path, addon_path])
-
-    # create environment
-    registry = odoo.registry(args.database)
-    with odoo.api.Environment.manage():
-        with registry.cursor() as cr:
-            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
-            runbot_client = RunbotClient(env)
-            # run main loop
-            runbot_client.main_loop()
+    def loop_turn(self):
+        if self.count == 1: # cleanup at second iteration
+            self.env['runbot.runbot']._source_cleanup()
+            self.env['runbot.build']._local_cleanup()
+            self.env['runbot.runbot']._docker_cleanup()
+            self.host.set_psql_conn_count()
+            self.host._docker_build()
+        return self.env['runbot.runbot']._scheduler_loop_turn(self.host)
 
 
 if __name__ == '__main__':
-    run()
-    _logger.info("Stopping gracefully")
+    run(BuilderClient)

--- a/runbot_builder/leader.py
+++ b/runbot_builder/leader.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+from tools import RunbotClient, run
+import logging
+import time
+
+_logger = logging.getLogger(__name__)
+
+class LeaderClient(RunbotClient):  # Conductor, Director, Main, Maestro, Lead
+    def __init__(self, env):
+        self.pull_info_failures = {}
+        super().__init__(env)
+
+    def loop_turn(self):
+        return self.env['runbot.runbot']._fetch_loop_turn(self.host, self.pull_info_failures)
+
+
+if __name__ == '__main__':
+    run(LeaderClient)

--- a/runbot_builder/tester.py
+++ b/runbot_builder/tester.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+from tools import RunbotClient, run
+import logging
+
+_logger = logging.getLogger(__name__)
+
+class TesterClient(RunbotClient):
+
+    def loop_turn(self):
+        _logger.info('='*50)
+        _logger.info('Testing: %s', self.env['runbot.build'].search_count([('local_state', '=', 'testing')]))
+        _logger.info('Pending: %s', self.env['runbot.build'].search_count([('local_state', '=', 'pending')]))
+        return 10
+
+if __name__ == '__main__':
+    run(TesterClient)

--- a/runbot_builder/tools.py
+++ b/runbot_builder/tools.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python3
+import argparse
+import logging
+import os
+import sys
+import threading
+import signal
+
+from logging.handlers import WatchedFileHandler
+
+LOG_FORMAT = '%(asctime)s %(levelname)s %(name)s: %(message)s'
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logging.getLogger('odoo.addons.runbot').setLevel(logging.DEBUG)
+logging.addLevelName(25, "!NFO")
+
+_logger = logging.getLogger(__name__)
+
+
+class RunbotClient():
+
+    def __init__(self, env):
+        self.env = env
+        self.ask_interrupt = threading.Event()
+        self.host = None
+        self.count = 0
+        self.max_count = 60
+
+    def on_start(self):
+        pass
+
+    def main_loop(self):
+        from odoo import fields
+        self.on_start()
+        signal.signal(signal.SIGINT, self.signal_handler)
+        signal.signal(signal.SIGTERM, self.signal_handler)
+        signal.signal(signal.SIGQUIT, self.dump_stack)
+        self.host = self.env['runbot.host']._get_current()
+        self.host._bootstrap()
+        logging.info(
+            'Host %s running with %s slots on pid %s%s',
+            self.host.name,
+            self.host.nb_worker,
+            os.getpid(),
+            ' (assigned only)' if self.host.assigned_only else ''
+        )
+        while True:
+            try:
+                self.host.last_start_loop = fields.Datetime.now()
+                self.count = self.count % self.max_count
+                sleep_time = self.loop_turn()
+                self.count += 1
+                self.host.last_end_loop = fields.Datetime.now()
+                self.env.cr.commit()
+                self.env.clear()
+                self.sleep(sleep_time)
+            except Exception as e:
+                _logger.exception('Builder main loop failed with: %s', e)
+                self.env.cr.rollback()
+                self.env.clear()
+                self.sleep(10)
+            if self.ask_interrupt.is_set():
+                return
+
+    def loop_turn(self):
+        raise NotImplementedError()
+
+    def signal_handler(self, _signal, _frame):
+        if self.ask_interrupt.is_set():
+            _logger.info("Second Interrupt detected, force exit")
+            os._exit(1)
+
+        _logger.info("Interrupt detected")
+        self.ask_interrupt.set()
+
+    def dump_stack(self, _signal, _frame):
+        import odoo
+        odoo.tools.misc.dumpstacks()
+
+    def sleep(self, t):
+        self.ask_interrupt.wait(t)
+
+
+def run(client_class):
+    # parse args
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--odoo-path', help='Odoo sources path')
+    parser.add_argument('--db_host')
+    parser.add_argument('--db_port')
+    parser.add_argument('--db_user')
+    parser.add_argument('--db_password')
+    parser.add_argument('-d', '--database', default='runbot', help='name of runbot db')
+    parser.add_argument('--logfile', default=False)
+    args = parser.parse_args()
+    if args.logfile:
+        dirname = os.path.dirname(args.logfile)
+        if dirname and not os.path.isdir(dirname):
+            os.makedirs(dirname)
+
+        handler = WatchedFileHandler(args.logfile)
+        formatter = logging.Formatter(LOG_FORMAT)
+        handler.setFormatter(formatter)
+        logging.getLogger().addHandler(handler)
+
+    # configure odoo
+    sys.path.append(args.odoo_path)
+    import odoo
+    _logger.info("Starting scheduler on database %s", args.database)
+    odoo.tools.config['db_host'] = args.db_host
+    odoo.tools.config['db_port'] = args.db_port
+    odoo.tools.config['db_user'] = args.db_user
+    odoo.tools.config['db_password'] = args.db_password
+    addon_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+    config_addons_path = odoo.tools.config['addons_path']
+    odoo.tools.config['addons_path'] = ','.join([config_addons_path, addon_path])
+
+    # create environment
+    registry = odoo.registry(args.database)
+    with odoo.api.Environment.manage():
+        with registry.cursor() as cr:
+            env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+            client = client_class(env)
+            # run main loop
+            client.main_loop()
+    _logger.info("Stopping gracefully")


### PR DESCRIPTION
As for the builder, this give the ability to run the discovery of new
commits and all related logic in a separate process.

This will mainly be usefull to restart frontend without waiting for cron
or restart "leader" without stoping the frontend. This will also be
usefull for optimisation purpose.