### PR TITLE
[FIX] runbot: cast markup into str before saving

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -479,8 +479,8 @@ class Repo(models.Model):
                 git_config_path = os.path.join(repo.path, 'config')
                 template_params = {'repo': repo}
                 git_config = self.env['ir.ui.view']._render_template("runbot.git_config", template_params)
-                with open(git_config_path, 'wb') as config_file:
-                    config_file.write(git_config)
+                with open(git_config_path, 'w') as config_file:
+                    config_file.write(str(git_config))
                 _logger.info('Config updated for repo %s' % repo.name)
             else:
                 _logger.info('Repo not cloned, skiping config update for %s' % repo.name)

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -161,8 +161,8 @@ class Runbot(models.AbstractModel):
                 content = f.read()
         if content != nginx_config:
             _logger.info('reload nginx')
-            with open(nginx_conf_path, 'wb') as f:
-                f.write(nginx_config)
+            with open(nginx_conf_path, 'w') as f:
+                f.write(str(nginx_config))
             try:
                 pid = int(open(os.path.join(nginx_dir, 'nginx.pid')).read().strip(' \n'))
                 os.kill(pid, signal.SIGHUP)


### PR DESCRIPTION
When rendering templates for git configuration and nginx configuration,
the templates are rendered as Markup, while a byte-like object was
expected for the saving.

With this commit, the Markup is casted into str and the files are saved
as text files.