### PR TITLE
[FIX] runbot: avoid sending status on running kill

### DIFF
--- a/runbot/controllers/hook.py
+++ b/runbot/controllers/hook.py
@@ -32,7 +32,6 @@ class Hook(http.Controller):
                 if not remote_id:
                     _logger.error("Remote %s not found", repo_data['ssh_url'])
         remote = request.env['runbot.remote'].sudo().browse(remote_id)
-        _logger.info('Remote found %s', remote)
 
         # force update of dependencies too in case a hook is lost
         if not payload or event == 'push':

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -102,7 +102,9 @@ class Runbot(models.AbstractModel):
             if build.host == host.name
         ][:running_max]
         build_ids = host.get_builds([('local_state', '=', 'running'), ('id', 'not in', cannot_be_killed_ids)], order='job_start desc').ids
-        Build.browse(build_ids)[running_max:]._kill()
+        for build in Build.browse(build_ids)[running_max:]:
+            build._kill()
+
 
     def _gc_testing(self, host):
         """garbage collect builds that could be killed"""


### PR DESCRIPTION
The _kill method was called in multiple case, usually when something wrong happen:
- exception initiating pending
- kill requested manually
- testing time exceeded
- exception running a job
- ...

But it will also be called when killing a running build.

It was usually not an issue since the status remains the same, but it is not true if the same commit is used in two build, the new one is green, the old one is red (enterprise commit remaining the same but community commit changed as an example)

In this situation, the enterprise commit may receive the red ci from the old build while the last one is green.

Since with the last version, the github status responsibility is left to write method, this github status is not useful anymore, updating the state and result is enough.

This commit also removes the commit since it is not always a god idea. Most of the time the transaction will be comited quite fast after that with the new scheduler.

Note that checking in github status if no status has a more recent build may be a good idea. Only the most recent build using a commit could sending a status? This would not alway be helpful Imagine a commit used in 2 branches by mistake, the last build is not always the one we want (usually fixed by rebuilding a subbuild of the good build)