### PR TITLE
[FIX] runbot: avoid children in team errors

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -245,8 +245,8 @@ class RunbotTeam(models.Model):
 
     name = fields.Char('Team', required=True)
     user_ids = fields.Many2many('res.users', string='Team Members', domain=[('share', '=', False)])
-    dashboard_id = fields.Many2one('runbot.dashboard',string='Dashboard')
-    build_error_ids = fields.One2many('runbot.build.error', 'team_id', string='Team Errors')
+    dashboard_id = fields.Many2one('runbot.dashboard', string='Dashboard')
+    build_error_ids = fields.One2many('runbot.build.error', 'team_id', string='Team Errors', domain=[('parent_id', '=', False)])
     path_glob = fields.Char('Module Wildcards',
         help='Comma separated list of `fnmatch` wildcards used to assign errors automaticaly\n'
         'Negative wildcards starting with a `-` can be used to discard some path\n'


### PR DESCRIPTION
When an error is assigned to a team and the error is a child of another
one, the two errors are displayed on the team dashboard and adds
confusion.