### PR TITLE
16.0 avoid modal moc

### DIFF
--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -288,7 +288,7 @@
                     <t t-else="">
                       <t t-if="'\n' not in l.message" t-esc="l.message"/>
                       <pre t-if="'\n' in l.message" style="margin:0;padding:0; border: none;"><t t-esc="l.message"/></pre>
-                      <t t-if="l.type == 'subbuild' and nb_subbuild &lt;= 20 and build.local_result!='ok' subbuild.sudo().error_log_ids">
+                      <t t-if="l.type == 'subbuild' and nb_subbuild &lt;= 20 and build.local_result != 'ok' and subbuild.sudo().error_log_ids">
                         <a class="show" data-toggle="collapse" t-attf-data-target="#subbuild-{{subbuild.id}}">
                           <i class="fa"/>
                         </a>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -64,6 +64,7 @@
                         <field name="module_name"/>
                         <field name="summary"/>
                         <field name="build_count"/>
+                        <button type="object" name="get_formview_action" icon="fa-arrow-right" title="View linked error"/>
                       </tree>
                     </field>
                   </page>
@@ -78,6 +79,7 @@
                         <field name="responsible"/>
                         <field name="fixing_commit"/>
                         <field name="id"/>
+                        <button type="object" name="get_formview_action" icon="fa-arrow-right" title="View linked error"/>
                       </tree>
                     </field>
                   </page>


### PR DESCRIPTION
- [IMP] avoid modal in build error view when trying to open a linked error or an error from the history
- [FIX] fix invalid condition in build template