### PR TITLE
[IMP] runbot: multi-versions branch support

### DIFF
--- a/runbot/models/custom_trigger.py
+++ b/runbot/models/custom_trigger.py
@@ -12,6 +12,7 @@ class BundleTriggerCustomization(models.Model):
     config_id = fields.Many2one('runbot.build.config')
     extra_params = fields.Char("Custom parameters")
     config_data = JsonDictField("Config data")
+    target_version_id = fields.Many2one('runbot.version', string="Target Version")
 
     _sql_constraints = [
         (
@@ -29,6 +30,7 @@ class CustomTriggerWizard(models.TransientModel):
     project_id = fields.Many2one(related='bundle_id.project_id', string='Project')
     trigger_id = fields.Many2one('runbot.trigger', domain="[('project_id', '=', project_id)]")
     config_id = fields.Many2one('runbot.build.config', string="Config id", default=lambda self: self.env.ref('runbot.runbot_build_config_custom_multi'))
+    target_version_id = fields.Many2one('runbot.version', string="Target Version")
 
     config_data = JsonDictField("Config data")
 
@@ -93,4 +95,5 @@ class CustomTriggerWizard(models.TransientModel):
             'trigger_id': self.trigger_id.id,
             'config_id': self.config_id.id,
             'config_data': self.config_data,
+            'target_version_id': self.target_version_id.id or False,
         })

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -6,6 +6,7 @@ class Project(models.Model):
     _description = 'Project'
 
     name = fields.Char('Project name', required=True)
+    multi_versions_branch = fields.Boolean(string="Multi-Versions Branch", help="Project's bundles can target multiple Odoo versions")
     group_ids = fields.Many2many('res.groups', string='Required groups')
     keep_sticky_running = fields.Boolean('Keep last sticky builds running')
     trigger_ids = fields.One2many('runbot.trigger', 'project_id', string='Triggers')

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -44,6 +44,9 @@ class Trigger(models.Model):
     config_id = fields.Many2one('runbot.build.config', string="Config", required=True)
     batch_dependent = fields.Boolean('Batch Dependent', help="Force adding batch in build parameters to make it unique and give access to bundle")
 
+    target_version_id = fields.Many2one('runbot.version', help="Target a specific version")
+    dockerfile_id = fields.Many2one('runbot.dockerfile', help="Use a custom Dockerfile")
+
     ci_context = fields.Char("Ci context", default='ci/runbot', tracking=True)
     category_id = fields.Many2one('runbot.category', default=lambda self: self.env.ref('runbot.default_category', raise_if_not_found=False))
     version_domain = fields.Char(string="Version domain")

--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -16,7 +16,7 @@
                             <td>Category</td>
                             <td t-esc="batch.category_id.name"></td>
                         </tr>
-                        <tr>
+                        <tr t-if="not batch.bundle_id.project_id.multi_versions_branch">
                             <td>Version</td>
                             <td t-esc="batch.slot_ids[0].params_id.version_id.name if batch.slot_ids else batch.bundle_id.version_id.name"/>
                         </tr>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -30,7 +30,7 @@
                             </div>
                             <div>
                                 <table class="table table-condensed table-responsive table-stripped">
-                                    <tr>
+                                    <tr t-if="bundle.version_id">
                                         <td>Version</td>
                                         <td>
                                             <t t-esc="bundle.version_id.name"/>

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -34,7 +34,7 @@ class RunbotCase(TransactionCase):
         commiter_email = '%s@somewhere.com' % committer.lower().replace(' ', '_')
         author = author or committer
         author_email = '%s@somewhere.com' % author.lower().replace(' ', '_')
-        self.commit_list[self.repo_server.id] = [(
+        self.commit_list[remote.repo_id.id] = [(
             'refs/%s/heads/%s' % (remote.remote_name, branch_name),
             sha or 'd0d0caca',
             str(tstamp or int(time.time())),

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -7,6 +7,7 @@
             <form string="Projects">
                 <group>
                     <field name="name"/>
+                    <field name="multi_versions_branch"/>
                     <field name="keep_sticky_running"/>
                     <field name="dockerfile_id"/>
                     <field name="group_ids"/>
@@ -66,6 +67,7 @@
                             <field name="config_id"/>
                             <field name="extra_params"/>
                             <field name="config_data"/>
+                            <field name="target_version_id"/>
                         </tree>
                     </field>
                     <field string="Last batches" name="last_batchs">
@@ -90,6 +92,7 @@
                 <field name="config_id"/>
                 <field name="extra_params"/>
                 <field name="config_data"/>
+                <field name="target_version_id"/>
             </tree>
         </field>
     </record>
@@ -104,6 +107,7 @@
                     <field name="config_id"/>
                     <field name="extra_params"/>
                     <field name="config_data"/>
+                    <field name="target_version_id"/>
                 </group>
             </form>
         </field>

--- a/runbot/views/custom_trigger_wizard_views.xml
+++ b/runbot/views/custom_trigger_wizard_views.xml
@@ -11,6 +11,7 @@
                     <field name="warnings" decoration-warning="warnings"/>
                     <field name="trigger_id"/>
                     <field name="config_id"/>
+                    <field name="target_version_id"/>
                     <field name="number_build"/>
                     <field name="child_extra_params"/>
                     <field name="child_dump_url"/>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -21,6 +21,8 @@
                 <field name="config_id"/>
                 <field name="batch_dependent"/>
                 <field name="version_domain" widget="domain" options="{'model': 'runbot.version', 'in_dialog': True}"/>
+                <field name="dockerfile_id"/>
+                <field name="target_version_id"/>
                 <field name="hide"/>
                 <field name="manual"/>
                 <field name="upgrade_dumps_trigger_id"/>


### PR DESCRIPTION
Some repositories host branches with addons that should be tested
on multiples versions, so to ease those use cases, this commit:

* Adds a "Multi-Versions Branch" flag on runbot.project, to indicate
  that we should not rely on the branch name to determine the version
  of the target builds.

  When set, we also hide version on related bundles/batches as only
  version/commit on the build are relevant.

* Adds a "Target Version" on runbot.trigger and runbot.bundle.trigger.custom,
  that (if set) overwrite the base bundle used to determine the missing
  commits of a specific build

* Adds a "Dockerfile" on runbot.trigger, allowing forcing specific
  image to use for a trigger.