### PR TITLE
[FIX] runbot: avoid empty negative test tags

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -99,7 +99,7 @@ class BuildError(models.Model):
                         raise UserError(f"Cannot parent an error with test tags: {build_error.test_tags}")
                     elif not parent.test_tags:
                         parent.sudo().test_tags = build_error.test_tags
-                        build_error.sudo().test_tags = ''
+                        build_error.sudo().test_tags = False
                 if build_error.responsible:
                     if parent.responsible and parent.responsible != build_error.responsible and not self.env.su:
                         raise UserError(f"Error {parent.id} as already a responsible ({parent.responsible}) cannot assign {build_error.responsible}")

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -146,9 +146,6 @@ class TestBuildError(RunbotCase):
             'active': False
         })
 
-        # test that a test tag with a dash raise an Vamlidation error
-        with self.assertRaises(ValidationError):
-            error_a.test_tags = '-foo'
 
         error_a.test_tags = 'foo,bar'
         error_b.test_tags = 'blah'
@@ -160,6 +157,13 @@ class TestBuildError(RunbotCase):
         # test that test tags on fixed errors are not taken into account
         self.assertNotIn('blah', self.BuildError.test_tags_list())
         self.assertNotIn('-blah', self.BuildError.disabling_tags())
+
+        error_a.test_tags = False
+        error_b.active = True
+        error_b.parent_id = error_a.id
+        self.assertEqual(error_b.test_tags, False)
+        self.assertEqual(self.BuildError.disabling_tags(), ['-blah',])
+
 
     def test_build_error_team_wildcards(self):
         website_team = self.BuildErrorTeam.create({


### PR DESCRIPTION
When parenting a build error, if a test_tag is set on it, the tag is transferred to the parent and cleared to an empty string. In that case, a single `-` appears in the disabling tags and leads to an apocalyptic situation ... the runbot builds don't run any tests.

With this commit, the test_tags is set to `False`.