### PR TITLE
[FIX] runbot_merge: updating of commit date on rebase

### DIFF
--- a/runbot_merge/github.py
+++ b/runbot_merge/github.py
@@ -308,15 +308,14 @@ class GH(object):
         prev = original_head
         mapping = {}
         for c in commits:
+            committer = c['commit']['committer']
+            committer.pop('date')
             copy = self('post', 'git/commits', json={
                 'message': c['commit']['message'],
                 'tree': c['new_tree'],
                 'parents': [prev],
                 'author': c['commit']['author'],
-                'committer': dict(
-                    c['commit']['committer'],
-                    date=datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-                ),
+                'committer': committer,
             }, check={409: MergeError}).json()
             logger.debug('copied %s to %s (parent: %s)', c['sha'], copy['sha'], prev)
             prev = mapping[c['sha']] = copy['sha']


### PR DESCRIPTION
On #509, the rebasing process was changed to forcefully update the
commit date of the commits, in order to force trigger builds.

However when squashing was re-enabled for #539 for some fool reason it
implemented its own bespoke rebasing (despite that not actually saving
any API call that I can see), meaning it did *not* update the commit
date. As such, an old commit being squashed would not get picked up by
the runbot, which is what happened to odoo/documentation#1226 (which
ultimately had to be hand-rebased after some confusion as to why it
did not work).

Update `_stage_squash` to go through `rebase` the normal way, also
update `rebase` to pop the commit date entirely instead of setting it
manually, and update the squashing test to check that the commit date
gets properly updated.

Fixes #579