### PR TITLE
[FIX] runbot: fix inconsistent update global_state

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -261,6 +261,7 @@ class BuildResult(models.Model):
                     record.global_state = record.local_state
                 else:
                     record.global_state = 'waiting'
+                self.env.cache._dirty[self._fields['global_state']].update(self._ids)
             else:
                 record.global_state = record.local_state
 


### PR DESCRIPTION
In some case the global state can be inconsistent, waiting when all builds are done. My suspicion is that two build finish at the same time, but the update is not done in database leading to an inconsistent state if two build finishes at the same time.

This should solve this issue by forcing the update, leading to the rollback of one of the transaction.

This still need further investigation to check if it is the real issue.