### PR TITLE
[FIX] runbot: reduce load when builder are idle

### DIFF
--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -273,7 +273,7 @@ class Runbot(models.AbstractModel):
 
         return manager.get('sleep', default_sleep)
 
-    def _scheduler_loop_turn(self, host, default_sleep=1):
+    def _scheduler_loop_turn(self, host, default_sleep=5):
         _logger.info('Scheduling...')
         with self.manage_host_exception(host) as manager:
             self._scheduler(host)


### PR DESCRIPTION
The sleep 1 was ok with a few builder bur regarding the number of
request on the database when no build are running, this become
problematic.

An ideal solution would be to detect if
-> me managed some testing build
-> There is load (pendings)

In both case, we don't want to sleep to much.
In other cases, we may want to wait a little longer.

A simple quick fix will just wait longer in all cases.