### PR TITLE
[IMP] runbot: hide some buttons

### DIFF
--- a/runbot/security/runbot_security.xml
+++ b/runbot/security/runbot_security.xml
@@ -57,11 +57,16 @@
       <field name="category_id" ref="module_project"/>
     </record>
 
+    <record id="group_runbot_advanced_user" model="res.groups">
+      <field name="name">Advanced runbot user</field>
+      <field name="category_id" ref="module_project"/>
+    </record>
+
     <record id="group_runbot_admin" model="res.groups">
       <field name="name">Runbot administrator</field>
       <field name="category_id" ref="module_project"/>
       <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
-      <field name="implied_ids" eval="[(4, ref('runbot.group_user')), (4, ref('runbot.group_build_config_administrator'))]"/>
+      <field name="implied_ids" eval="[(4, ref('runbot.group_runbot_advanced_user')), (4, ref('runbot.group_user')), (4, ref('runbot.group_build_config_administrator'))]"/>
     </record>
     
 

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -11,13 +11,13 @@
                                     <t t-esc="bundle.name"/>
                                     <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
                                     <div class="btn-group" role="group">
-                                        <a groups="runbot.group_runbot_admin" t-attf-href="/web/#id={{bundle.id}}&amp;view_type=form&amp;model=runbot.bundle&amp;menu_id={{env.ref('runbot.runbot_menu_root').id}}" class="btn btn-default btn-sm" target="new" title="View in Backend">
+                                        <a groups="runbot.group_runbot_advanced_user" t-attf-href="/web/#id={{bundle.id}}&amp;view_type=form&amp;model=runbot.bundle&amp;menu_id={{env.ref('runbot.runbot_menu_root').id}}" class="btn btn-default btn-sm" target="new" title="View in Backend">
                                           <i class="fa fa-list"/>
                                         </a>
-                                        <a class="btn btn-default" groups="base.group_user" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Force A New Batch">
+                                        <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Force A New Batch">
                                             <i class="fa fa-refresh"/>
                                         </a>
-                                        <a class="btn btn-default" groups="base.group_user" t-attf-href="/runbot/bundle/{{bundle.id}}/force/1" title="Force A New Batch with automatic rebase">
+                                        <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force/1" title="Force A New Batch with automatic rebase">
                                             <i class="fa fa-fast-forward"/>
                                         </a>
                                         <t t-call="runbot.branch_copy_button"/>


### PR DESCRIPTION
Force new batch buttons can be sometimes confusing for user. Creating a group to show this button for advanced user only will help avoiding useless new batch when it's not needed.

New batch is only needed:
- to create a new slot when a new trigger is added/modified through a custom trigger
- take last databases into account for upgrades, mainly when backporting a new field or strange usually forbiden operations
- avoiding to need to push again to rebase when a r+ was added on one pr but one of them needs to be rebased or adapted.

Thos case are unusuall but the button is used most of the time thinking this is a kind or rebuild or maybe it will rebase and push the branch on the pr. Only user with basic knowledge of when it is needed should have access to these buttons.