### PR TITLE
16.0 runbot docker registry moc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ runbot/static/sources
 runbot/static/nginx
 runbot/static/databases
 runbot/static/docker
+runbot/static/docker-registry

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -622,6 +622,7 @@ class BuildResult(models.Model):
         if candidate_for_partial_gc:
             for dest in _filter(candidate_for_partial_gc, label='workspace'):
                 build_dir = Path(builds_dir) / dest
+                gcstamp = build_dir / '.gcstamp'
                 for bdir_file in build_dir.iterdir():
                     if bdir_file.is_dir() and bdir_file.name not in ('logs', 'tests'):
                         shutil.rmtree(bdir_file)

--- a/runbot/models/res_config_settings.py
+++ b/runbot/models/res_config_settings.py
@@ -51,6 +51,7 @@ class ResConfigSettings(models.TransientModel):
     runbot_pending_warning = fields.Integer('Pending warning limit', default=5, config_parameter='runbot.pending.warning')
     runbot_pending_critical = fields.Integer('Pending critical limit', default=5, config_parameter='runbot.pending.critical')
 
+    runbot_docker_registry_host_id = fields.Many2one('runbot.host', 'Docker registry', help='Runbot host which handles Docker registry.', config_parameter='runbot.docker_registry_host_id')
     # TODO other icp
     # runbot.runbot_maxlogs 100
     # migration db

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -1,3 +1,4 @@
+import docker
 import time
 import logging
 import glob
@@ -223,7 +224,7 @@ class Runbot(models.AbstractModel):
         # Bootstrap
         host._bootstrap()
         if runbot_do_schedule:
-            host._docker_build()
+            host._docker_update_images()
             self._source_cleanup()
             self.env['runbot.build']._local_cleanup()
             self._docker_cleanup()
@@ -366,7 +367,7 @@ class Runbot(models.AbstractModel):
 
     def _docker_cleanup(self):
         _logger.info('Docker cleaning')
-        docker_ps_result = docker_ps()
+        docker_ps_result = [container for container in docker_ps() if container != "runbot-registry"]
 
         containers = {}
         ignored = []
@@ -383,6 +384,40 @@ class Runbot(models.AbstractModel):
         if ignored:
             _logger.info('docker (%s) not deleted because not dest format', list(ignored))
 
+    def _start_docker_registry(self, host):
+        """
+        Start a docker registry if not already running.
+        The registry is in `always_restart` mode, meaning that it will restart properly after a reboot.
+        """
+        docker_client = docker.from_env()
+        try:
+            registry_container = docker_client.containers.get('runbot-registry')
+        except docker.errors.NotFound:
+            registry_container = None
+
+        if registry_container:
+            if registry_container.status in ('running', 'created', 'restarting'):
+                if registry_container.status != 'running':
+                    _logger.info('Docker registry container already found with status %s, skipping start procedure.', registry_container.status)
+                return
+
+            _logger.info('Docker registry container found with status %s, trying the start procedure.', registry_container.status)
+
+        try:
+            registry_container = docker_client.containers.run(
+                'registry:2',
+                name='runbot-registry',
+                volumes={f'{os.path.join(self._root(), "docker-registry")}':{'bind': '/var/lib/registry', 'mode': 'rw'}},
+                ports={5000: ('127.0.0.1', 5001)},
+                restart_policy= {"Name": "always"},
+                detach=True
+            )
+            _logger.info('Docker registry started')
+            # TODO push local images in registry here 
+        except Exception as e:
+            message = f'Starting registry failed with exception: {e}'
+            self.warning(message)
+            _logger.error(message)
 
     def _warning(self, message, *args):
         if args:

--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -51,6 +51,23 @@ server {
     }
 }
 
+server {
+  listen 8080;
+  server_name ~^dockerhub\.<t t-esc="re_escape(host_name)"/>$;
+
+	location /v2/ {
+		limit_except GET HEAD OPTIONS {
+		    deny all;
+		}
+		proxy_pass http://localhost:5001;
+    proxy_set_header  Host               $http_host;
+    proxy_set_header  X-Real-IP          $remote_addr;
+    proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;
+    proxy_set_header  X-Forwarded-Proto  $scheme;
+    proxy_read_timeout                   900;
+	}
+}
+
 <t id="root_anchor"/>
 
 <t t-foreach="builds" t-as="build">

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -180,6 +180,7 @@ class RunbotCase(TransactionCase):
         self.start_patcher('isfile', 'odoo.addons.runbot.common.os.path.isfile', True)
         self.start_patcher('docker_run', 'odoo.addons.runbot.container._docker_run')
         self.start_patcher('docker_build', 'odoo.addons.runbot.container._docker_build')
+        self.start_patcher('docker_push', 'odoo.addons.runbot.container._docker_push')
         self.start_patcher('docker_ps', 'odoo.addons.runbot.container._docker_ps', [])
         self.start_patcher('docker_stop', 'odoo.addons.runbot.container._docker_stop')
         self.start_patcher('docker_get_gateway_ip', 'odoo.addons.runbot.models.build_config.docker_get_gateway_ip', None)

--- a/runbot/tests/test_cron.py
+++ b/runbot/tests/test_cron.py
@@ -32,10 +32,10 @@ class TestCron(RunbotCase):
         mock_update_batches.assert_called()
 
     @patch('time.sleep', side_effect=sleep)
-    @patch('odoo.addons.runbot.models.host.Host._docker_build')
+    @patch('odoo.addons.runbot.models.host.Host._docker_update_images')
     @patch('odoo.addons.runbot.models.host.Host._bootstrap')
     @patch('odoo.addons.runbot.models.runbot.Runbot._scheduler')
-    def test_cron_build(self, mock_scheduler, mock_host_bootstrap, mock_host_docker_build, *args):
+    def test_cron_build(self, mock_scheduler, mock_host_bootstrap, mock_host_docker_update_images, *args):
         """ test that cron_fetch_and_build do its work """
         hostname = 'cronhost.runbot.com'
         self.patchers['hostname_patcher'].return_value = hostname
@@ -49,7 +49,7 @@ class TestCron(RunbotCase):
             pass  # sleep raises an exception to avoid to stay stuck in loop
         mock_scheduler.assert_called()
         mock_host_bootstrap.assert_called()
-        mock_host_docker_build.assert_called()
+        mock_host_docker_update_images.assert_called()
         host = self.env['runbot.host'].search([('name', '=', hostname)])
         self.assertTrue(host, 'A new host should have been created')
         # self.assertGreater(host.psql_conn_count, 0, 'A least one connection should exist on the current psql batch')

--- a/runbot/views/host_views.xml
+++ b/runbot/views/host_views.xml
@@ -11,6 +11,7 @@
                         <field name="name" readonly='1'/>
                         <field name="disp_name"/>
                         <field name="active"/>
+                        <field name="use_remote_docker_registry"/>
                         <field name="last_start_loop" readonly='1'/>
                         <field name="last_end_loop" readonly='1'/>
                         <field name="last_success" readonly='1'/>
@@ -53,6 +54,7 @@
                 <field name="name"/>
                 <field name="disp_name"/>
                 <field name="assigned_only" widget="boolean_toggle"/>
+                <field name="use_remote_docker_registry" widget="boolean_toggle"/>
                 <field name="nb_worker"/>
                 <field name="nb_run_slot"/>
             </tree>

--- a/runbot/views/res_config_settings_views.xml
+++ b/runbot/views/res_config_settings_views.xml
@@ -93,7 +93,11 @@
                       <field name="runbot_upgrade_exception_message" class="w-100"/>
                     </setting>
                   </block>
-
+                  <block title="Docker Registry Settings">
+                    <setting>
+                      <field name="runbot_docker_registry_host_id"/>
+                    </setting>
+                  </block>
                 </app>
               </xpath>
             </field>

--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -20,18 +20,28 @@ class BuilderClient(RunbotClient):
             for repo in self.env['runbot.repo'].search([('mode', '!=', 'disabled')]):
                 repo._update(force=True)
 
-        self.last_docker_update = None
+        self.last_docker_updates = None
 
     def loop_turn(self):
+        icp = self.env['ir.config_parameter']
+        docker_registry_host_id = icp.get_param('runbot.docker_registry_host_id', default=False)
+        is_registry = docker_registry_host_id == str(self.host.id)
+        if is_registry:
+            self.env['runbot.runbot']._start_docker_registry(self.host)
         last_docker_updates = self.env['runbot.dockerfile'].search([('to_build', '=', True)]).mapped('write_date')
-        if self.count == 1 or last_docker_updates and self.last_docker_update != max(last_docker_updates):
-            self.host._docker_build()
-            self.last_docker_update = max(last_docker_updates)
+        if self.count == 1 or self.last_docker_updates != last_docker_updates:
+            self.last_docker_updates = last_docker_updates
+            self.host._docker_update_images()
+            self.env.cr.commit()
         if self.count == 1:  # cleanup at second iteration
             self.env['runbot.runbot']._source_cleanup()
+            self.env.cr.commit()
             self.env['runbot.build']._local_cleanup()
+            self.env.cr.commit()
             self.env['runbot.runbot']._docker_cleanup()
+            self.env.cr.commit()
             self.host._set_psql_conn_count()
+            self.env.cr.commit()
             self.env['runbot.repo']._update_git_config()
             self.env.cr.commit()
             self.git_gc()


### PR DESCRIPTION
Actually, when using multiple runbot builders each one is building its Docker images.
Although they use the same Dockerfile, some small differences could happen.

e.g., two runbot host are not setup at the same date some distribution packages may have been updated in the most recent Docker built image.

This PR adds the possibility to use a Docker registry. By default, the runbot should work without a registry and each host can be configured to use it or not.

THIS PR IS A DRAFT TEST