### PR TITLE
[FIX] runbot: set version_id for new base bundles

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -157,6 +157,7 @@ class Branch(models.Model):
                 }
                 if need_new_base:
                     values['is_base'] = True
+                    values['version_id'] = self.env['runbot.version']._get(name)
 
                 if branch.is_pr and branch.target_branch_name:  # most likely external_pr, use target as version
                     base = self.env['runbot.bundle'].search([


### PR DESCRIPTION
In new installations of runbot this is necessary, otherwise the user will have to edit the base bundles manually to set the `version_id`.
I am not sure if there will be any unwanted side effects from this, e.g: creating versions for unnecessarily.

Closes #565