### PR TITLE
[IMP] runbot: cross project trigger

### DIFF
--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -12,6 +12,7 @@ class Project(models.Model):
     trigger_ids = fields.One2many('runbot.trigger', 'project_id', string='Triggers')
     dockerfile_id = fields.Many2one('runbot.dockerfile', index=True, help="Project Default Dockerfile")
     repo_ids = fields.One2many('runbot.repo', 'project_id', string='Repos')
+    enable_base_triggers = fields.Boolean('Enable base triggers', default=True)
     sequence = fields.Integer('Sequence')
 
 

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -38,7 +38,7 @@ class Trigger(models.Model):
     sequence = fields.Integer('Sequence')
     name = fields.Char("Name")
     description = fields.Char("Description", help="Informative description")
-    project_id = fields.Many2one('runbot.project', string="Project id", required=True)  # main/security/runbot
+    project_id = fields.Many2one('runbot.project', string="Project id", default=lambda self: self.env.ref('runbot.main_project'))
     repo_ids = fields.Many2many('runbot.repo', relation='runbot_trigger_triggers', string="Triggers", domain="[('project_id', '=', project_id)]")
     dependency_ids = fields.Many2many('runbot.repo', relation='runbot_trigger_dependencies', string="Dependencies")
     config_id = fields.Many2one('runbot.build.config', string="Config", required=True)

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -8,6 +8,7 @@
                 <group>
                     <field name="name"/>
                     <field name="keep_sticky_running"/>
+                    <field name="enable_base_triggers"/>
                     <field name="dockerfile_id"/>
                     <field name="group_ids"/>
                     <field name="trigger_ids"/>
@@ -23,6 +24,7 @@
             <tree string="Projects">
                 <field name="name"/>
                 <field name="keep_sticky_running"/>
+                <field name="enable_base_triggers"/>
                 <field name="dockerfile_id"/>
                 <field name="group_ids"/>
                 <field name="trigger_ids"/>


### PR DESCRIPTION
Allow to create a trigger without project, that execute for every project. In this case the repos are all the repo of the project that where updated.

This is mainly for psxrunbot.

Also allows to create a trigger that cross category