### PR TITLE
[IMP] runbot: add cpus parameter

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -122,7 +122,7 @@ def docker_run(*args, **kwargs):
     return _docker_run(*args, **kwargs)
 
 
-def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, memory=None, preexec_fn=None, ro_volumes=None, env_variables=None):
+def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, cpu_period=100000, cpus=0, memory=None, preexec_fn=None, ro_volumes=None, env_variables=None):
     """Run tests in a docker container
     :param run_cmd: command string to run in container
     :param log_path: path to the logfile that will contain odoo stdout and stderr
@@ -131,6 +131,8 @@ def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False
     :param container_name: used to give a name to the container for later reference
     :param image_tag: Docker image tag name to select which docker image to use
     :param exposed_ports: if not None, starting at 8069, ports will be exposed as exposed_ports numbers
+    :param cpu_period: Specify the CPU CFS scheduler period, which is used alongside cpu_quota
+    :param cpus: used to compute cpu_quota = cpu_period * cpus (equivalent of --cpus in docker CLI)
     :param memory: memory limit in bytes for the container
     :params ro_volumes: dict of dest:source volumes to mount readonly in builddir
     :params env_variables: list of environment variables
@@ -181,6 +183,8 @@ def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False
         mem_limit=memory,
         ports=ports,
         ulimits=ulimits,
+        cpu_period=cpu_period,
+        cpu_quota=int(cpus * cpu_period ) if cpus else None,
         environment=env_variables,
         init=True,
         command=['/bin/bash', '-c',

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -770,6 +770,7 @@ class BuildResult(models.Model):
         containers_memory_limit = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_memory', 0)
         if containers_memory_limit and 'memory' not in kwargs:
             kwargs['memory'] = int(float(containers_memory_limit) * 1024 ** 3)
+
         self.docker_start = now()
         if self.job_start:
             start_step_time = int(dt2time(self.docker_start) - dt2time(self.job_start))

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -641,8 +641,6 @@ class BuildResult(models.Model):
                     build._log('wake_up', 'Impossible to wake-up, **build dir does not exists anymore**', log_type='markdown', level='SEPARATOR')
                 else:
                     try:
-                        log_path = build._path('logs', 'wake_up.txt')
-
                         port = self._find_port()
                         build.write({
                             'job_start': now(),
@@ -658,7 +656,7 @@ class BuildResult(models.Model):
                             run_step = step_ids[-1]
                         else:
                             run_step = self.env.ref('runbot.runbot_build_config_step_run')
-                        run_step._run_step(build, log_path, force=True)
+                        run_step._run_step(build, force=True)
                         # reload_nginx will be triggered by _run_run_odoo
                     except Exception:
                         _logger.exception('Failed to wake up build %s', build.dest)

--- a/runbot/models/build_config_codeowner.py
+++ b/runbot/models/build_config_codeowner.py
@@ -60,7 +60,7 @@ class ConfigStep(models.Model):
             reviewer_per_file[file] = file_reviewers
         return reviewer_per_file
 
-    def _run_codeowner(self, build, log_path):
+    def _run_codeowner(self, build):
         bundle = build.params_id.create_batch_id.bundle_id
         if bundle.is_base:
             build._log('', 'Skipping base bundle')

--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -10,6 +10,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     runbot_workers = fields.Integer('Default number of workers')
+    runbot_containers_cpus = fields.Float('Allowed Containers CPUs (0 means no limit)')
     runbot_containers_memory = fields.Float('Memory limit for containers (in GiB)')
     runbot_memory_bytes = fields.Float('Bytes', compute='_compute_memory_bytes')
     runbot_running_max = fields.Integer('Maximum number of running builds')
@@ -58,6 +59,7 @@ class ResConfigSettings(models.TransientModel):
         res = super(ResConfigSettings, self).get_values()
         get_param = self.env['ir.config_parameter'].sudo().get_param
         res.update(runbot_workers=int(get_param('runbot.runbot_workers', default=2)),
+                   runbot_containers_cpus=float(get_param('runbot.runbot_containers_cpus', default=0)),
                    runbot_containers_memory=float(get_param('runbot.runbot_containers_memory', default=0)),
                    runbot_running_max=int(get_param('runbot.runbot_running_max', default=5)),
                    runbot_timeout=int(get_param('runbot.runbot_timeout', default=10000)),
@@ -81,6 +83,7 @@ class ResConfigSettings(models.TransientModel):
         super(ResConfigSettings, self).set_values()
         set_param = self.env['ir.config_parameter'].sudo().set_param
         set_param("runbot.runbot_workers", self.runbot_workers)
+        set_param("runbot.runbot_containers_cpus", self.runbot_containers_cpus)
         set_param("runbot.runbot_containers_memory", self.runbot_containers_memory)
         set_param("runbot.runbot_running_max", self.runbot_running_max)
         set_param("runbot.runbot_timeout", self.runbot_timeout)

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -16,6 +16,8 @@
                         <div class="content-group">
                           <label for="runbot_workers" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_workers" style="width: 15%;"/>
+                          <label for="runbot_containers_cpus" class="col-xs-3 o_light_label" style="width: 60%;"/>
+                          <field name="runbot_containers_cpus" style="width: 15%;"/>&amp;nbsp;
                           <label for="runbot_containers_memory" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_containers_memory" style="width: 15%;"/>&amp;nbsp;
                           <field name="runbot_memory_bytes" readonly='1' style="width: 15%;"/>

--- a/runbot_cla/build_config.py
+++ b/runbot_cla/build_config.py
@@ -15,7 +15,7 @@ class Step(models.Model):
 
     job_type = fields.Selection(selection_add=[('cla_check', 'Check cla')], ondelete={'cla_check': 'cascade'})
 
-    def _run_cla_check(self, build, log_path):
+    def _run_cla_check(self, build):
         build._checkout()
         cla_glob = glob.glob(build._get_server_commit()._source_path("doc/cla/*/*.md"))
         error = False


### PR DESCRIPTION
When a build eats all the CPU's resources, it may interfere with other builds and cause collateral damages.

With this commit, a new settings parameter `Containers CPUs` is added in order to limit the usage of available CPU's on runbot instances.

If left to 0, no limts are applied.

Otherwise, the cpu_quota docker parameter is computed as Containers CPU's * (logical cpu's count / nb parallel builds) * cpu period which defaults to 100000.

e.g.:
- on a host with 16 logical CPU's
- with 8 parallel builds allowed
- with Containers CPUs set to 1.5
- with the default cpu_period cpu_quota will be:
    (16/8) * 1.5 * 100000 = 300000

This system parameter can be overridden by the `container_cpus` field on
steps.

references: 
  *  https://docs.docker.com/config/containers/resource_constraints/#cpu
  * https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run
 