### PR TITLE
[IMP] runbot: add blacklist support

### DIFF
--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -37,6 +37,12 @@ proxy_set_header X-Forwarded-Host $host;
 proxy_set_header X-Forwarded-Proto $real_scheme;
 proxy_set_header Host $host;
 
+set_real_ip_from 127.0.0.1;
+real_ip_header   X-Forwarded-For;
+real_ip_recursive on;
+
+include blacklist*.conf;
+
 server {
     listen 8080 default;
     location /runbot/static/ {


### PR DESCRIPTION
Deny access to running builds by setting a white spaces separated list of ip's
in `runbot.client.blacklist` config parameter.