### PR TITLE
[IMP] runbot: make disable host configurable

### DIFF
--- a/runbot/data/runbot_data.xml
+++ b/runbot/data/runbot_data.xml
@@ -48,6 +48,11 @@ admin_passwd=running_master_password</field>
 
     </data>
 
+    <record model="ir.config_parameter" id="runbot.runbot_disable_host_on_fetch_failure">
+        <field name="key">runbot.runbot_disable_host_on_fetch_failure</field>
+        <field name="value"></field>
+    </record>
+
     <record model="ir.config_parameter" id="runbot.runbot_is_base_regex">
         <field name="key">runbot.runbot_is_base_regex</field>
         <field name="value">^((master)|(saas-)?\d+\.\d+)$</field>

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -542,9 +542,11 @@ class Repo(models.Model):
                     message = 'Failed to fetch repo %s: %s' % (self.name, e.output.decode())
                     host = self.env['runbot.host']._get_current()
                     host.message_post(body=message)
-                    self.env['runbot.runbot'].warning('Host %s got reserved because of fetch failure' % host.name)
-                    _logger.exception(message)
-                    host.disable()
+                    icp = self.env['ir.config_parameter'].sudo()
+                    if icp.get_param('runbot.runbot_disable_host_on_fetch_failure', True):
+                        self.env['runbot.runbot'].warning('Host %s got reserved because of fetch failure' % host.name)
+                        _logger.exception(message)
+                        host.disable()
         return success
 
     def _update(self, force=False, poll_delay=5*60):

--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -27,6 +27,7 @@ class ResConfigSettings(models.TransientModel):
     runbot_is_base_regex = fields.Char('Regex is_base')
     runbot_forwardport_author = fields.Char('Forwardbot author')
     runbot_organisation = fields.Char('Organisation')
+    runbot_disable_host_on_fetch_failure = fields.Boolean('Disable host on fetch failure')
 
     runbot_db_gc_days = fields.Integer(
         'Days before gc',
@@ -70,8 +71,9 @@ class ResConfigSettings(models.TransientModel):
                    runbot_do_fetch=get_param('runbot.runbot_do_fetch', default=False),
                    runbot_do_schedule=get_param('runbot.runbot_do_schedule', default=False),
                    runbot_is_base_regex=get_param('runbot.runbot_is_base_regex', default=''),
-                   runbot_forwardport_author = get_param('runbot.runbot_forwardport_author', default=''),
-                   runbot_organisation = get_param('runbot.runbot_organisation', default=''),
+                   runbot_forwardport_author=get_param('runbot.runbot_forwardport_author', default=''),
+                   runbot_organisation=get_param('runbot.runbot_organisation', default=''),
+                   runbot_disable_host_on_fetch_failure=get_param('runbot.runbot_disable_host_on_fetch_failure', default=False),
                    )
         return res
 
@@ -94,6 +96,7 @@ class ResConfigSettings(models.TransientModel):
         set_param('runbot.runbot_is_base_regex', self.runbot_is_base_regex)
         set_param('runbot.runbot_forwardport_author', self.runbot_forwardport_author)
         set_param('runbot.runbot_organisation', self.runbot_organisation)
+        set_param('runbot.runbot_disable_host_on_fetch_failure', self.runbot_disable_host_on_fetch_failure)
 
     @api.onchange('runbot_is_base_regex')
     def _on_change_is_base_regex(self):

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -34,6 +34,8 @@
                         <div class="content-group">
                           <label for="runbot_max_age" class="col-xs-3 o_light_label" style="width: 60%;"/>
                           <field name="runbot_max_age" style="width: 15%;"/>
+                          <label for="runbot_disable_host_on_fetch_failure" class="col-xs-3 o_light_label" style="width: 40%;"/>
+                          <field name="runbot_disable_host_on_fetch_failure" style="width: 15%;"/>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
The auto disable host is mainly usefull when there are a lot of host for well configured repositories.

If for any reason a repo is corrupted on one host, this host will be disabled until a manual intervention cleans the repo.

For other cases, where thjere are many repositories with not so many host, it is most likely that a fetch will fail because of an invalid repository configuration. Disabling the host in this case is not a good idea.

With this commit, a settings allows to enable or disable this feature.