### PR TITLE
[FIX] runbot: redirect to current page after login

### DIFF
--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -121,7 +121,7 @@
                                     <t t-else="">
                                         <li class="nav-item dropdown" t-ignore="true">
                                             <b>
-                                                <a class="nav-link" t-attf-href="/web/login?redirect=/">Login</a>
+                                                <a class="nav-link" t-attf-href="/web/login?redirect={{request.httprequest.path}}">Login</a>
                                             </b>
                                         </li>
                                     </t>


### PR DESCRIPTION
Because the login link redirected to `/`, when logging in the user would have
to re-navigate to their previous page unless they'd remembered this issue and
kept the original page around.

Fix this because it's annoying and dumb: we know our URL when rendering
templates, so we can redirect back there after login.

Consideration: this could also be done on logout, however it seems likely that
in that case the original page is "privileged" and when coming back we'd just
get an access error. So don't do it for now.