### PR TITLE
[FIX] runbot: mitigate docker status race condition

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -242,12 +242,11 @@ def docker_state(container_name, build_dir):
     container_name = sanitize_container_name(container_name)
     exist = os.path.exists(os.path.join(build_dir, 'exist-%s' % container_name))
     started = os.path.exists(os.path.join(build_dir, 'start-%s' % container_name))
-    ended = os.path.exists(os.path.join(build_dir, 'end-%s' % container_name))
 
     if not exist:
         return 'VOID'
 
-    if ended:
+    if os.path.exists(os.path.join(build_dir, f'end-{container_name}')):
         return 'END'
 
     state = 'UNKNOWN'
@@ -259,6 +258,9 @@ def docker_state(container_name, build_dir):
             state = 'RUNNING' if container.status in ('created', 'running', 'paused') else 'GHOST'
         except docker.errors.NotFound:
             state = 'GHOST'
+        # check if the end- file has been written in between time
+        if state == 'GHOST' and os.path.exists(os.path.join(build_dir, f'end-{container_name}')):
+            state = 'END'
     return state
 
 


### PR DESCRIPTION
In some rare cases, a docker container has a status of exited, removed
or in removal and the `end-`file has been written right after the code
checked the existence of the file.

To mitigate the issue, this commit checks the `end-` file existence
after the container status have been checked. That way, if the file
exists we can be pretty confident that the build really ended.