### PR TITLE
[IMP] runbot: log container short id

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -192,7 +192,7 @@ def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False
     if container.status not in ('running', 'created') :
         _logger.error('Container %s started but status is not running or created:  %s', container_name, container.status)  # TODO cleanup
     else:
-        _logger.info('Started Docker container %s', container_name)
+        _logger.info('Started Docker container %s (%s)', container_name, container.short_id)
     return
 
 


### PR DESCRIPTION
When investigating kernel logs e.g.: for finding oom killed containers, the kernel does not log the name of the incriminated container but only the id. With this commit the runbot will also log the container short id which is enough to correlate the logs.