### PR TITLE
[IMP] runbot: add sort and filter capability on the build error page

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': "runbot",
     'summary': "Runbot",
-    'description': "Runbot for Odoo 13.0",
+    'description': "Runbot for Odoo 15.0",
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -324,3 +324,6 @@ body, .table {
 	background-color: #DDD;
 }
 
+.o_runbot_team_searchbar .nav {
+	margin-left: 0px !important;
+}

--- a/runbot/templates/build_error.xml
+++ b/runbot/templates/build_error.xml
@@ -113,9 +113,15 @@
                   <t t-set="dashboard" t-value="team.dashboard_id"/>
                 </t>
               </div>
-              <h3 t-if="team.build_error_ids">Team assigned Errors</h3>
+              <div class="d-flex">
+                <h3 t-if="build_error_ids">Team assigned Errors</h3>
+                <t t-call="portal.portal_searchbar">
+                  <t t-set="classes" t-valuef="o_runbot_team_searchbar border-0"/>
+                  <t t-set="title">&amp;nbsp;</t>
+                </t>
+              </div>
               <t t-call="runbot.build_error_cards">
-                <t t-set="build_errors" t-value="team.build_error_ids"/>
+                <t t-set="build_errors" t-value="build_error_ids"/>
                 <t t-set="accordion_id">team_errors</t>
               </t>
             </div>


### PR DESCRIPTION
Before this commit, the build errors page was neither sortable neither
filterable.

This commit adds a way to filter by:
- all
- unassigned
- seen more than once

It also allows to sort by:
- last seen
- nb seen

Typical need is to sort by nb seen and filter out the only seen once to
be able to figure which one is supposed to be checked in priority.

See result: https://watch.screencastify.com/v/L3x0qnuSgZOMQUjYDKk3