### PR TITLE
[IMP] runbot: fully garbage collect old builds

### DIFF
--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -27,6 +27,8 @@ class ResConfigSettings(models.TransientModel):
 
     runbot_db_gc_days = fields.Integer('Days before gc', default=30, config_parameter='runbot.db_gc_days')
     runbot_db_gc_days_child = fields.Integer('Days before gc of child', default=15, config_parameter='runbot.db_gc_days_child')
+    runbot_full_gc_days = fields.Integer('Days before directory removal', default=365, config_parameter='runbot.full_gc_days',
+                                         help='Counting from the db removal date')
 
     runbot_pending_warning = fields.Integer('Pending warning limit', default=5, config_parameter='runbot.pending.warning')
     runbot_pending_critical = fields.Integer('Pending critical limit', default=5, config_parameter='runbot.pending.critical')

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -12,6 +12,7 @@
                   <div class="row mt16 o_settings_container">
                     <div class="col-12 col-lg-6 o_setting_box">
                       <div class="o_setting_right_pane">
+                        <span class="o_form_label">General Runbot Settings</span>
                         <div class="content-group">
                           <label for="runbot_workers" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_workers" style="width: 15%;"/>
@@ -24,22 +25,25 @@
                           <field name="runbot_timeout" style="width: 15%;"/>
                           <label for="runbot_starting_port" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_starting_port" style="width: 15%;"/>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                      <div class="o_setting_right_pane">
+                        <span class="o_form_label">Git Related Settings</span>
+                        <div class="content-group">
+                          <label for="runbot_do_fetch" class="col-xs-3 o_light_label" style="width: 40%;"/>
+                          <field name="runbot_do_fetch"/>
                           <label for="runbot_max_age" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_max_age" style="width: 15%;"/>
                           <label for="runbot_update_frequency" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_update_frequency" style="width: 15%;"/>
-                          <label for="runbot_db_gc_days" class="col-xs-3 o_light_label" style="width: 60%;"/>
-                          <field name="runbot_db_gc_days" style="width: 15%;"/>
-                          <label for="runbot_db_gc_days_child" class="col-xs-3 o_light_label" style="width: 60%;"/>
-                          <field name="runbot_db_gc_days_child" style="width: 15%;"/>
                         </div>
                       </div>
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box">
                       <div class="o_setting_right_pane">
                         <div class="content-group">
-                          <label for="runbot_do_fetch" class="col-xs-3 o_light_label" style="width: 40%;"/>
-                          <field name="runbot_do_fetch"/>
                           <label for="runbot_do_schedule" class="col-xs-3 o_light_label" style="width: 40%;"/>
                           <field name="runbot_do_schedule"/>
                           <label for="runbot_domain" class="col-xs-3 o_light_label" style="width: 40%;"/>
@@ -48,6 +52,19 @@
                           <field name="runbot_template" style="width: 55%;"/>
                           <label for="runbot_is_base_regex" class="col-xs-3 o_light_label" style="width: 40%;"/>
                           <field name="runbot_is_base_regex" style="width: 55%;"/>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                      <div class="o_setting_right_pane">
+                        <span class="o_form_label">Garbage Collecting Settings</span>
+                        <div class="content-group">
+                          <label for="runbot_db_gc_days" class="col-xs-3 o_light_label" style="width: 60%;"/>
+                          <field name="runbot_db_gc_days" style="width: 15%;"/>
+                          <label for="runbot_db_gc_days_child" class="col-xs-3 o_light_label" style="width: 60%;"/>
+                          <field name="runbot_db_gc_days_child" style="width: 15%;"/>
+                          <label for="runbot_full_gc_days" class="col-xs-3 o_light_label" style="width: 60%;"/>
+                          <field name="runbot_full_gc_days" style="width: 15%;"/>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
When a build is garbage collected and the local folders are cleaned, the
log files are kept to allow build errors investigations.

With this commit, a full local cleanup will be done 365 days after the
garbage collect.  This means that the build dir will be completely
removed.  The default number of days can be tweaked with the
`runbot.full_gc_days` ir.config_parameter.

Also, the _local_cleanup method can be called with a `full` boolean
parameter to force a full cleanup. e.g.: when called in a config step.