### PR TITLE
[FIX] runbot: get_module remove prefix

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -561,7 +561,7 @@ class Repo(models.Model):
         for addons_path in (self.addons_paths or '').split(','):
             base_path = f'{self.name}/{addons_path}'
             if file.startswith(base_path):
-                return file.replace(base_path, '').strip('/').split('/')[0]
+                return file[len(base_path):].strip('/').split('/')[0]
 
 
 class RefTime(models.Model):

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -108,7 +108,9 @@ class TestCodeowner(TestBuildConfigStepCommon):
         self.assertEqual(self.repo_server.addons_paths, 'addons,core/addons')
         self.assertEqual('module1', self.repo_server._get_module('server/core/addons/module1/some/file.py'))
         self.assertEqual('module1', self.repo_server._get_module('server/addons/module1/some/file.py'))
+        self.assertEqual('module_addons', self.repo_addons._get_module('addons/module_addons/some/file.py'))
         self.assertEqual(None, self.repo_server._get_module('server/core/module1/some/file.py'))
+        self.assertEqual(None, self.repo_server._get_module('server/core/module/some/file.py'))
 
     def test_codeowner_regex_multiple(self):
         self.diff = 'file.js\nfile.py\nfile.xml'

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -491,12 +491,14 @@ class TestGetRefs(RunbotCase):
         return mock_git
 
     def test_get_refs(self):
+        current = time.time()
+        commit_time = str(int(current) - 5000)
         self.remote_server_dev.fetch_pull = True
-        to_ignore = { '242': 1672227770.0}
+        to_ignore = {'242': current - 100}
         good_ref = (
             'refs/bla-dev/heads/master-test-branch-rbt',
             'da39a3ee5e6b4b0d3255bfef95601890afd80709',
-            '1672139720',
+            commit_time,
             'foobarman',
             '<foobarman@somewhere.com>',
             '[IMP] mail: better tests',
@@ -506,7 +508,7 @@ class TestGetRefs(RunbotCase):
         bad_ref = (
             'refs/bla-dev/heads/1703',
             'e9b396d2dddffdb373bf2c6ad073696aa25b4f68',
-            '1672224639',
+            commit_time,
             'foobarman',
             '<foobarman@somewhere.com>',
             '[FIX] foo: bar',
@@ -516,7 +518,7 @@ class TestGetRefs(RunbotCase):
         to_ignore_ref = (
             'refs/bla-dev/pull/242',
             'ee89a48b76b58f4b3b0a7ee2c558dd8d936f6b12',
-            '1672224242',
+            commit_time,
             'foobarman',
             '<foobarman@somewhere.com>',
             '[IMP] blah: blah',


### PR DESCRIPTION
Since removeprefix was not available in ubuntu 20.04, a easier alternative using rebase was used.

The initial assumption was that the prefix would look like `odoo/addons/` and won't be in the filename.

When the repo is enterprise, the prefix is `enterprise/` meaning that module name ending with `enterprise` will be truncated

`repo._get_module('enterprise/mail_enterprise/static/src/widgets/form_renderer/form_renderer.js')`

will output

`mail_static`