### PR TITLE
[FIX] runbot: fix dockerfile choice order

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -165,7 +165,7 @@ class Batch(models.Model):
         if not bundle.version_id:
             _logger.error('No version found on bundle %s in project %s', bundle.name, project.name)
 
-        dockerfile_id = bundle.dockerfile_id or bundle.base_id.dockerfile_id or bundle.version_id.dockerfile_id or bundle.project_id.dockerfile_id
+        dockerfile_id = bundle.dockerfile_id or bundle.base_id.dockerfile_id or bundle.project_id.dockerfile_id or bundle.version_id.dockerfile_id
         if not dockerfile_id:
             _logger.error('No dockerfile found !')
 

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -859,7 +859,7 @@ class ConfigStep(models.Model):
         kwargs = dict(message='Step %s finished in %s' % (self.name, s2human(build.job_time)))
         if self.job_type == 'install_odoo':
             kwargs['message'] += ' $$fa-download$$'
-            db_suffix = build.params_id.config_data.get('db_name') or self.db_name
+            db_suffix = build.params_id.config_data.get('db_name') or (build.params_id.dump_db.db_suffix if not self.create_db else False) or self.db_name
             kwargs['path'] = '%s%s-%s.zip' % (build.http_log_url(), build.dest, db_suffix)
             kwargs['log_type'] = 'link'
         build._log('', **kwargs)


### PR DESCRIPTION
Since all versions will have a defined dockerfile, the project one will alway be ignored. The idea here is that for a project, we may definea default dockerfile_id so that we don't have to set it on all bundle to make it work.