### PR TITLE
[FIX] runbot: chatter must be after sheet

### DIFF
--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -95,8 +95,8 @@
             </sheet>
             <div class="oe_chatter">
                 <field name="message_follower_ids" widget="mail_followers"/>
-                <field name="message_ids" widget="mail_thread"/>
-                <field name="activity_ids" widget="mail_activity"/>
+                <field name="message_ids"/>
+                <field name="activity_ids"/>
             </div>
           </form>
         </field>
@@ -179,7 +179,7 @@
             </sheet>
             <div class="oe_chatter">
                 <field name="message_follower_ids" widget="mail_followers"/>
-                <field name="message_ids" widget="mail_thread"/>
+                <field name="message_ids"/>
             </div>
           </form>
         </field>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -5,92 +5,94 @@
         <field name="model">runbot.build.error</field>
         <field name="arch" type="xml">
           <form>
-            <widget name="web_ribbon" title="Test-tags" bg_color="bg-warning" attrs="{'invisible': [('test_tags', '=', False)]}"/>
-            <header>
-            </header>
-              <group>
-                <group name="build_error_group" string="Base info">
-                  <field name="content" readonly="1"/>
-                  <field name="module_name" readonly="1"/>
-                  <field name="function" readonly="1"/>
-                  <field name="file_path" readonly="1"/>
-                </group>
-              </group>
-              <group col="2">
-                <group name="fixer_info" string="Fixing">
-                  <field name="responsible" attrs="{'readonly': [('parent_id','!=', False), ('responsible','=', False)]}"/>
-                  <field name="team_id" attrs="{'readonly': [('parent_id','!=', False), ('team_id','=', False)]}"/>
-                  <field name="fixing_pr_id"/>
-                  <field name="fixing_pr_url" widget="url"/>
-                  <field name="active"/>
-                  <field name="test_tags" readonly="1" groups="!runbot.group_runbot_admin"/>
-                  <field name="test_tags" groups="runbot.group_runbot_admin" attrs="{'readonly': [('parent_id','!=', False), ('test_tags','=', False)]}"/>
-                </group>
-                  <group name="fixer_info" string="Fixing">
-                  <field name="version_ids" widget="many2many_tags"/>
-                  <field name="trigger_ids" widget="many2many_tags"/>
-                  <field name="tag_ids" widget="many2many_tags" readonly="1"/>
-                </group>
-              </group>
-              <group name="fixer_info" string="More info" col="2">
+            <sheet>
+              <widget name="web_ribbon" title="Test-tags" bg_color="bg-warning" attrs="{'invisible': [('test_tags', '=', False)]}"/>
+              <header>
+              </header>
                 <group>
-                  <field name="random"/>
-                  <field name="first_seen_date"/>
-                  <field name="first_seen_build_id" widget="frontend_url"/>
-                </group>
-                <group>
-                  <field name="parent_id"/>
-                  <field name="last_seen_date"/>
-                  <field name="last_seen_build_id" widget="frontend_url"/>
-                </group>
-              </group>
-              <notebook>
-                <page string="Builds">
-                  <field name="children_build_ids" widget="many2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
-                    <tree>
-                      <field name="create_date"/>
-                      <field name="host" groups="base.group_no_one"/>
-                      <field name="dest"/>
-                      <field name="version_id"/>
-                      <field name="trigger_id"/>
-                      <field name="description"/>
-                      <field name="build_url" widget="url" readonly="1" text="View build"/>
-                    </tree>
-                  </field>
-                </page>
-                <page string="Linked Errors" attrs="{'invisible': [('child_ids', '=', [])]}">
-                  <field name="child_ids" widget="many2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
-                    <tree>
-                      <field name="create_date"/>
-                      <field name="module_name"/>
-                      <field name="summary"/>
-                      <field name="build_count"/>
-                    </tree>
-                  </field>
-                </page>
-                <page string="Error history" attrs="{'invisible': [('error_history_ids', '=', [])]}">
-                  <field name="error_history_ids" widget="one2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
-                    <tree>
-                      <field name="create_date"/>
-                      <field name="module_name"/>
-                      <field name="summary"/>
-                      <field name="random"/>
-                      <field name="build_count"/>
-                      <field name="responsible"/>
-                      <field name="fixing_commit"/>
-                      <field name="id"/>
-                    </tree>
-                  </field>
-                </page>
-                <page string="Debug" groups="base.group_no_one">
-                  <group name="build_error_group">
-                    <field name="fingerprint" readonly="1"/>
-                    <field name="cleaned_content" readonly="1"/>
-                    <field name="fixing_commit" widget="url"/>
-                    <field name="bundle_ids" widget="many2many_tags"/>
+                  <group name="build_error_group" string="Base info">
+                    <field name="content" readonly="1"/>
+                    <field name="module_name" readonly="1"/>
+                    <field name="function" readonly="1"/>
+                    <field name="file_path" readonly="1"/>
                   </group>
-                </page>
-              </notebook>
+                </group>
+                <group col="2">
+                  <group name="fixer_info" string="Fixing">
+                    <field name="responsible" attrs="{'readonly': [('parent_id','!=', False), ('responsible','=', False)]}"/>
+                    <field name="team_id" attrs="{'readonly': [('parent_id','!=', False), ('team_id','=', False)]}"/>
+                    <field name="fixing_pr_id"/>
+                    <field name="fixing_pr_url" widget="url"/>
+                    <field name="active"/>
+                    <field name="test_tags" readonly="1" groups="!runbot.group_runbot_admin"/>
+                    <field name="test_tags" groups="runbot.group_runbot_admin" attrs="{'readonly': [('parent_id','!=', False), ('test_tags','=', False)]}"/>
+                  </group>
+                    <group name="fixer_info" string="Fixing">
+                    <field name="version_ids" widget="many2many_tags"/>
+                    <field name="trigger_ids" widget="many2many_tags"/>
+                    <field name="tag_ids" widget="many2many_tags" readonly="1"/>
+                  </group>
+                </group>
+                <group name="fixer_info" string="More info" col="2">
+                  <group>
+                    <field name="random"/>
+                    <field name="first_seen_date"/>
+                    <field name="first_seen_build_id" widget="frontend_url"/>
+                  </group>
+                  <group>
+                    <field name="parent_id"/>
+                    <field name="last_seen_date"/>
+                    <field name="last_seen_build_id" widget="frontend_url"/>
+                  </group>
+                </group>
+                <notebook>
+                  <page string="Builds">
+                    <field name="children_build_ids" widget="many2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
+                      <tree>
+                        <field name="create_date"/>
+                        <field name="host" groups="base.group_no_one"/>
+                        <field name="dest"/>
+                        <field name="version_id"/>
+                        <field name="trigger_id"/>
+                        <field name="description"/>
+                        <field name="build_url" widget="url" readonly="1" text="View build"/>
+                      </tree>
+                    </field>
+                  </page>
+                  <page string="Linked Errors" attrs="{'invisible': [('child_ids', '=', [])]}">
+                    <field name="child_ids" widget="many2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
+                      <tree>
+                        <field name="create_date"/>
+                        <field name="module_name"/>
+                        <field name="summary"/>
+                        <field name="build_count"/>
+                      </tree>
+                    </field>
+                  </page>
+                  <page string="Error history" attrs="{'invisible': [('error_history_ids', '=', [])]}">
+                    <field name="error_history_ids" widget="one2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
+                      <tree>
+                        <field name="create_date"/>
+                        <field name="module_name"/>
+                        <field name="summary"/>
+                        <field name="random"/>
+                        <field name="build_count"/>
+                        <field name="responsible"/>
+                        <field name="fixing_commit"/>
+                        <field name="id"/>
+                      </tree>
+                    </field>
+                  </page>
+                  <page string="Debug" groups="base.group_no_one">
+                    <group name="build_error_group">
+                      <field name="fingerprint" readonly="1"/>
+                      <field name="cleaned_content" readonly="1"/>
+                      <field name="fixing_commit" widget="url"/>
+                      <field name="bundle_ids" widget="many2many_tags"/>
+                    </group>
+                  </page>
+                </notebook>
+            </sheet>
             <div class="oe_chatter">
                 <field name="message_follower_ids" widget="mail_followers"/>
                 <field name="message_ids" widget="mail_thread"/>

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -36,53 +36,54 @@
         <field name="model">runbot.bundle</field>
         <field name="arch" type="xml">
             <form string="Bundles">
-                <div class="oe_button_box" name="button_box">
-                </div>
-                <group>
-                    <field name="name" widget="char_frontend_url"/>
-                    <field name="project_id"/>
-                    <field name="sticky" readonly="0"/>
-                    <field name="to_upgrade" readonly="0"/>
-                    <field name="is_base"/>
-                    <field name="base_id"/>
-                    <field name="defined_base_id"/>
-                    <field name="version_id"/>
-                    <field name="no_build"/>
-                    <field name="no_auto_run"/>
-                    <field name="priority"/>
-                    <field name="build_all"/>
-                    <field name="dockerfile_id"/>
-                    <field name="host_id" readonly="0"/>
-                    <field name="commit_limit"/>
-                    <field name="file_limit"/>
-                    <field name="disable_codeowner"/>
-                    <field name="for_next_freeze"/>
-                    <field name="branch_ids">
-                        <tree>
-                            <field name="dname"/>
-                            <field name="remote_id"/>
-                            <field name="pull_head_name"/>
-                            <field name="target_branch_name"/>
-                        </tree>
-                    </field>
-                    <field string="Trigger customisations" name="trigger_custom_ids">
-                        <tree editable="bottom">
-                            <field name="start_mode"/>
-                            <field name="trigger_id" domain="[('project_id', '=', parent.project_id)]"/>
-                            <field name="config_id"/>
-                            <field name="extra_params"/>
-                            <field name="config_data" widget="jsonb"/>
-                        </tree>
-                    </field>
-                    <field string="Last batches" name="last_batchs">
-                        <tree>
-                            <field name="state"/>
-                            <field name="commit_link_ids"/>
-                            <field name="slot_ids"/>
-                        </tree>
-                    </field>
-                </group>
-
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                    </div>
+                    <group>
+                        <field name="name" widget="char_frontend_url"/>
+                        <field name="project_id"/>
+                        <field name="sticky" readonly="0"/>
+                        <field name="to_upgrade" readonly="0"/>
+                        <field name="is_base"/>
+                        <field name="base_id"/>
+                        <field name="defined_base_id"/>
+                        <field name="version_id"/>
+                        <field name="no_build"/>
+                        <field name="no_auto_run"/>
+                        <field name="priority"/>
+                        <field name="build_all"/>
+                        <field name="dockerfile_id"/>
+                        <field name="host_id" readonly="0"/>
+                        <field name="commit_limit"/>
+                        <field name="file_limit"/>
+                        <field name="disable_codeowner"/>
+                        <field name="for_next_freeze"/>
+                        <field name="branch_ids">
+                            <tree>
+                                <field name="dname"/>
+                                <field name="remote_id"/>
+                                <field name="pull_head_name"/>
+                                <field name="target_branch_name"/>
+                            </tree>
+                        </field>
+                        <field string="Trigger customisations" name="trigger_custom_ids">
+                            <tree editable="bottom">
+                                <field name="start_mode"/>
+                                <field name="trigger_id" domain="[('project_id', '=', parent.project_id)]"/>
+                                <field name="config_id"/>
+                                <field name="extra_params"/>
+                                <field name="config_data" widget="jsonb"/>
+                            </tree>
+                        </field>
+                        <field string="Last batches" name="last_batchs">
+                            <tree>
+                                <field name="state"/>
+                                <field name="commit_link_ids"/>
+                                <field name="slot_ids"/>
+                            </tree>
+                        </field>
+                    </group>
+                </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers"/>
                     <field name="message_ids" widget="mail_thread"/>

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -85,8 +85,8 @@
                     </group>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids"/>
+                    <field name="message_ids"/>
                 </div>
             </form>
         </field>

--- a/runbot/views/codeowner_views.xml
+++ b/runbot/views/codeowner_views.xml
@@ -16,8 +16,8 @@
                     </group>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids"/>
+                    <field name="message_ids"/>
                 </div>
             </form>
         </field>

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -23,8 +23,8 @@
                     </group>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids"/>
+                    <field name="message_ids"/>
                 </div>
             </form>
         </field>
@@ -127,8 +127,8 @@
                     </group>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids"/>
+                    <field name="message_ids"/>
                 </div>
             </form>
         </field>

--- a/runbot/views/dashboard_views.xml
+++ b/runbot/views/dashboard_views.xml
@@ -50,8 +50,8 @@
               </notebook>
             </sheet>
             <div class="oe_chatter">
-              <field name="message_follower_ids" widget="mail_followers"/>
-              <field name="message_ids" widget="mail_thread"/>
+              <field name="message_follower_ids"/>
+              <field name="message_ids"/>
           </div>
           </form>
         </field>

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -44,8 +44,8 @@
               </notebook>
             </sheet>
             <div class="oe_chatter">
-                <field name="message_follower_ids" widget="mail_followers"/>
-                <field name="message_ids" widget="mail_thread"/>
+                <field name="message_follower_ids"/>
+                <field name="message_ids"/>
             </div>
           </form>
         </field>

--- a/runbot/views/host_views.xml
+++ b/runbot/views/host_views.xml
@@ -31,8 +31,8 @@
                     </group>
                 </sheet>
                 <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers"/>
-                    <field name="message_ids" widget="mail_thread"/>
+                    <field name="message_follower_ids"/>
+                    <field name="message_ids"/>
                 </div>
             </form>
         </field>


### PR DESCRIPTION
The `oe_chatter` div must be defined after a sheet, otherwise two chatters are visible on the form. One bellow and one on the right side.