### PR TITLE
[IMP] runbot_merge: speedup frontend page

### DIFF
--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -1722,7 +1722,7 @@ class Commit(models.Model):
 class Stagings(models.Model):
     _name = _description = 'runbot_merge.stagings'
 
-    target = fields.Many2one('runbot_merge.branch', required=True)
+    target = fields.Many2one('runbot_merge.branch', required=True, index=True)
 
     batch_ids = fields.One2many(
         'runbot_merge.batch', 'staging_id',
@@ -1737,7 +1737,7 @@ class Stagings(models.Model):
     ], default='pending')
     active = fields.Boolean(default=True)
 
-    staged_at = fields.Datetime(default=fields.Datetime.now)
+    staged_at = fields.Datetime(default=fields.Datetime.now, index=True)
     timeout_limit = fields.Datetime(store=True, compute='_compute_timeout_limit')
     reason = fields.Text("Reason for final state (if any)")
 
@@ -2127,9 +2127,9 @@ class Batch(models.Model):
     """
     _name = _description = 'runbot_merge.batch'
 
-    target = fields.Many2one('runbot_merge.branch', required=True)
-    staging_id = fields.Many2one('runbot_merge.stagings')
-    split_id = fields.Many2one('runbot_merge.split')
+    target = fields.Many2one('runbot_merge.branch', required=True, index=True)
+    staging_id = fields.Many2one('runbot_merge.stagings', index=True)
+    split_id = fields.Many2one('runbot_merge.split', index=True)
 
     prs = fields.Many2many('runbot_merge.pull_requests')
 

--- a/runbot_merge/views/templates.xml
+++ b/runbot_merge/views/templates.xml
@@ -154,7 +154,7 @@
     <template id="stagings" name="mergebot branch stagings">
         <t t-set="repo_statuses" t-value="branch.project_id.repo_ids.having_branch(branch).status_ids"/>
         <ul class="list-unstyled stagings">
-            <t t-foreach="branch.staging_ids.sorted(lambda s: s.staged_at, reverse=True)[:6]" t-as="staging">
+            <t t-foreach="branch.env['runbot_merge.stagings'].search([('target', '=', branch.id)], order='staged_at desc', limit=6)" t-as="staging">
                 <t t-set="success" t-value="staging.state == 'success'"/>
                 <t t-set="failure" t-value="staging.state == 'failure'"/>
                 <t t-set="pending" t-value="staging.active and (not staging.state or staging.state == 'pending')"/>


### PR DESCRIPTION
The mergebot page become a bit slow with the years, it is time to make small optimisation to speed up thinks a little.

Note: all changes where applied modifying the views or adding index by hand. There is still room for improvement but it would need more in depth refactoring, mainly adding specialized computed fields to enable a better batching.

The first issue was using branch.staging_ids

    branch.staging_ids.sorted(lambda s: s.staged_at, reverse=True)[:6]

The number of staging_ids is increasing and prefetching + sorting all of them is slow.

The proposed solution is to replace it by a search, not ideal, a specialized compute field may be a good idea, but this is a quick fix that can be done editing a view.

    branch.env['runbot_merge.stagings'].search([('target', '=', branch.id)],order='staged_at desc', limit=6)

Other changes are just index on critical columns.

Before changes, /runbot_merge page takes ~5s to load
After changes,  /runbot_merge page takes ~1s to load

Small note: note 100% sure that runbot_merge.batch.target was useful