### PR TITLE
[IMP] runbot: avoid concurrent update when updating build status

### DIFF
--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -287,7 +287,12 @@ class MessageQueue(models.Model):
 
     def _process(self):
         records = self
-        # todo consume messages here
+        global_updates = records.filtered(lambda r: r.message == 'global_updated')
+        global_updates.build_id._update_globals()
+        records -= global_updates
+        # ask_kills = records.filtered(lambda r: r.message == 'ask_kill')
+        # ask_kills.build_id._ask_kill()
+        # records -= ask_kills
         if records:
             for record in records:
                 self.env['runbot.runbot'].warning(f'Host {record.host_id.name} got an unexpected message {record.message}')

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -275,7 +275,6 @@ class Runbot(models.AbstractModel):
                     _logger.warning('Removing %s from pull_info_failures', pr_number)
                     del pull_info_failures[pr_number]
 
-
         return manager.get('sleep', default_sleep)
 
     def _scheduler_loop_turn(self, host, sleep=5):

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -173,10 +173,9 @@ class TestBuildResult(RunbotCase):
 
         # test a bulk write, that one cannot change from 'ko' to 'ok'
         builds = self.Build.browse([build.id, other.id])
-        with self.assertRaises(ValidationError):
-            builds.write({'local_result': 'warn'})
-        # self.assertEqual(build.local_result, 'warn')
-        # self.assertEqual(other.local_result, 'ko')
+        builds.write({'local_result': 'warn'})
+        self.assertEqual(build.local_result, 'warn')
+        self.assertEqual(other.local_result, 'ko')
 
 
     def test_markdown_description(self):
@@ -385,16 +384,16 @@ class TestBuildResult(RunbotCase):
         with self.assertQueries([]):  # no change should be triggered
             build1_2.local_state = "testing"
 
-        # with self.assertQueries(['''UPDATE "runbot_build" SET "global_state"=%s,"local_state"=%s,"write_date"=%s,"write_uid"=%s WHERE id IN %s''']):
-        build1.local_state = 'done'
-        build1.flush()
+        with self.assertQueries(['''UPDATE "runbot_build" SET "global_state"=%s,"local_state"=%s,"write_date"=%s,"write_uid"=%s WHERE id IN %s''']):
+            build1.local_state = 'done'
+            build1.flush()
 
         self.assertEqual('waiting', build1.global_state)
         self.assertEqual('testing', build1_1.global_state)
 
-        # with self.assertQueries([]): # write the same value, no update should be triggered
-        build1.local_state = 'done'
-        build1.flush()
+        with self.assertQueries([]): # write the same value, no update should be triggered
+            build1.local_state = 'done'
+            build1.flush()
 
         build1_1.local_state = 'done'
 

--- a/runbot_populate/demo/runbot_demo.xml
+++ b/runbot_populate/demo/runbot_demo.xml
@@ -55,6 +55,10 @@
         <field name="repo_id" ref="repo_runbot"/>
     </record>
 
+    <record id="version_16" model="runbot.version">
+        <field name="name">16.0</field>
+    </record>
+
     <!-- BUNDLES -->
     <record id="bundle_16_1" model="runbot.bundle">
         <field name="name">saas-16.1</field>
@@ -146,7 +150,6 @@
         <field name="ci_context"/>        
     </record>
 
-
     <record id="runbot_build_config_linting" model="runbot.build.config">
         <field name="name">Linting</field>
     </record>
@@ -154,6 +157,47 @@
         <field name="name">Security</field>
     </record>
 
+    <record id="runbot_build_config_split" model="runbot.build.config">
+        <field name="name">Split</field>
+    </record>
+
+    <record id="runbot_build_config_post_install" model="runbot.build.config">
+        <field name="name">Post install</field>
+    </record>
+
+    <record id="main_host" model="runbot.host">
+        <field name="name">main host</field>
+    </record>
+
+    <record id="build_base_params" model="runbot.build.params">
+        <field name="config_id" ref="runbot_build_config_split"/>
+        <field name="version_id" ref="version_16"/>
+        <field name="project_id" ref="project_runbot"/>
+    </record>
+
+    <record id="build_base" model="runbot.build">
+        <field name="params_id" ref="build_base_params"/>
+        <field name="host">main host</field>
+    </record>
+
+    <record id="build_child_params" model="runbot.build.params">
+        <field name="config_id" ref="runbot_build_config_post_install"/>
+        <field name="version_id" ref="version_16"/>
+        <field name="project_id" ref="project_runbot"/>
+    </record>
+
+    <record id="build_child1" model="runbot.build">
+        <field name="params_id" ref="build_child_params"/>
+        <field name="parent_id" ref="build_base"/>
+        <field name="host">main host</field>
+    </record>
+
+    <record id="build_child2" model="runbot.build">
+        <field name="params_id" ref="build_child_params"/>
+        <field name="parent_id" ref="build_base"/>
+        <field name="host">main host</field>
+    </record>
+    
     <function model="runbot.runbot" name="_create_demo_data">
     </function>
     

--- a/runbot_populate/tests/__init__.py
+++ b/runbot_populate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_concurrency

--- a/runbot_populate/tests/test_concurrency.py
+++ b/runbot_populate/tests/test_concurrency.py
@@ -1,0 +1,55 @@
+from odoo import api, SUPERUSER_ID
+from odoo.tests import TransactionCase
+from unittest.mock import patch
+
+
+class TestConcurrency(TransactionCase):
+    def test_local_status_update(self):
+        """
+        This test ensures that a parent build global state will eventually be updated
+        even if updated concurrenctly in 2 different transactions, without transaction error
+        """
+        with self.registry.cursor() as cr0:
+            env0 = api.Environment(cr0, SUPERUSER_ID, {})
+            host = env0.ref('runbot_populate.main_host')
+            host._process_messages()  # ensure queue is empty
+            parent_build = env0.ref('runbot_populate.build_base')
+            build_child1 = env0.ref('runbot_populate.build_child1')
+            build_child2 = env0.ref('runbot_populate.build_child2')
+            parent_build.local_state = 'done'
+            self.assertEqual(host.host_message_ids.mapped('message'), [])
+            build_child1.local_state = 'testing'
+            build_child2.local_state = 'testing'
+            self.assertEqual(host.host_message_ids.mapped('message'), ['global_updated', 'global_updated'])
+            self.assertEqual(host.host_message_ids.build_id, parent_build)
+            host._process_messages()
+            self.assertEqual(parent_build.global_state, 'waiting')
+            env0.cr.commit()  # youplahé
+
+            with self.registry.cursor() as cr1:
+                env1 = api.Environment(cr1, SUPERUSER_ID, {})
+                with self.registry.cursor() as cr2:
+                    env2 = api.Environment(cr2, SUPERUSER_ID, {})
+                    build_child_cr1 = env1['runbot.build'].browse(build_child1.id)
+                    build_child_cr2 = env2['runbot.build'].browse(build_child2.id)
+                    self.assertEqual(build_child_cr1.parent_id.global_state, 'waiting')
+                    self.assertEqual(build_child_cr1.parent_id.children_ids.mapped('local_state'), ['testing', 'testing'])
+                    self.assertEqual(build_child_cr2.parent_id.global_state, 'waiting')
+                    self.assertEqual(build_child_cr2.parent_id.children_ids.mapped('local_state'), ['testing', 'testing'])
+                    build_child_cr1.local_state = 'done'
+                    build_child_cr2.local_state = 'done'
+                    # from the point of view of each transaction, the other one local_state didn't changed
+                    self.assertEqual(build_child_cr1.parent_id.children_ids.mapped('local_state'), ['testing', 'done'])
+                    self.assertEqual(build_child_cr2.parent_id.global_state, 'waiting')
+                    self.assertEqual(build_child_cr2.parent_id.children_ids.mapped('local_state'), ['done', 'testing'])
+                    env1.cr.commit()
+                    env2.cr.commit()
+                    env0.cr.commit()  # not usefull just to ensure we have efefct of other transactions
+                    env0.cache.invalidate()
+                    self.assertEqual(parent_build.children_ids.mapped('local_state'), ['done', 'done'])
+                    self.assertEqual(parent_build.children_ids.mapped('global_state'), ['done', 'done'])
+                    self.assertEqual(host.host_message_ids.mapped('message'), ['global_updated', 'global_updated'])
+                    self.assertEqual(host.host_message_ids.build_id, parent_build)
+                    # at this point, this assertion is true, but not expected : self.assertEqual(parent_build.global_state, 'waiting')
+                    host._process_messages()
+                    self.assertEqual(parent_build.global_state, 'done')


### PR DESCRIPTION
A common issue on runbot.odoo.com are concurrent updates, mainly for build with many subuilds. This is mainly visible during the nightly builds, since there are a lot of builds spread on almost all host. Because of that, a build that should take a few seconds can take multiple minutes to be able to write the status. This phenomenon became more and more visible with the number of hosts in the infrastructure. 

This is not an issue most of the time since Split config have a limited number of subuilds (~10) and they don't usually write status at the same time. They also are quite long build meaning that the concurrency is not so visible. This became a problem only with the nightly and multibuilds.

A common example to reproduce the issue is when trying to reproduce a random error: Using a custom config, a database is restored and a test that may last a few seconds is started. If the complete tests takes ~30 seconds, for some of the subuild it can take multiple minutes because of the scheduler retrying to write the result/state.

Example:

```
2023-03-01 23:00:03,155 ERROR odoo.sql_db: bad query: UPDATE "runbot_build" SET "global_state"='waiting',"write_date"='2023-03-01T23:00:02.682585'::timestamp,"write_uid"=1 WHERE id IN (24549289, 24549938, 24550022)
ERROR: could not serialize access due to concurrent update
```

The issue is that multiple sub-build finishing at the same time will write at the exact same time on the same record,  creating a restart of the scheduler loop for almost all of them.

One of the cause of this issue is that global_state and global_result are **store computed fields**. In 15.0 the compute field will write on the record even if the value didn't change as soon as the compute was triggered. This fields needs to be stored
since it is displayed on the main page and it wouldn't be a good idea to fetch all sub-builds to have this information for display. This is also usefull to be able to search on this.

We don't really need and synchronous update of a global_state, especially if the update is done quite quickly. **The first idea** of this pull request is to give the responsibility of the global_state/global_result management to the parent build.

- Only one host can write on a build, the builds update his own state by checking children states.
- Not using a compute field will also help avoiding concurrent update since we won't write every time. This could be enough as a solution, since the concurrent update should only happen once,  but we would like to avoid having any. 

The main downside of this solution is that a build will need to check child states quite often. 
- if a runbot is down, or slow because of a docker image update, the state may take a while to be updated. 
- we need to read all children quite often. 

The intermediate solution of not writing computed value every-time would be also enough. This means that we may have at most one concurrent update per child per change of result/state. When right now in the worst case it could be the factorial of number of children. But this solution revealed not being safe in all case because not triggering the update may cause inconsistency if the state could have been different with other childs state. See `test_local_status_update` demonstrating this issue. The last assertion was not working in the previous version: The two child will compute the parent state at the same time and think that the state is still waiting (other child looks testing).

The final chosen solution uses a queue to avoid reading to much on children.
 