### PR TITLE
[FIX] runbot: catch exceptions during db drop

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -905,17 +905,28 @@ class BuildResult(models.Model):
         return sorted(modules_to_install)
 
     def _local_pg_dropdb(self, dbname):
-        with local_pgadmin_cursor() as local_cr:
-            pid_col = 'pid' if local_cr.connection.server_version >= 90200 else 'procpid'
-            query = 'SELECT pg_terminate_backend({}) FROM pg_stat_activity WHERE datname=%s'.format(pid_col)
-            local_cr.execute(query, [dbname])
-            local_cr.execute('DROP DATABASE IF EXISTS "%s"' % dbname)
-        # cleanup filestore
-        datadir = appdirs.user_data_dir()
-        paths = [os.path.join(datadir, pn, 'filestore', dbname) for pn in 'OpenERP Odoo'.split()]
-        cmd = ['rm', '-rf'] + paths
-        _logger.info(' '.join(cmd))
-        subprocess.call(cmd)
+        msg = ''
+        try:
+            with local_pgadmin_cursor() as local_cr:
+                pid_col = 'pid' if local_cr.connection.server_version >= 90200 else 'procpid'
+                query = 'SELECT pg_terminate_backend({}) FROM pg_stat_activity WHERE datname=%s'.format(pid_col)
+                local_cr.execute(query, [dbname])
+                local_cr.execute('DROP DATABASE IF EXISTS "%s"' % dbname)
+            # cleanup filestore
+            datadir = appdirs.user_data_dir()
+            paths = [os.path.join(datadir, pn, 'filestore', dbname) for pn in 'OpenERP Odoo'.split()]
+            cmd = ['rm', '-rf'] + paths
+            _logger.info(' '.join(cmd))
+            subprocess.call(cmd)
+        except psycopg2.errors.InsufficientPrivilege:
+            msg = f"Insuficient priveleges to drop local database '{dbname}'"
+            _logger.warning(msg)
+        except Exception as e:
+            msg = f"Failed to drop local logs database : {dbname} with exception: {e}"
+            _logger.exception(msg)
+        if msg:
+            host_name = self.env['runbot.host']._get_current_name()
+            self.env['runbot.runbot'].warning(f'Host {host_name}: {msg}')
 
     def _local_pg_createdb(self, dbname):
         icp = self.env['ir.config_parameter']


### PR DESCRIPTION
When the runbot tries to drop a local database, if the that raises an exception, it goes in a loop failure. It mays happen for example if someone forgot to close a psql during an investigation :-)

With this commit, the exceptions are catched and at least the database name is logged.