### PR TITLE
16.0 search single version moc

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -471,7 +471,6 @@ class Runbot(Controller):
 
         # Sort & Filter
         sortby = kwargs.get('sortby', 'count')
-        filterby = kwargs.get('filterby', 'not_one')
         searchbar_sortings = {
             'date': {'label': 'Recently Seen', 'order': 'last_seen_date desc'},
             'count': {'label': 'Nb Seen', 'order': 'build_count desc'},
@@ -482,6 +481,16 @@ class Runbot(Controller):
             'unassigned': {'label': 'Unassigned', 'domain': [('responsible', '=', False)]},
             'not_one': {'label': 'Seen more than once', 'domain': [('build_count', '>', 1)]},
         }
+
+        for trigger in team.build_error_ids.trigger_ids if team else []:
+            k = f'trigger_{trigger.name.lower().replace(" ", "_")}'
+            searchbar_filters.update(
+                {k: {'label': f'Trigger {trigger.name}', 'domain': [('trigger_ids', '=', trigger.id)]}}
+            )
+
+        filterby = kwargs.get('filterby', 'not_one')
+        if filterby not in searchbar_filters:
+            filterby = 'not_one'
         domain = expression.AND([domain, searchbar_filters[filterby]['domain']])
 
         qctx = {

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -191,7 +191,7 @@ class BuildError(models.Model):
         for fingerprint, logs in hash_dict.items():
             build_errors |= self.env['runbot.build.error'].create({
                 'content': logs[0].message,
-                'module_name': logs[0].name,
+                'module_name': logs[0].name.removeprefix('odoo.').removeprefix('addons.'),
                 'file_path': logs[0].path,
                 'function': logs[0].func,
                 'build_ids': [(6, False, [r.build_id.id for r in logs])],

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -114,15 +114,15 @@ class BuildError(models.Model):
             top_parent_builds = build_error.build_ids.mapped(lambda rec: rec and rec.top_parent)
             build_error.bundle_ids = top_parent_builds.mapped('slot_ids').mapped('batch_id.bundle_id')
 
-    @api.depends('build_ids', 'child_ids.build_ids')
+    @api.depends('children_build_ids')
     def _compute_version_ids(self):
         for build_error in self:
-            build_error.version_ids = build_error.build_ids.version_id
+            build_error.version_ids = build_error.children_build_ids.version_id 
 
-    @api.depends('build_ids')
+    @api.depends('children_build_ids')
     def _compute_trigger_ids(self):
         for build_error in self:
-            build_error.trigger_ids = build_error.build_ids.trigger_id
+            build_error.trigger_ids = build_error.children_build_ids.trigger_id
 
     @api.depends('content')
     def _compute_summary(self):

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -220,7 +220,11 @@ class BuildError(models.Model):
         return ['-%s' % tag for tag in self._test_tags_list()]
 
     def _search_version(self, operator, value):
-        return [('build_ids.version_id', operator, value)]
+        exclude_domain = []
+        if operator == '=':
+            exclude_ids = self.env['runbot.build.error'].search([('version_ids', '!=', value)])
+            exclude_domain = [('id', 'not in', exclude_ids.ids)]
+        return [('build_ids.version_id', operator, value)] + exclude_domain
 
     def _search_trigger_ids(self, operator, value):
         return [('build_ids.trigger_id', operator, value)]

--- a/runbot/templates/build_error.xml
+++ b/runbot/templates/build_error.xml
@@ -9,6 +9,7 @@
               <div class="col">Last seen date</div>
               <div class="col col-md-3">Module</div>
               <div class="col col-md-5">Summary</div>
+              <div class="col">Triggers</div>
               <div class="col">Assigned to</div>
               <div class="col">&amp;nbsp;</div>
             </div>
@@ -25,6 +26,11 @@
                     <i class="fa fa-minus"/>
                   </button>
                   <code><t t-esc="build_error.summary"/></code>
+                </div>
+                <div class="col">
+                  <t t-foreach="build_error.trigger_ids" t-as="trigger">
+                    <span class="badge badge-pill badge-light small"><t t-esc="trigger.name"/></span>
+                  </t>
                 </div>
                 <div class="col">
                   <t t-if="build_error.responsible" t-esc="build_error.responsible.name"/>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -150,7 +150,7 @@
                   decoration-success="fixing_pr_id and not test_tags and not fixing_pr_alive"
                   decoration-warning="test_tags and fixing_pr_id and not fixing_pr_alive"
                   multi_edit="1"
-                  create="False"
+                  create="false"
                   >
                 <header>
                   <button name="%(runbot.runbot_open_bulk_wizard)d" string="Bulk Update" type="action" groups="runbot.group_runbot_admin,runbot.group_runbot_error_manager"/>
@@ -194,6 +194,7 @@
           <separator/>
           <filter string="Not Assigned" name="not_assigned_errors" domain="[('responsible', '=', False)]"/>
           <filter string="Assigned" name="assigned_errors" domain="[('responsible', '!=', False)]"/>
+          <separator/>
           <filter string="Having a PR" name="pr_set_errors" domain="[('fixing_pr_id', '!=', False)]"/>
           <filter string="Fixing PR is closed" name="pr_closed_errors" domain="[('fixing_pr_id', '!=', False), ('fixing_pr_id.alive', '=', False)]"/>
           <filter string="Fixing PR is open" name="pr_open_errors" domain="[('fixing_pr_id', '!=', False), ('fixing_pr_id.alive', '=', True)]"/>


### PR DESCRIPTION
When filtering the build error tree view based on the versions equality,
the results may not be what you expect.

e.g.: searching for `versions is equal to 16.0` gives the errors that
appeared in `16.0` (hopefully) but also those which appeared in other
versions too.

With this commit, this search will give the errors that appeared in the
specified version only. When the user wants to list errors that appeared
in `16.0` and other versions too, he has to use the `contains 16.0`
criteria.
