### PR TITLE
15.0 runbot varfixes moc

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -26,7 +26,7 @@ class RunbotException(Exception):
 
 
 def fqdn():
-    return socket.getfqdn()
+    return socket.gethostname()
 
 
 def time2str(t):

--- a/runbot/data/runbot_data.xml
+++ b/runbot/data/runbot_data.xml
@@ -37,7 +37,8 @@
 
         <record model="ir.config_parameter" id="runbot.runbot_default_odoorc">
             <field name="key">runbot.runbot_default_odoorc</field>
-            <field name="value">[options]\nadmin_passwd=running_master_password</field>
+            <field name="value">[options]
+admin_passwd=running_master_password</field>
         </record>
 
     </data>

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -285,7 +285,7 @@ class ConfigStep(models.Model):
         for child_data in child_data_list:
             for create_config in self.env['runbot.build.config'].browse(child_data.get('config_id', config_ids.ids)):
                 _child_data = {**child_data, 'config_id': create_config}
-                for _ in range(_child_data.get('number_build', self.number_builds)):
+                for _ in range(config_data.get('number_build', self.number_builds)):
                     count += 1
                     if count > 200:
                         build._logger('Too much build created')

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -121,7 +121,7 @@ class RunbotCase(TransactionCase):
         self.commit_list = {}
 
         self.start_patcher('git_patcher', 'odoo.addons.runbot.models.repo.Repo._git', new=self.mock_git_helper())
-        self.start_patcher('fqdn_patcher', 'odoo.addons.runbot.common.socket.getfqdn', 'host.runbot.com')
+        self.start_patcher('hostname_patcher', 'odoo.addons.runbot.common.socket.gethostname', 'host.runbot.com')
         self.start_patcher('github_patcher', 'odoo.addons.runbot.models.repo.Remote._github', {})
         self.start_patcher('repo_root_patcher', 'odoo.addons.runbot.models.runbot.Runbot._root', '/tmp/runbot_test/static')
         self.start_patcher('makedirs', 'odoo.addons.runbot.common.os.makedirs', True)

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -85,8 +85,7 @@ class TestBuildConfigStepCreate(TestBuildConfigStepCommon):
 
     def test_config_step_create_child_data_unique(self):
         """ Test the config step of type create """
-        self.config_step.number_builds = 5
-        json_config = {'child_data': {'extra_params': '-i m1'}}
+        json_config = {'child_data': {'extra_params': '-i m1'}, 'number_build': 5}
         self.parent_build = self.Build.create({
             'params_id': self.base_params.create({
                 'version_id': self.version_13.id,

--- a/runbot/tests/test_cron.py
+++ b/runbot/tests/test_cron.py
@@ -37,7 +37,7 @@ class TestCron(RunbotCase):
     def test_cron_build(self, mock_scheduler, mock_host_bootstrap, mock_host_docker_build, *args):
         """ test that cron_fetch_and_build do its work """
         hostname = 'cronhost.runbot.com'
-        self.patchers['fqdn_patcher'].return_value = hostname
+        self.patchers['hostname_patcher'].return_value = hostname
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_update_frequency', 1)
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_do_schedule', True)
         self.env['runbot.repo'].search([('id', '!=', self.repo_server.id)]).write({'mode': 'disabled'})  # disable all other existing repo than repo_server

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -420,7 +420,6 @@ class TestRepoScheduler(RunbotCase):
         # as the _scheduler method commits, we need to protect the database
         super(TestRepoScheduler, self).setUp()
 
-        self.fqdn_patcher = patch('odoo.addons.runbot.models.host.fqdn')
         mock_root = self.patchers['repo_root_patcher']
         mock_root.return_value = '/tmp/static'
 


### PR DESCRIPTION
Various fixes:

* fix broken custom build wizard that was not using the number_build parameter anymore
* use a real line feed in an xml file instead of a literal \n that broke odoorc file
*  use gethostname instead of getfqdn