### PR TITLE
[FIX] runbot: limit max log size

### DIFF
--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -251,6 +251,10 @@ class Host(models.Model):
                     ir_log['message'] = 'Log limit reached (full logs are still available in the log file)'
                 elif log_counter < 0:
                     continue
+                else:
+                    if len(ir_log['message']) > 10000:
+                        ir_log['message'] = ir_log['message'][:10000] + "\n ...<message too long, truncated>"
+
                 ir_log['build_id'] = build.id
                 logs_to_send.append({k:ir_log[k] for k in ir_log if k != 'id'})
             build.log_counter = log_counter


### PR DESCRIPTION
In some case, a build can add a lot of info in a log, there is already a limit to the number of entry but not to the size of an entry. This will limit the database usage in case of mistake/abuse.