### PR TITLE
[FIX] runbot: avoid werkzeug deprecated escape

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -13,9 +13,8 @@ from collections import OrderedDict
 from datetime import timedelta
 from babel.dates import format_timedelta
 from markupsafe import Markup
-from werkzeug import utils
 
-from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, html_escape
 
 _logger = logging.getLogger(__name__)
 
@@ -121,7 +120,7 @@ def list_local_dbs(additionnal_conditions=None):
 
 
 def pseudo_markdown(text):
-    text = utils.escape(text)
+    text = html_escape(text)
 
     # first, extract code blocs:
     codes = []

--- a/runbot/tests/test_event.py
+++ b/runbot/tests/test_event.py
@@ -129,5 +129,5 @@ class TestIrLogging(RunbotCase):
         log.message = 'foo <script>console.log("hello world")</script>'
         self.assertEqual(
             log._markdown(),
-            'foo &lt;script&gt;console.log(&quot;hello world&quot;)&lt;/script&gt;'
+            'foo &lt;script&gt;console.log(&#34;hello world&#34;)&lt;/script&gt;'
         )


### PR DESCRIPTION
The `utils.escape` utility was deprecated in werkzeug 2.0.0, so it can
be replaced with our `html_escape` which is itself `markupsafe.escape`.

Also, with this change, the double quotes are now escaped in `&#34;`
instead of `&quot;`, so we fix the test too.