### PR TITLE
[IMP] runbot: avoid link to killed build

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -122,7 +122,8 @@ class Batch(models.Model):
             domain += [('host', '=', self.bundle_id.host_id.name), ('keep_host', '=', True)]
         build = self.env['runbot.build'].search(domain, limit=1, order='id desc')
         link_type = 'matched'
-        if build:
+        killed_states = ('skipped', 'killed', 'manually_killed')
+        if build and build.local_result not in killed_states and build.global_result not in killed_states:
             if build.killable:
                 build.killable = False
         else:

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -363,6 +363,7 @@ class BuildResult(models.Model):
 
         for init_global_state, build in zip(init_global_states, self):
             if init_global_state not in ('done', 'running') and build.global_state in ('done', 'running'):
+                build.build_end = now()
                 build._github_status()
 
         return res


### PR DESCRIPTION
When a build is created, it will first check for another build having the same params. It is usually a good idea to avoid to much load. In some case, a build can be found, but a killed one.

This is not what we want:
The first scenario is to consecutive force push,
commit1 -> commit2 -> commit1

The build of commit1 may be killed because of commit2, then when forcepushing commit1 again, it will be linked to a killed build.

A even more problematic problem was discovered because of a delay In odoo/odoo repo hook. An odoo-dev/odoo 16.0-... branch was discovered first using this commit, and a build was created.
Then, the branch was forcedpushed and the build was killed. Finally, the 16.0 commit was discovered, and was linked to the killed build. This was mainly an issue because the build was a template.

With this changes, the 16.0 would have created a new build, not linking to a killed one.

Note that linking to a red build is not an error. Only a killed one.