### PR TITLE
[IMP] runbot: status management

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -138,7 +138,7 @@ class Batch(models.Model):
                 build.host = self.bundle_id.host_id.name
                 build.keep_host = True
 
-            build._github_status(post_commit=False)
+            build._github_status()
         return link_type, build
 
     def _prepare(self, auto_rebase=False):

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1136,7 +1136,7 @@ class BuildResult(models.Model):
         if self.global_result in ('skipped', 'killed', 'manually_killed'):
             return 'killed'
 
-    def _github_status(self, post_commit=True):
+    def _github_status(self):
         """Notify github of failed/successful builds"""
         for build in self:
             # TODO maybe avoid to send status if build is killable (another new build exist and will send the status)
@@ -1144,7 +1144,7 @@ class BuildResult(models.Model):
                 if build.orphan_result:
                     _logger.info('Skipping result for orphan build %s', self.id)
                 else:
-                    build.parent_id._github_status(post_commit)
+                    build.parent_id._github_status()
             else:
                 trigger = self.params_id.trigger_id
                 if not trigger.ci_context:
@@ -1170,4 +1170,4 @@ class BuildResult(models.Model):
                 for build_commit in self.params_id.commit_link_ids:
                     commit = build_commit.commit_id
                     if 'base_' not in build_commit.match_type and commit.repo_id in trigger.repo_ids:
-                        commit._github_status(build, trigger.ci_context, state, target_url, desc, post_commit)
+                        commit._github_status(build, trigger.ci_context, state, target_url, desc)

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -260,11 +260,15 @@ class Runbot(models.AbstractModel):
                         self._commit()
             self._commit()
 
+            self.env['runbot.commit.status']._send_to_process()
+            self._commit()
+
             # cleanup old pull_info_failures
             for pr_number, t in pull_info_failures.items():
                 if t + 15*60 < time.time():
                     _logger.warning('Removing %s from pull_info_failures', pr_number)
                     del pull_info_failures[pr_number]
+
 
         return manager.get('sleep', default_sleep)
 

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -94,6 +94,7 @@
                     <field name="sequence"/>
                     <field name="fetch_heads" string="Branch"/>
                     <field name="fetch_pull" string="PR"/>
+                    <field name="send_status"/>
                     <field name="token"/>
                   </tree>
                 </field>
@@ -118,6 +119,7 @@
                 <field name="token"/>
                 <field name="fetch_pull"/>
                 <field name="fetch_heads"/>
+                <field name="send_status"/>
               </group>
             </sheet>
           </form>
@@ -133,6 +135,7 @@
                 <field name="repo_id"/>
                 <field name="fetch_pull"/>
                 <field name="fetch_heads"/>
+                <field name="send_status"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
The status are currently sent by leader when build are created and by
workers on post_commit.

If the leader fails during the preparing of a batch (while creating
builds) the transaction is rollbacked and the status are send again.

The number of status to send makes it quite slow, making the transaction
longuer, and the retry even more expensive. This leads to preparing time
being quite important, sometimes ten minutes after many retries.

This commit proposes to send status in another dedicated transaction.
Since status are sent in batch, we can also try to use a unique session,
and uniquify commit+context status.

This allows to remove the postcommit logic

A further improvement would be to wait before sending status in order to
skip the pending status if the build is verry fast.

An option is also added on the remote to skip the status: if the remote
is a fork, sending the satus on the main remote should be enough.