### PR TITLE
[IMP] runbot: add a monitoring tool to the builder

### DIFF
--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python3
 import logging
+import threading
 
-from tools import RunbotClient, run
+from pathlib import Path
+
+from tools import RunbotClient, run, docker_monitoring_loop
 
 _logger = logging.getLogger(__name__)
 
@@ -9,6 +12,10 @@ _logger = logging.getLogger(__name__)
 class BuilderClient(RunbotClient):
 
     def on_start(self):
+        builds_path = Path(self.env['runbot.runbot']._root()) / 'build'
+        monitoring_thread = threading.Thread(target=docker_monitoring_loop, args=(builds_path,), daemon=True)
+        monitoring_thread.start()
+
         for repo in self.env['runbot.repo'].search([('mode', '!=', 'disabled')]):
             repo._update(force=True)
 


### PR DESCRIPTION
At this moment it's difficult to monitor a build cpu and memory usage. This must be done from outside the container to avoid to kill the cat by opening the box.

This commit adds a daemonic thread launched by the builder. This thread will read the memory and cpu stats of the running dockers and report their stats in a log file into the logs directory of the builds.

The log file format is made to be easily mixed with the build logs and spot memory leaks or cpu overload during builds.