### PR TITLE
[FIX] runbot: manage or in debian/controll

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -222,6 +222,9 @@ class Branch(models.Model):
                 self.bundle_id.defined_base_id = base.id
                 self.bundle_id._force()
 
+        if self.draft:
+            self.reviewers = ''  # reset reviewers on draft
+
         if (not self.draft and was_draft) or (self.alive and not was_alive) or (self.target_branch_name != init_target_branch_name and self.alive):
             self.bundle_id._force()
 

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -1,9 +1,11 @@
 import logging
 from odoo import models, fields, api
+from odoo.tools import config
 from ..common import fqdn, local_pgadmin_cursor, os
 from ..container import docker_build
 _logger = logging.getLogger(__name__)
 
+forced_host_name = None
 
 class Host(models.Model):
     _name = 'runbot.host'
@@ -94,8 +96,8 @@ class Host(models.Model):
         return os.path.abspath(os.path.join(os.path.dirname(__file__), '../static'))
 
     @api.model
-    def _get_current(self, suffix=''):
-        name = '%s%s' % (fqdn(), suffix)
+    def _get_current(self):
+        name = config.get('forced_host_name') or fqdn()
         return self.search([('name', '=', name)]) or self.create({'name': name})
 
     def get_running_max(self):

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -366,7 +366,7 @@ class Repo(models.Model):
                 if not git_refs:
                     return []
                 refs = [tuple(field for field in line.split('\x00')) for line in git_refs.split('\n')]
-                refs = [r for r in refs if dateutil.parser.parse(r[2][:19]) + datetime.timedelta(days=max_age) > datetime.datetime.now() or self.env['runbot.branch'].match_is_base(r[0])]
+                refs = [r for r in refs if dateutil.parser.parse(r[2][:19]) + datetime.timedelta(days=max_age) > datetime.datetime.now() or self.env['runbot.branch'].match_is_base(r[0].split('\n')[-1])]
                 if ignore:
                     refs = [r for r in refs if r[0].split('/')[-1] not in ignore]
                 return refs

--- a/runbot/templates/dockerfile.xml
+++ b/runbot/templates/dockerfile.xml
@@ -85,7 +85,7 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ADD https://raw.githubusercontent.com/odoo/odoo/<t t-esc="values['odoo_branch']"/>/debian/control /tmp/control.txt
 RUN apt-get update \
     &amp;&amp; sed -n '/^Depends:/,/^[A-Z]/p' /tmp/control.txt \
-       | awk '/^ [a-z]/ { gsub(/,/,"") ; print }' | sort -u \
+       | awk '/^ [a-z]/ { gsub(/,/,"") ; print $1 }' | sort -u \
        | egrep -v 'postgresql-client' \
        | sed 's/python-imaging/python-pil/'| sed 's/python-pypdf/python-pypdf2/' \
        | DEBIAN_FRONTEND=noninteractive xargs apt-get install -y -qq \

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -44,6 +44,8 @@
                 <field name="config_id"/>
                 <field name="ci_context"/>
                 <field name="repo_ids" widget="many2many_tags"/>
+                <field name="dependency_ids" widget="many2many_tags"/>
+                <field name="manual"/>
             </tree>
         </field>
       </record>

--- a/runbot_builder/tools.py
+++ b/runbot_builder/tools.py
@@ -46,6 +46,7 @@ class RunbotClient():
         while True:
             try:
                 self.host.last_start_loop = fields.Datetime.now()
+                self.env.cr.commit()
                 self.count = self.count % self.max_count
                 sleep_time = self.loop_turn()
                 self.count += 1
@@ -90,6 +91,8 @@ def run(client_class):
     parser.add_argument('--db_password')
     parser.add_argument('-d', '--database', default='runbot', help='name of runbot db')
     parser.add_argument('--logfile', default=False)
+    parser.add_argument('--forced-host-name', default=False)
+
     args = parser.parse_args()
     if args.logfile:
         dirname = os.path.dirname(args.logfile)
@@ -112,6 +115,8 @@ def run(client_class):
     addon_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
     config_addons_path = odoo.tools.config['addons_path']
     odoo.tools.config['addons_path'] = ','.join([config_addons_path, addon_path])
+
+    odoo.tools.config['forced_host_name'] = args.forced_host_name
 
     # create environment
     registry = odoo.registry(args.database)


### PR DESCRIPTION
Since odoo/odoo@3d6043a7356b90e5a69a5b535ec6c651d0860711 the controll file can contain fallbacks `dep1 | dep2 | dep3`.
Taking the first column will work in most cases.