### PR TITLE
[FIX] runbot: download phantomjs from nightly server

### DIFF
--- a/runbot/templates/dockerfile.xml
+++ b/runbot/templates/dockerfile.xml
@@ -38,7 +38,7 @@ RUN curl -sSL http://nightly.odoo.com/odoo.key | apt-key add - \
 
     <template id="runbot.docker_install_phantomjs">
 # Install phantomjs
-RUN curl -sSL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2  -o /tmp/phantomjs.tar.bz2 \
+RUN curl -sSL https://nightly.odoo.com/resources/phantomjs.tar.bz2  -o /tmp/phantomjs.tar.bz2 \
     &amp;&amp; tar xvfO /tmp/phantomjs.tar.bz2 phantomjs-2.1.1-linux-x86_64/bin/phantomjs > /usr/local/bin/phantomjs \
     &amp;&amp; chmod +x /usr/local/bin/phantomjs \
     &amp;&amp; rm -f /tmp/phantomjs.tar.bz2


### PR DESCRIPTION
In order to avoid bitbucket rate limiting, we prefer to download this old pal from our server.