### PR TITLE
[FIX] runbot: avoid recursion in create steps

### DIFF
--- a/runbot/data/runbot_build_config_data.xml
+++ b/runbot/data/runbot_build_config_data.xml
@@ -149,10 +149,18 @@
         <field name="protected" eval="True"/>
     </record>
 
+    <record id="runbot_build_config_step_create_custom_multi" model="runbot.build.config.step">
+        <field name="name">custom_multi</field>
+        <field name="job_type">create_build</field>
+        <field name="number_builds">0</field>
+        <field name="protected" eval="True"/>
+    </record>
+
+
     <record id="runbot_build_config_custom_multi" model="runbot.build.config">
         <field name="name">Custom Multi</field>
         <field name="description">Generic multibuild to use with custom trigger wizard</field>
-        <field name="step_order_ids" eval="[(5,0,0), (0, 0, {'step_id': ref('runbot_build_config_step_create_light_multi')})]"/>
+        <field name="step_order_ids" eval="[(5,0,0), (0, 0, {'step_id': ref('runbot_build_config_step_create_custom_multi')})]"/>
         <field name="protected" eval="True"/>
     </record>
     

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -345,6 +345,11 @@ class BuildResult(models.Model):
         return res
 
     def _add_child(self, param_values, orphan=False, description=False, additionnal_commit_links=False):
+
+        if len(self.parent_path.split('/')) > 8:
+            self._log('_run_create_build', 'This is too deep, skipping create')
+            return self
+
         if additionnal_commit_links:
             commit_link_ids = self.params_id.commit_link_ids
             commit_link_ids |= additionnal_commit_links

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -289,13 +289,13 @@ class ConfigStep(models.Model):
         config_data = build.params_id.config_data
         config_ids = config_data.get('create_config_ids', self.create_config_ids)
 
-        child_data_list = config_data.get('child_data',[{}])
+        child_data_list = config_data.get('child_data', [{}])
         if not isinstance(child_data_list, list):
             child_data_list = [child_data_list]
 
         for child_data in child_data_list:
             for create_config in self.env['runbot.build.config'].browse(child_data.get('config_id', config_ids.ids)):
-                _child_data = {**child_data, 'config_id': create_config}
+                _child_data = {'config_data': {}, **child_data, 'config_id': create_config}
                 for _ in range(config_data.get('number_build', self.number_builds)):
                     count += 1
                     if count > 200:
@@ -303,7 +303,6 @@ class ConfigStep(models.Model):
                         break
                     child = build._add_child(_child_data, orphan=self.make_orphan)
                     build._log('create_build', 'created with config %s' % create_config.name, log_type='subbuild', path=str(child.id))
-
 
     def make_python_ctx(self, build):
         return {


### PR DESCRIPTION
Since the custom create was introduced, if a config is added in the config data of a create step, the config can be dynamic. If the given config contains a create step, this become recursive.

This is fixed in this commit by:
- Only taking a custom config if the base config as no create_config_id This means that the only elligible config should be the Custom Multi since it was adapted for that.
- Checking the parent_path depth in add_child. This will also work for python config.
- Consuming the params when adding the child