### PR TITLE
[IMP] runbot: add priority queue for debuging

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -128,10 +128,17 @@ class Batch(models.Model):
         else:
             description = params.trigger_id.description if params.trigger_id.description else False
             link_type = 'created'
+
+            build_type = 'normal'
+            if self.category_id != self.env.ref('runbot.default_category'):
+                build_type = 'scheduled'
+            elif self.bundle_id.priority:
+                build_type = 'priority'
+
             build = self.env['runbot.build'].create({
                 'params_id': params.id,
                 'description': description,
-                'build_type': 'normal' if self.category_id == self.env.ref('runbot.default_category') else 'scheduled',
+                'build_type': build_type,
                 'no_auto_run': self.bundle_id.no_auto_run,
             })
             if self.bundle_id.host_id:

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -196,6 +196,7 @@ class BuildResult(models.Model):
                                    ('rebuild', 'This build is a rebuild'),
                                    ('normal', 'normal build'),
                                    ('indirect', 'Automatic rebuild'), # TODO cleanup remove
+                                   ('priority', 'Priority'),
                                    ],
                                   default='normal',
                                   string='Build type')

--- a/runbot/models/build_config_codeowner.py
+++ b/runbot/models/build_config_codeowner.py
@@ -24,7 +24,6 @@ class ConfigStep(models.Model):
                 build._log('', 'No pr for repo %s, skipping' % commit.repo_id.name)
         return pr_by_commit
 
-
     def _codeowners_regexes(self, codeowners, version_id):
         regexes = {}
         for codeowner in codeowners:

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -42,7 +42,7 @@ class Bundle(models.Model):
     previous_major_version_base_id = fields.Many2one('runbot.bundle', 'Previous base bundle', compute='_compute_relations_base_id')
     intermediate_version_base_ids = fields.Many2many('runbot.bundle', 'Intermediate base bundles', compute='_compute_relations_base_id')
 
-    priority = fields.Boolean('Build priority', default=False)
+    priority = fields.Boolean('Build priority', default=False, groups="runbot.group_runbot_admin")
 
     # Custom parameters
     trigger_custom_ids = fields.One2many('runbot.bundle.trigger.custom', 'bundle_id')

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -51,7 +51,9 @@ class Runbot(models.AbstractModel):
             self._commit()
         self._assign_pending_builds(host, host.nb_worker, [('build_type', '!=', 'scheduled')])
         self._commit()
-        self._assign_pending_builds(host, host.nb_worker-1 or host.nb_worker)
+        self._assign_pending_builds(host, host.nb_worker - 1 or host.nb_worker)
+        self._commit()
+        self._assign_pending_builds(host, host.nb_worker and host.nb_worker + 1, [('build_type', '=', 'priority')])
         self._commit()
         for build in self._get_builds_to_init(host):
             build = build.browse(build.id)  # remove preftech ids, manage build one by one
@@ -80,7 +82,6 @@ class Runbot(models.AbstractModel):
         if assignable_slots > 0:
             allocated = self._allocate_builds(host, assignable_slots, domain)
             if allocated:
-
                 _logger.info('Builds %s where allocated to runbot', allocated)
 
     def _get_builds_to_init(self, host):


### PR DESCRIPTION
The main idea is to allow some build to use an extra slot from all host if a bundle is in priority mode.

This is mainly for quick step debuging, mainly when modifying python steps when the runbot is fully loaded.

This will also be usefull to concurrency test, by starting a build on each host at the same time, even when some host are already fully loaded