### PR TITLE
[IMP] runbot: add kill on ko step option

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -805,6 +805,19 @@ class BuildResult(models.Model):
                 next_index += 1
                 continue
             break
+
+        if self.local_result == 'ko':
+            if self.active_step and self.active_step.break_after_if_ko:
+                self._log('break_on_ko', f'Build is in failure, stopping after {self.active_step.name}')
+                self.local_state = 'done'
+                self.active_step = False
+                return
+            if new_step.break_before_if_ko:
+                self._log('break_on_ko', f'Build is in failure, stopping before {new_step.name}')
+                self.local_state = 'done'
+                self.active_step = False
+                return
+
         build.active_step = new_step.id
         build.local_state = new_step._step_state()
 

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -100,6 +100,7 @@ class ConfigStepUpgradeDb(models.Model):
     db_pattern = fields.Char('Db suffix pattern')
     min_target_version_id = fields.Many2one('runbot.version', "Minimal target version_id")
 
+
 TYPES = [
         ('install_odoo', 'Test odoo'),
         ('run_odoo', 'Run odoo'),
@@ -110,6 +111,8 @@ TYPES = [
         ('test_upgrade', 'Test Upgrade'),
         ('restore', 'Restore'),
     ]
+
+
 class ConfigStep(models.Model):
     _name = 'runbot.build.config.step'
     _description = "Config step"
@@ -179,6 +182,8 @@ class ConfigStep(models.Model):
 
     commit_limit = fields.Integer('Commit limit', default=50)
     file_limit = fields.Integer('File limit', default=450)
+    break_before_if_ko = fields.Boolean('Break before this step if build is ko')
+    break_after_if_ko = fields.Boolean('Break after this step if build is ko')
 
     @api.constrains('python_code')
     def _check_python_code(self):

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -47,6 +47,8 @@
                         <field name="protected"/>
                         <field name="default_sequence" groups="base.group_no_one"/>
                         <field name="group" groups="base.group_no_one"/>
+                        <field name="break_after_if_ko"/>
+                        <field name="break_before_if_ko"/>
                     </group>
                     <group string="Stats regexes" invisible="not make_stats">
                       <field name="build_stat_regex_ids">


### PR DESCRIPTION
In some case, if a step fails (restore, upgrade, ...) we don't want to continue since it makes no sense to run tests afterward.

This option will allow to avoid unwanted build error especially for upgrade as well as useless load.