### PR TITLE
[IMP] runbot: make runbot.bundle::write() callable through xml-rpc

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -203,10 +203,11 @@ class Bundle(models.Model):
         return res
 
     def write(self, values):
-        super().write(values)
+        res = super().write(values)
         if 'is_base' in values:
             model = self.browse()
             model._get_base_ids.clear_cache(model)
+        return res
 
     def _force(self, category_id=None):
         self.ensure_one()


### PR DESCRIPTION
The XML-RPC implementation does not allow for receiving or sending `None` values (both as query parameters and response).

Since the `write` method of `runbot.bundle` was overriden without returning a value, an exception is raised when the method is called through the external API.

This makes the `write` method return the value from its call to `super()` which should be equal to `True` if all went well.