### PR TITLE
[FIX] runbot: avoid sudo when using pip

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -32,9 +32,7 @@ DOCKERUSER = """
 RUN groupadd -g %(group_id)s odoo \\
 && useradd -u %(user_id)s -g odoo -G audio,video odoo \\
 && mkdir /home/odoo \\
-&& chown -R odoo:odoo /home/odoo \\
-&& echo "odoo ALL= NOPASSWD: /usr/bin/pip" > /etc/sudoers.d/pip \\
-&& echo "odoo ALL= NOPASSWD: /usr/bin/pip3" >> /etc/sudoers.d/pip
+&& chown -R odoo:odoo /home/odoo
 USER odoo
 ENV COVERAGE_FILE /data/build/.coverage
 """ % {'group_id': os.getgid(), 'user_id': os.getuid()}

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -966,7 +966,7 @@ class BuildResult(models.Model):
             if not self.params_id.skip_requirements and os.path.isfile(commit_id._source_path('requirements.txt')):
                 repo_dir = self._docker_source_folder(commit_id)
                 requirement_path = os.path.join(repo_dir, 'requirements.txt')
-                pres.append(['sudo', 'pip%s' % py_version, 'install', '--progress-bar', 'off', '-r', '%s' % requirement_path])
+                pres.append([f'python{py_version}', '-m', 'pip', 'install','--user', '--progress-bar', 'off', '-r', f'{requirement_path}'])
 
         addons_paths = self._get_addons_path()
         (server_commit, server_file) = self._get_server_info()


### PR DESCRIPTION
In bd4cf76b7 a new argument `--progress-bar off` was added to the pip
command line. Unfortunately, it appears that this argument is not
available in some pip versions, typically the one from Ubuntu Bionic
(9.0.1) [0]. The argument appeared in version 10.0.0 [1].

Also, in the DockerFile, we allow the user to use `sudo` for
`/usr/bin/pip3` and the main reason for that was to avoid having `pip`
to re-install the package that are pre-installed by the distribution
package manager.

That said, it appears that since pip 10.0.0 when installing packages
locally for the user, pip now properly detects distribution installed
packages.

So, as the solution to fix the progress bar issue is to upgrade pip to a
newer version, we can take advantage of it to get rid of the `sudo`.

Besides the fact that `--user` is the default on Debian based
distributions [2] , we enforce it in case another distribution is used
in the Dockerfile.

[0](https://packages.ubuntu.com/bionic-updates/python3-pip)
[1](https://pip.pypa.io/en/stable/news/#id744)
[2](https://wiki.debian.org/Python#Deviations_from_upstream)