### PR TITLE
[IMP] runbot: add single branch repo

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -61,13 +61,17 @@ class Branch(models.Model):
             if branch.is_pr:
                 _, name = branch.pull_head_name.split(':')
                 if branch.pull_head_remote_id:
-                    branch.reference_name = name
+                    reference_name = name
                 else:
-                    branch.reference_name = branch.pull_head_name  # repo is not known, not in repo list must be an external pr, so use complete label
+                    reference_name = branch.pull_head_name  # repo is not known, not in repo list must be an external pr, so use complete label
                     #if ':patch-' in branch.pull_head_name:
                     #    branch.reference_name = '%s~%s' % (branch.pull_head_name, branch.name)
             else:
-                branch.reference_name = branch.name
+                reference_name = branch.name
+            forced_version = branch.remote_id.repo_id.single_version  # we don't add a depend on repo.single_version to avoid mass recompute of existing branches
+            if forced_version and not reference_name.startswith(f'{forced_version.name}-'):
+                reference_name = f'{forced_version.name}---{reference_name}'
+            branch.reference_name = reference_name
 
     @api.depends('name')
     def _compute_branch_infos(self, pull_info=None):

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -242,6 +242,7 @@ class Repo(models.Model):
     last_processed_hook_time = fields.Float('Last processed hook time')
     get_ref_time = fields.Float('Last refs db update', compute='_compute_get_ref_time')
     trigger_ids = fields.Many2many('runbot.trigger', relation='runbot_trigger_triggers', readonly=True)
+    single_version = fields.Many2one('runbot.version', "Single version", help="Limit the repo to a single version for non versionned repo")
     forbidden_regex = fields.Char('Forbidden regex', help="Regex that forid bundle creation if branch name is matching", tracking=True)
     invalid_branch_message = fields.Char('Forbidden branch message', tracking=True)
 

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -85,6 +85,7 @@
                 <field name="mode"/>
                 <field name="forbidden_regex"/>
                 <field name="invalid_branch_message"/>
+                <field name="single_version"/>
                 <field name="remote_ids">
                   <tree string="Remotes" editable="bottom">
                     <field name="name"/>


### PR DESCRIPTION
Right now single version repo like upgrade are managed using
a regex to limit name prefix, this avoid grouping branches when
mergebot wont be able to merge them together but the ci can be painfull
since the branch needs to be renamed (closing existing pr) or a manual
operation to move the branch into a new bundle must be performed.
This commit proposes to replace the forbidden_regex mechanism with
an explicit single_version mechanism.
In this case the reference name will be automatically prefixes with
the version. The name is also suffixed with `-()` to indicate that some
magic was applied.