### PR TITLE
[IMP] runbot: let the build insert logs into local database

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '5.1',
+    'version': '5.2',
     'application': True,
     'depends': ['base', 'base_automation', 'website'],
     'data': [

--- a/runbot/common.py
+++ b/runbot/common.py
@@ -108,6 +108,16 @@ def local_pgadmin_cursor():
         if cnx:
             cnx.close()
 
+@contextlib.contextmanager
+def local_pg_cursor(db_name):
+    cnx = None
+    try:
+        cnx = psycopg2.connect(f"dbname={db_name}")
+        yield cnx.cursor()
+    finally:
+        if cnx:
+            cnx.commit()
+            cnx.close()
 
 def list_local_dbs(additionnal_conditions=None):
     additionnal_condition_str = ''

--- a/runbot/data/runbot_data.xml
+++ b/runbot/data/runbot_data.xml
@@ -41,6 +41,11 @@
 admin_passwd=running_master_password</field>
         </record>
 
+        <record model="ir.config_parameter" id="runbot.runbot_default_logdb_name">
+            <field name="key">runbot.logdb_name</field>
+            <field name="value">runbot_logs</field>
+        </record>
+
     </data>
 
     <record model="ir.config_parameter" id="runbot.runbot_is_base_regex">

--- a/runbot/migrations/15.0.5.2/pre-migration.py
+++ b/runbot/migrations/15.0.5.2/pre-migration.py
@@ -1,0 +1,3 @@
+def migrate(cr, version):
+    cr.execute("DROP TRIGGER IF EXISTS runbot_new_logging ON ir_logging")
+    cr.execute("DROP FUNCTION IF EXISTS runbot_set_logging_build")

--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -16,8 +16,7 @@ class ResConfigSettings(models.TransientModel):
     runbot_timeout = fields.Integer('Max allowed step timeout (in seconds)')
     runbot_starting_port = fields.Integer('Starting port for running builds')
     runbot_max_age = fields.Integer('Max commit age (in days)')
-    runbot_logdb_uri = fields.Char('Runbot URI for build logs',
-        help='postgres://user:password@host/db formated uri to give to a build to log in database. Should be a user with limited access rights (ir_logging, runbot_build)')
+    runbot_logdb_name = fields.Char('Local Logs DB name', default='runbot_logs', config_parameter='runbot.logdb_name')
     runbot_update_frequency = fields.Integer('Update frequency (in seconds)')
     runbot_template = fields.Char('Postgresql template', help="Postgresql template to use when creating DB's")
     runbot_message = fields.Text('Frontend warning message', help="Will be displayed on the frontend when not empty")
@@ -62,7 +61,6 @@ class ResConfigSettings(models.TransientModel):
                    runbot_timeout=int(get_param('runbot.runbot_timeout', default=10000)),
                    runbot_starting_port=int(get_param('runbot.runbot_starting_port', default=2000)),
                    runbot_max_age=int(get_param('runbot.runbot_max_age', default=30)),
-                   runbot_logdb_uri=get_param('runbot.runbot_logdb_uri', default=False),
                    runbot_update_frequency=int(get_param('runbot.runbot_update_frequency', default=10)),
                    runbot_template=get_param('runbot.runbot_db_template'),
                    runbot_message=get_param('runbot.runbot_message', default=''),
@@ -84,7 +82,6 @@ class ResConfigSettings(models.TransientModel):
         set_param("runbot.runbot_timeout", self.runbot_timeout)
         set_param("runbot.runbot_starting_port", self.runbot_starting_port)
         set_param("runbot.runbot_max_age", self.runbot_max_age)
-        set_param("runbot.runbot_logdb_uri", self.runbot_logdb_uri)
         set_param('runbot.runbot_update_frequency', self.runbot_update_frequency)
         set_param('runbot.runbot_db_template', self.runbot_template)
         set_param('runbot.runbot_message', self.runbot_message)

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -42,6 +42,8 @@ class Runbot(models.AbstractModel):
         for build in self._get_builds_with_requested_actions(host):
             build._process_requested_actions()
             self._commit()
+        host.process_logs()
+        self._commit()
         for build in self._get_builds_to_schedule(host):
             build._schedule()
             self._commit()

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_runbot
 from . import test_commit
 from . import test_upgrade
 from . import test_dockerfile
+from . import test_host

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -172,6 +172,7 @@ class RunbotCase(TransactionCase):
         self.start_patcher('makedirs', 'odoo.addons.runbot.common.os.makedirs', True)
         self.start_patcher('mkdir', 'odoo.addons.runbot.common.os.mkdir', True)
         self.start_patcher('local_pgadmin_cursor', 'odoo.addons.runbot.common.local_pgadmin_cursor', False)  # avoid to create databases
+        self.start_patcher('host_local_pg_cursor', 'odoo.addons.runbot.models.host.local_pg_cursor')
         self.start_patcher('isdir', 'odoo.addons.runbot.common.os.path.isdir', True)
         self.start_patcher('isfile', 'odoo.addons.runbot.common.os.path.isfile', True)
         self.start_patcher('docker_run', 'odoo.addons.runbot.container._docker_run')

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -211,15 +211,12 @@ class TestBuildResult(RunbotCase):
         self.assertEqual(modules_to_test, sorted(['good_module', 'bad_module', 'other_good', 'l10n_be', 'hwgood', 'hw_explicit', 'other_mod_1', 'other_mod_2']))
 
     def test_build_cmd_log_db(self, ):
-        """ test that the logdb connection URI is taken from the .odoorc file """
-        uri = 'postgres://someone:pass@somewhere.com/db'
-        self.env['ir.config_parameter'].sudo().set_param("runbot.runbot_logdb_uri", uri)
-
+        """ test that the log_db parameter is set in the .odoorc file """
         build = self.Build.create({
             'params_id': self.server_params.id,
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('log_db = %s' % uri, cmd.get_config())
+        self.assertIn('log_db = runbot_logs', cmd.get_config())
 
     def test_build_cmd_server_path_no_dep(self):
         """ test that the server path and addons path """
@@ -242,7 +239,8 @@ class TestBuildResult(RunbotCase):
                 '/tmp/runbot_test/static/sources/addons/d0d0caca0000ffffffffffffffffffffffffffff/requirements.txt',
                 '/tmp/runbot_test/static/sources/server/dfdfcfcf0000ffffffffffffffffffffffffffff/requirements.txt',
                 '/tmp/runbot_test/static/sources/server/dfdfcfcf0000ffffffffffffffffffffffffffff/server.py',
-                '/tmp/runbot_test/static/sources/server/dfdfcfcf0000ffffffffffffffffffffffffffff/openerp/tools/config.py'
+                '/tmp/runbot_test/static/sources/server/dfdfcfcf0000ffffffffffffffffffffffffffff/openerp/tools/config.py',
+                '/tmp/runbot_test/static/sources/server/dfdfcfcf0000ffffffffffffffffffffffffffff/openerp/sql_db.py'
             ])
             if file == '/tmp/runbot_test/static/sources/addons/d0d0caca0000ffffffffffffffffffffffffffff/requirements.txt':
                 return False

--- a/runbot/tests/test_cron.py
+++ b/runbot/tests/test_cron.py
@@ -15,6 +15,7 @@ class TestCron(RunbotCase):
 
     def setUp(self):
         super(TestCron, self).setUp()
+        self.start_patcher('list_local_dbs_patcher', 'odoo.addons.runbot.models.host.list_local_dbs', ['runbot_logs'])
         self.start_patcher('_get_cron_period', 'odoo.addons.runbot.models.runbot.Runbot._get_cron_period', 2)
 
     @patch('time.sleep', side_effect=sleep)

--- a/runbot/tests/test_event.py
+++ b/runbot/tests/test_event.py
@@ -4,57 +4,6 @@ from .common import RunbotCase
 
 class TestIrLogging(RunbotCase):
 
-    def simulate_log(self, build, func, message, level='INFO'):
-        """ simulate ir_logging from an external build """
-        dest = '%s-fake-dest' % build.id
-        val = ('server', dest, 'test', level, message, 'test', '0', func)
-        self.cr.execute("""
-                INSERT INTO ir_logging(create_date, type, dbname, name, level, message, path, line, func)
-                VALUES (NOW() at time zone 'UTC', %s, %s, %s, %s, %s, %s, %s, %s)
-            """, val)
-
-    def test_ir_logging(self):
-        build = self.Build.create({
-            'active_step': self.env.ref('runbot.runbot_build_config_step_test_all').id,
-            'params_id': self.base_params.id,
-        })
-
-        build.log_counter = 10
-
-        #  Test that an ir_logging is created and a the trigger set the build_id
-        self.simulate_log(build, 'test function', 'test message')
-        log_line = self.env['ir.logging'].search([('func', '=', 'test function'), ('message', '=', 'test message'), ('level', '=', 'INFO')])
-        self.assertEqual(len(log_line), 1, "A build log event should have been created")
-        self.assertEqual(log_line.build_id, build)
-        self.assertEqual(log_line.active_step_id, self.env.ref('runbot.runbot_build_config_step_test_all'), 'The active step should be set on the log line')
-
-        #  Test that a warn log line sets the build in warn
-        self.simulate_log(build, 'test function', 'test message', level='WARNING')
-        build.invalidate_cache()
-        self.assertEqual(build.triggered_result, 'warn', 'A warning log should sets the build in warn')
-
-        #  Test that a error log line sets the build in ko
-        self.simulate_log(build, 'test function', 'test message', level='ERROR')
-        build.invalidate_cache()
-        self.assertEqual(build.triggered_result, 'ko', 'An error log should sets the build in ko')
-        self.assertEqual(7, build.log_counter, 'server lines should decrement the build log_counter')
-
-        build.log_counter = 10
-
-        # Test the log limit
-        for i in range(11):
-            self.simulate_log(build, 'limit function', 'limit message')
-        log_lines = self.env['ir.logging'].search([('build_id', '=', build.id), ('type', '=', 'server'), ('func', '=', 'limit function'), ('message', '=', 'limit message'), ('level', '=', 'INFO')])
-        self.assertGreater(len(log_lines), 7, 'Trigger should have created logs with appropriate build id')
-        self.assertLess(len(log_lines), 10, 'Trigger should prevent insert more lines of logs than log_counter')
-        last_log_line = self.env['ir.logging'].search([('build_id', '=', build.id)], order='id DESC', limit=1)
-        self.assertIn('Log limit reached', last_log_line.message, 'Trigger should modify last log message')
-
-        # Test that the _log method is still able to add logs
-        build._log('runbot function', 'runbot message')
-        log_lines = self.env['ir.logging'].search([('type', '=', 'runbot'), ('name', '=', 'odoo.runbot'), ('func', '=', 'runbot function'), ('message', '=', 'runbot message'), ('level', '=', 'INFO')])
-        self.assertEqual(len(log_lines), 1, '_log should be able to add logs from the runbot')
-
     def test_markdown(self):
         log = self.env['ir.logging'].create({
             'name': 'odoo.runbot',

--- a/runbot/tests/test_host.py
+++ b/runbot/tests/test_host.py
@@ -1,0 +1,113 @@
+import logging
+
+from .common import RunbotCase
+
+from datetime import datetime, timedelta
+
+_logger = logging.getLogger(__name__)
+
+def fetch_local_logs_return_value(nb_logs=10, message='', log_type='server', level='INFO', build_dest='1234567-master-all'):
+
+    log_date = datetime(2022, 8, 17, 21, 55)
+    logs = []
+    for i in range(nb_logs):
+        logs += [{
+            'id': i,
+            'create_date': log_date,
+            'name': 'odoo.modules.loading',
+            'level': level,
+            'dbname': build_dest,
+            'func': 'runbot',
+            'path': '/data/build/odoo/odoo/netsvc.py',
+            'line': '274',
+            'type': log_type,
+            'message': '75 modules loaded in 0.92s, 717 queries (+1 extra)' if message == '' else message,
+        }]
+        log_date += timedelta(seconds=20)
+    return logs
+
+class TestHost(RunbotCase):
+
+    def setUp(self):
+        super().setUp()
+        self.test_host = self.env['runbot.host'].create({'name': 'test_host'})
+        self.server_commit = self.Commit.create({
+            'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
+            'repo_id': self.repo_server.id
+        })
+
+        self.addons_commit = self.Commit.create({
+            'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
+            'repo_id': self.repo_addons.id,
+        })
+
+        self.server_params = self.base_params.copy({'commit_link_ids': [
+            (0, 0, {'commit_id': self.server_commit.id})
+        ]})
+
+        self.addons_params = self.base_params.copy({'commit_link_ids': [
+            (0, 0, {'commit_id': self.server_commit.id}),
+            (0, 0, {'commit_id': self.addons_commit.id})
+        ]})
+
+        self.start_patcher('find_patcher', 'odoo.addons.runbot.common.find', 0)
+        self.start_patcher('host_bootstrap', 'odoo.addons.runbot.models.host.Host._bootstrap', None)
+
+    def test_build_logs(self):
+
+        build = self.Build.create({
+            'params_id': self.server_params.id,
+            'port': '1234567',
+            'active_step': self.env.ref('runbot.runbot_build_config_step_test_all').id,
+            'log_counter': 20,
+        })
+
+        # check that local logs are inserted in leader ir.logging
+        logs = fetch_local_logs_return_value(build_dest=build.dest)
+        self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', logs)
+        self.test_host.process_logs()
+        self.patchers['host_local_pg_cursor'].assert_called()
+        self.assertEqual(
+            self.env['ir.logging'].search_count([
+                ('build_id', '=', build.id),
+                ('active_step_id', '=', self.env.ref('runbot.runbot_build_config_step_test_all').id)
+            ]),
+            10,
+        )
+
+        # check that a warn log sets the build in warning
+        logs = fetch_local_logs_return_value(nb_logs=1, build_dest=build.dest, level='WARNING')
+        self.patchers['fetch_local_logs'].return_value = logs
+        self.test_host.process_logs()
+        self.patchers['host_local_pg_cursor'].assert_called()
+        self.assertEqual(
+            self.env['ir.logging'].search_count([
+                ('build_id', '=', build.id),
+                ('active_step_id', '=', self.env.ref('runbot.runbot_build_config_step_test_all').id),
+                ('level', '=', 'WARNING')
+            ]),
+            1,
+        )
+        self.assertEqual(build.triggered_result, 'warn', 'A warning log should sets the build in warn')
+
+        # now check that error logs sets the build in ko
+        logs = fetch_local_logs_return_value(nb_logs=1, build_dest=build.dest, level='ERROR')
+        self.patchers['fetch_local_logs'].return_value = logs
+        self.test_host.process_logs()
+        self.patchers['host_local_pg_cursor'].assert_called()
+        self.assertEqual(
+            self.env['ir.logging'].search_count([
+                ('build_id', '=', build.id),
+                ('active_step_id', '=', self.env.ref('runbot.runbot_build_config_step_test_all').id),
+                ('level', '=', 'ERROR')
+            ]),
+            1,
+        )
+        self.assertEqual(build.triggered_result, 'ko', 'An error log should sets the build in ko')
+
+        build.log_counter = 10
+        # Test log limit
+        logs = fetch_local_logs_return_value(nb_logs=11, message='test log limit', build_dest=build.dest)
+        self.patchers['fetch_local_logs'].return_value = logs
+        self.test_host.process_logs()
+        self.patchers['host_local_pg_cursor'].assert_called()

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -273,6 +273,7 @@ class TestUpgradeFlow(RunbotCase):
         host = self.env['runbot.host']._get_current()
         upgrade_current_build.host = host.name
         upgrade_current_build._init_pendings(host)
+        self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', [])  # the local logs have to be empty
         upgrade_current_build._schedule()
         self.assertEqual(upgrade_current_build.local_state, 'done')
         self.assertEqual(len(upgrade_current_build.children_ids), 4)

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -46,6 +46,8 @@
                           <field name="runbot_is_base_regex" style="width: 55%;"/>
                           <label for="runbot_forwardport_author" class="col-xs-3 o_light_label" style="width: 40%;"/>
                           <field name="runbot_forwardport_author" style="width: 55%;"/>
+                          <label for="runbot_logdb_name" class="col-xs-3 o_light_label" style="width: 40%;"/>
+                          <field name="runbot_logdb_name" style="width: 15%;"/>
                         </div>
                       </div>
                     </div>
@@ -62,8 +64,6 @@
                         </div>
                       </div>
                     </div>
-                    <label for="runbot_logdb_uri" class="col-xs-3 o_light_label" style="width: 60%;"/>
-                    <field name="runbot_logdb_uri" style="width: 100%;"/>
                     <label for="runbot_default_odoorc" class="col-xs-3 o_light_label" style="width: 60%;"/>
                     <field name="runbot_default_odoorc" style="width: 100%;"/>
                     <label for="runbot_message" class="col-xs-3 o_light_label" style="width: 60%;"/>

--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
-from tools import RunbotClient, run
 import logging
 
+from tools import RunbotClient, run
+
 _logger = logging.getLogger(__name__)
+
 
 class BuilderClient(RunbotClient):
 


### PR DESCRIPTION
When the number of runbot builder is growing, the concurency for inserting logs increase drastically.
This PR is an attempt to mitigate this issue by allowing runbot builds to insert logs into a local database instead of the one from the runbot leader.
After each loop turn, it's now the builder that will insert the logs directly into the leader database.
