### PR TITLE
[FIX] runbot: remove useless pip warning

### DIFF
--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -126,6 +126,7 @@ class Host(models.Model):
             && mkdir /home/{user} \\
             && chown -R {user}:{user} /home/{user}
             USER {user}
+            ENV PATH /home/{user}/.local/bin:$PATH
             ENV COVERAGE_FILE /data/build/.coverage
             """
 


### PR DESCRIPTION
When pip installs a package that contains a script, it goes in `~/.local/bin` directory of the current user. This leads to a log warning to warn the user that the script won't be accessible by other users.

e.g.:
`WARNING: The script pygmentize is installed in '/home/odoo/.local/bin' which is not on PATH.`

This is particularly annoying for documentation builds because it may confuse the users.