### PR TITLE
[FIX] runbot: avoid traceback when forcing a preparing batch

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -210,9 +210,10 @@ class Runbot(Controller):
     def force_bundle(self, bundle, auto_rebase=False, **_post):
         _logger.info('user %s forcing bundle %s', request.env.user.name, bundle.name)  # user must be able to read bundle
         batch = bundle.sudo()._force()
-        batch._log('Batch forced by %s', request.env.user.name)
-        batch._prepare(auto_rebase)
-        return werkzeug.utils.redirect('/runbot/batch/%s' % batch.id)
+        if batch:
+            batch._log('Batch forced by %s', request.env.user.name)
+            batch._prepare(auto_rebase)
+            return werkzeug.utils.redirect('/runbot/batch/%s' % batch.id)
 
     @route(['/runbot/batch/<int:batch_id>'], website=True, auth='public', type='http', sitemap=False)
     def batch(self, batch_id=None, **kwargs):


### PR DESCRIPTION
When forcing a new batch on a bundle the _force method does not return a batch leading to a traceback in the force_bundle route.