### PR TITLE
[IMP] runbot: improve build_error management

### DIFF
--- a/runbot/controllers/hook.py
+++ b/runbot/controllers/hook.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 class Hook(http.Controller):
 
-    @http.route(['/runbot/hook', '/runbot/hook/<int:remote_id>'], type='http', auth="public", website=True, csrf=False)
+    @http.route(['/runbot/hook', '/runbot/hook/<int:remote_id>'], type='http', auth="public", website=True, csrf=False, sitemap=False)
     def hook(self, remote_id=None, **_post):
         event = request.httprequest.headers.get("X-Github-Event")
         payload = json.loads(request.params.get('payload', '{}'))

--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -12,6 +12,8 @@ class Branch(models.Model):
     _name = 'runbot.branch'
     _description = "Branch"
     _order = 'name'
+    _rec_name = 'dname'
+
     _sql_constraints = [('branch_repo_uniq', 'unique (name,remote_id)', 'The branch must be unique per repository !')]
 
     name = fields.Char('Name', required=True)
@@ -44,7 +46,7 @@ class Branch(models.Model):
 
     def _search_dname(self, operator, value):
         if ':' not in value:
-            return [('name', operator, 'value')]
+            return [('name', operator, value)]
         repo_short_name, branch_name = value.split(':')
         owner, repo_name = repo_short_name.split('/')
         return ['&', ('remote_id', '=', self.env['runbot.remote'].search([('owner', '=', owner), ('repo_name', '=', repo_name)]).id), ('name', operator, branch_name)]

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -7,27 +7,39 @@
           <form>
             <header>
             </header>
-              <group name="build_error_group">
-                <field name="fingerprint" readonly="1"/>
-                <field name="content"/>
-                <field name="module_name"/>
-                <field name="function"/>
-                <field name="random"/>
-                <field name="responsible"/>
-                <field name="team_id"/>
-                <field name="fixing_commit"/>
-                <field name="fixing_pr_id"/>
-                <field name="active"/>
-                <field name="parent_id" />
-                <field name="bundle_ids" widget="many2many_tags"/>
-                <field name="version_ids" widget="many2many_tags"/>
-                <field name="trigger_ids" widget="many2many_tags"/>
-                <field name="tag_ids" widget="many2many_tags"/>
-                <field name="first_seen_date"/>
-                <field name="first_seen_build_id" widget="frontend_url"/>
-                <field name="last_seen_date"/>
-                <field name="last_seen_build_id" widget="frontend_url"/>
-                <field name="test_tags"/>
+              <group>
+                <group name="build_error_group" string="Base info">
+                  <field name="content" readonly="1"/>
+                  <field name="module_name" readonly="1"/>
+                  <field name="function" readonly="1"/>
+                </group>
+              </group>
+              <group col="2">
+                <group name="fixer_info" string="Fixing">
+                  <field name="responsible"/>
+                  <field name="team_id"/>
+                  <field name="fixing_pr_id"/>
+                  <field name="active"/>
+                  <field name="test_tags" readonly="1" groups="!runbot.group_runbot_admin"/>
+                  <field name="test_tags" readonly="0" groups="runbot.group_runbot_admin"/>
+                </group>
+                  <group name="fixer_info" string="Fixing">
+                  <field name="version_ids" widget="many2many_tags"/>
+                  <field name="trigger_ids" widget="many2many_tags"/>
+                  <field name="tag_ids" widget="many2many_tags" readonly="1"/>
+                </group>
+              </group>
+              <group name="fixer_info" string="More info" col="2">
+                <group>
+                  <field name="random"/>
+                  <field name="first_seen_date"/>
+                  <field name="first_seen_build_id" widget="frontend_url"/>
+                </group>
+                <group>
+                  <field name="parent_id"/>
+                  <field name="last_seen_date"/>
+                  <field name="last_seen_build_id" widget="frontend_url"/>
+                </group>
               </group>
               <notebook>
                 <page string="Builds">
@@ -76,9 +88,12 @@
                     </tree>
                   </field>
                 </page>
-                <page string="Cleaned" groups="base.group_no_one">
+                <page string="Debug" groups="base.group_no_one">
                   <group name="build_error_group">
+                    <field name="fingerprint" readonly="1"/>
                     <field name="cleaned_content"/>
+                    <field name="fixing_commit"/>
+                    <field name="bundle_ids" widget="many2many_tags"/>
                   </group>
                 </page>
               </notebook>

--- a/runbot/views/menus.xml
+++ b/runbot/views/menus.xml
@@ -51,6 +51,7 @@
     <menuitem id="runbot_menu_ir_cron_act" action="base.ir_cron_act" parent="runbot_menu_technical"/>
     <menuitem id="runbot_menu_base_automation_act" action="base_automation.base_automation_act" parent="runbot_menu_technical"/>
     <menuitem id="runbot_menu_action_ui_view" action="base.action_ui_view" parent="runbot_menu_technical"/>
+    <menuitem id="runbot_menu_action_res_users" action="base.action_res_users" parent="runbot_menu_technical"/>
 
     <menuitem name="▶" id="runbot_menu_website" parent="runbot_menu_root" sequence="20000" action="website.action_website"/>
 


### PR DESCRIPTION
The build error view was unstructured and contains to much information.

This commit organize fields in groups and also validate some modification on records in order to avoid build error manager to disable test-tags by mistake.

An error cannot be deactivated if it appeared less than 24 hours ago to avoid disabling a non forxardported pr that will fail the next nightly generating another build error.

Test tags can only be added or removed by administrators.

Also adds a menu for easier User managerment

Also fixed the dname search and display.