### PR TITLE
[IMP] runbot: better team ownership management

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -56,12 +56,13 @@
         'views/custom_trigger_wizard_views.xml',
         'wizards/stat_regex_wizard_views.xml',
         'views/menus.xml',
+        'views/user.xml',
     ],
     'license': 'LGPL-3',
 
     'assets': {
         'web.assets_backend': [
-            'runbot/static/src/js/json_field.js',
+            'runbot/static/src/js/fields.js',
         ],
     }
 

--- a/runbot/common.py
+++ b/runbot/common.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import psycopg2
 import re
+import requests
 import socket
 import time
 import os
@@ -166,3 +167,11 @@ def pseudo_markdown(text):
 
     text = Markup(re.sub(r'<code>(\d+)</code>', code_replace, text, flags=re.DOTALL))
     return text
+
+
+def _make_github_session(token):
+    session = requests.Session()
+    if token:
+        session.auth = (token, 'x-oauth-basic')
+    session.headers.update({'Accept': 'application/vnd.github.she-hulk-preview+json'})
+    return session

--- a/runbot/data/runbot_data.xml
+++ b/runbot/data/runbot_data.xml
@@ -58,6 +58,11 @@ admin_passwd=running_master_password</field>
         <field name="value">fw-bot</field>
     </record>
 
+    <record model="ir.config_parameter" id="runbot.runbot_organisation">
+        <field name="key">runbot.runbot_organisation</field>
+        <field name="value">odoo</field>
+    </record>
+
     <record model="ir.actions.server" id="action_toggle_is_base">
         <field name="name">Mark is base</field>
         <field name="model_id" ref="runbot.model_runbot_bundle" />

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -13,6 +13,7 @@ _logger = logging.getLogger(__name__)
 class Bundle(models.Model):
     _name = 'runbot.bundle'
     _description = "Bundle"
+    _inherit = 'mail.thread'
 
     name = fields.Char('Bundle name', required=True, help="Name of the base branch")
     project_id = fields.Many2one('runbot.project', required=True, index=True)
@@ -49,6 +50,7 @@ class Bundle(models.Model):
     dockerfile_id = fields.Many2one('runbot.dockerfile', index=True, help="Use a custom Dockerfile")
     commit_limit = fields.Integer("Commit limit")
     file_limit = fields.Integer("File limit")
+    disable_codeowner = fields.Boolean("Disable codeowners", tracking=True)
 
     @api.depends('name')
     def _compute_host_id(self):
@@ -188,7 +190,6 @@ class Bundle(models.Model):
     def _url(self):
         self.ensure_one()
         return "/runbot/bundle/%s" % self.id
-
 
     def create(self, values_list):
         res = super().create(values_list)

--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -1,7 +1,7 @@
 
 import subprocess
 
-from ..common import os, RunbotException
+from ..common import os, RunbotException, _make_github_session
 import glob
 import shutil
 
@@ -212,7 +212,7 @@ class CommitStatus(models.Model):
                         _logger.warning('No token on remote %s, skipping status', remote.mapped("name"))
                     else:
                         if remote.token not in session_cache:
-                            session_cache[remote.token] = remote._make_github_session()
+                            session_cache[remote.token] = _make_github_session(remote.token)
                         session = session_cache[remote.token]
                         _logger.info(
                             "github updating %s status %s to %s in repo %s",

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -13,6 +13,8 @@ class Project(models.Model):
     dockerfile_id = fields.Many2one('runbot.dockerfile', index=True, help="Project Default Dockerfile")
     repo_ids = fields.One2many('runbot.repo', 'project_id', string='Repos')
     sequence = fields.Integer('Sequence')
+    organisation = fields.Char('organisation', default=lambda self: self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_organisation'))
+    token = fields.Char("Github token", groups="runbot.group_runbot_admin")
 
 
 class Category(models.Model):

--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -26,6 +26,7 @@ class ResConfigSettings(models.TransientModel):
     runbot_do_schedule = fields.Boolean('Schedule builds')
     runbot_is_base_regex = fields.Char('Regex is_base')
     runbot_forwardport_author = fields.Char('Forwardbot author')
+    runbot_organisation = fields.Char('Organisation')
 
     runbot_db_gc_days = fields.Integer(
         'Days before gc',
@@ -70,6 +71,7 @@ class ResConfigSettings(models.TransientModel):
                    runbot_do_schedule=get_param('runbot.runbot_do_schedule', default=False),
                    runbot_is_base_regex=get_param('runbot.runbot_is_base_regex', default=''),
                    runbot_forwardport_author = get_param('runbot.runbot_forwardport_author', default=''),
+                   runbot_organisation = get_param('runbot.runbot_organisation', default=''),
                    )
         return res
 
@@ -91,6 +93,7 @@ class ResConfigSettings(models.TransientModel):
         set_param('runbot.runbot_do_schedule', self.runbot_do_schedule)
         set_param('runbot.runbot_is_base_regex', self.runbot_is_base_regex)
         set_param('runbot.runbot_forwardport_author', self.runbot_forwardport_author)
+        set_param('runbot.runbot_organisation', self.runbot_organisation)
 
     @api.onchange('runbot_is_base_regex')
     def _on_change_is_base_regex(self):

--- a/runbot/models/res_users.py
+++ b/runbot/models/res_users.py
@@ -8,3 +8,21 @@ class ResUsers(models.Model):
     _inherit = 'res.users'
 
     runbot_team_ids = fields.Many2many('runbot.team', string="Runbot Teams")
+    github_login = fields.Char('Github account')
+
+    _sql_constraints = [
+        (
+            "github_login_unique",
+            "unique (github_login)",
+            "Github login can only belong to one user",
+        )
+    ]
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ['github_login']
+
+    def write(self, values):
+        if list(values.keys()) == ['github_login'] and self.env.user.has_group('runbot.group_runbot_team_manager'):
+            return super(ResUsers, self.sudo()).write(values)
+        return super().write(values)

--- a/runbot/static/src/js/fields.js
+++ b/runbot/static/src/js/fields.js
@@ -67,6 +67,39 @@ registry.add('frontend_url', FrontendUrl)
 function stringify(obj) {
     return JSON.stringify(obj, null, '\t')
 }
+
 field_utils.format.jsonb = stringify;
 field_utils.parse.jsonb = JSON.parse;
+
+var GithubTeamWidget = basic_fields.InputField.extend({
+    events: _.extend({'click': '_onClick'}, basic_fields.InputField.prototype.events),
+    _renderReadonly: function () {
+        if (!this.value) {
+            return;
+        }
+        this.el.textContent = '';
+        const organisation = this.record.data.organisation;
+        this.value.split(',').forEach((value) => {
+            const href = 'https://github.com/orgs/' + organisation + '/teams/' + value.trim() + '/members';
+            const anchorEl = Object.assign(document.createElement('a'), {
+                text: value + " ",
+                href: href,
+                target: '_blank',
+            });
+            this.el.appendChild(anchorEl);
+        });
+      
+    },
+
+    /**
+     * Prevent the URL click from opening the record (when used on a list).
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onClick: function (ev) {
+        ev.stopPropagation();
+    },
+});
+registry.add('github_team', GithubTeamWidget)
+
 });

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -12,6 +12,7 @@
                   <field name="content" readonly="1"/>
                   <field name="module_name" readonly="1"/>
                   <field name="function" readonly="1"/>
+                  <field name="file_path" readonly="1"/>
                 </group>
               </group>
               <group col="2">

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -12,6 +12,7 @@
                     <field name="group_ids"/>
                     <field name="trigger_ids"/>
                     <field name="sequence"/>
+                    <field name="token" password="True"/>
                 </group>
             </form>
         </field>
@@ -54,6 +55,7 @@
                     <field name="host_id" readonly="0"/>
                     <field name="commit_limit"/>
                     <field name="file_limit"/>
+                    <field name="disable_codeowner"/>
                     <field name="branch_ids">
                         <tree>
                             <field name="dname"/>
@@ -78,8 +80,12 @@
                             <field name="slot_ids"/>
                         </tree>
                     </field>
-
                 </group>
+
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>

--- a/runbot/views/codeowner_views.xml
+++ b/runbot/views/codeowner_views.xml
@@ -9,7 +9,8 @@
                     <group>
                         <field name="project_id"/>
                         <field name="team_id"/>
-                        <field name="github_teams"/>
+                        <field name="organisation" invisible="1"/>
+                        <field name="github_teams" widget="github_team"/>
                         <field name="regex"/>
                         <field name="version_domain" widget="domain" options="{'model': 'runbot.version', 'in_dialog': True, 'operators': ['in','=', '&lt;', '&gt;']}"/>
                     </group>
@@ -28,10 +29,11 @@
         <field name="arch" type="xml">
             <tree string="Codeowners">
                 <field name="project_id"/>
-                <field name="team_id"/>
                 <field name="version_domain"/>
                 <field name="regex"/>
-                <field name="github_teams"/>
+                <field name="organisation" invisible="1"/>
+                <field name="team_id"/>
+                <field name="github_teams" widget="github_team"/>
             </tree>
         </field>
     </record>

--- a/runbot/views/dashboard_views.xml
+++ b/runbot/views/dashboard_views.xml
@@ -8,22 +8,30 @@
             <sheet>
               <group name="team_group">
                 <field name="name"/>
-                <field name="github_team"/>
+                <field name="organisation" invisible="1"/>
+                <field name="github_team" widget="github_team"/>
+                <field name="github_logins"/>
+                <field name="skip_team_pr"/>
                 <field name="dashboard_id"/>
                 <field name="path_glob"/>
                 <field name="module_ownership_ids">
                   <tree>
-                    <field name="module_id"/>
-                    <field name="is_fallback"/>
+                    <field name="module_id" readonly="1"/>
+                    <field name="is_fallback" widget="boolean_toggle"/>
                   </tree>
                 </field>
               </group>
               <notebook>
+                <page string="Team Members">
+                  <field name="user_ids" nolabel="1" widget="many2many" options="{'not_delete': True, 'no_create': True}">
+                    <tree editable="bottom">
+                      <field name="name" readonly="1"></field>
+                      <field name="github_login"></field>
+                    </tree>
+                  </field>
+                </page>
                 <page string="Team Errors">
                   <field name="build_error_ids" nolabel="1" widget="many2many" options="{'not_delete': True, 'no_create': True}"/>
-                </page>
-                <page string="Team Members">
-                  <field name="user_ids" nolabel="1" widget="many2many" options="{'not_delete': True, 'no_create': True}"/>
                 </page>
               </notebook>
             </sheet>
@@ -56,7 +64,7 @@
               <field name="ownership_ids">
                 <tree editable="bottom">
                   <field name="team_id"/>
-                  <field name="is_fallback"/>
+                  <field name="is_fallback" widget="boolean_toggle"/>
                 </tree>
               </field>
             </group>
@@ -71,7 +79,8 @@
         <field name="arch" type="xml">
             <tree string="Runbot modules">
               <field name="name"/>
-              <field name="ownership_ids"/>
+              <field name="ownership_ids" widget="many2many_tags"/>
+              <field name="team_ids" widget="many2many_tags"/>
             </tree>
         </field>
     </record>
@@ -96,7 +105,7 @@
             <tree string="Runbot modules ownership" editable="bottom" multi_edit="1">
               <field name="team_id"/>
               <field name="module_id"/>
-              <field name="is_fallback"/>
+              <field name="is_fallback" widget="boolean_toggle"/>
             </tree>
         </field>
     </record>
@@ -171,6 +180,17 @@
             </tree>
         </field>
     </record>
+
+    <record model="ir.actions.server" id="action_fetch_team_members">
+      <field name="name">Fetch members</field>
+      <field name="model_id" ref="runbot.model_runbot_team" />
+      <field name="binding_model_id" ref="runbot.model_runbot_team" />
+      <field name="type">ir.actions.server</field>
+      <field name="state">code</field>
+      <field name="code">
+          action = records._fetch_members()
+      </field>
+   </record>
 
     <record id="open_view_runbot_dashboard_tile" model="ir.actions.act_window">
       <field name="name">Runbot Dashboards Tiles</field>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -98,7 +98,7 @@
                     <field name="fetch_heads" string="Branch"/>
                     <field name="fetch_pull" string="PR"/>
                     <field name="send_status"/>
-                    <field name="token"/>
+                    <field name="token" password="True"/>
                   </tree>
                 </field>
               </group>

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -46,6 +46,8 @@
                           <field name="runbot_is_base_regex" style="width: 55%;"/>
                           <label for="runbot_forwardport_author" class="col-xs-3 o_light_label" style="width: 40%;"/>
                           <field name="runbot_forwardport_author" style="width: 55%;"/>
+                          <label for="runbot_organisation" class="col-xs-3 o_light_label" style="width: 40%;"/>
+                          <field name="runbot_organisation" style="width: 55%;"/>
                           <label for="runbot_logdb_name" class="col-xs-3 o_light_label" style="width: 40%;"/>
                           <field name="runbot_logdb_name" style="width: 15%;"/>
                         </div>

--- a/runbot/views/user.xml
+++ b/runbot/views/user.xml
@@ -1,0 +1,55 @@
+<odoo>
+<data>
+    <record id="res_users_form_view_runbot" model="ir.ui.view">
+        <field name="name">res.users.form.view</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form_simple_modif" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='email']" position="after">
+                <field name="github_login"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="res_users_view_search">
+        <field name="name">res.users.view.search.inherit.runbot</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//search" position="inside">
+                <separator/>
+                <field name="github_login"/>
+                <filter string="Has github login" name="has_github_login" domain="[('github_login', '!=', False)]"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="runbot_users_form">
+        <field name="name">Runbot Users Form</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Runbot">
+                    <group>
+                        <field name="github_login"/>
+                        <field name="runbot_team_ids"/>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_users_state_tree" model="ir.ui.view">
+        <field name="name">res.users.tree.inherit</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='login_date']" position="after">
+                <field name="github_login"/>
+            </xpath>
+        </field>
+    </record>
+
+</data>
+</odoo>


### PR DESCRIPTION
This idea was postpone for a while since this was most a mergebot responsability but having the github login of the user will help for some team feature requests.

The main one is to only ping a team if the pr was not opened by a member of the team. We want to let the team manager manage that as much as possible so the team manager group will be able to write the user github login (as well as the user himself) and add a list of non user github_login to consider if not all user have a account on runbot.

This commit also improves the views for team managers.