### PR TITLE
[IMP] runbot: improve build error cleaning action

### DIFF
--- a/runbot/models/ir_logging.py
+++ b/runbot/models/ir_logging.py
@@ -56,7 +56,7 @@ class IrLogging(models.Model):
             ir_logging.error_id = False
             if ir_logging.level in ('ERROR', 'CRITICAL', 'WARNING') and ir_logging.type == 'server':
                 fingerprints[self.env['runbot.build.error']._digest(cleaning_regexes._r_sub('%', ir_logging.message))].append(ir_logging)
-        for build_error in self.env['runbot.build.error'].search([('fingerprint', 'in', list(fingerprints.keys()))]):
+        for build_error in self.env['runbot.build.error'].search([('fingerprint', 'in', list(fingerprints.keys()))], order='active asc'):
             for ir_logging in fingerprints[build_error.fingerprint]:
                 ir_logging.error_id = build_error.id
 

--- a/runbot/models/ir_logging.py
+++ b/runbot/models/ir_logging.py
@@ -55,7 +55,7 @@ class IrLogging(models.Model):
         for ir_logging in self:
             ir_logging.error_id = False
             if ir_logging.level in ('ERROR', 'CRITICAL', 'WARNING') and ir_logging.type == 'server':
-                fingerprints[self.env['runbot.build.error']._digest(cleaning_regexes._r_sub('%', ir_logging.message))].append(ir_logging)
+                fingerprints[self.env['runbot.build.error']._digest(cleaning_regexes._r_sub(ir_logging.message))].append(ir_logging)
         for build_error in self.env['runbot.build.error'].search([('fingerprint', 'in', list(fingerprints.keys()))], order='active asc'):
             for ir_logging in fingerprints[build_error.fingerprint]:
                 ir_logging.error_id = build_error.id

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -113,7 +113,10 @@ class TestBuildError(RunbotCase):
         ko_build = self.create_test_build({'local_result': 'ok', 'local_state': 'testing'})
         ok_build = self.create_test_build({'local_result': 'ok', 'local_state': 'running'})
 
-
+        cleaner = self.env['runbot.error.regex'].create({
+            'regex': '^FAIL: ',
+            're_type': 'cleaning',
+        })
 
         error_team = self.BuildErrorTeam.create({
             'name': 'test-error-team',
@@ -143,6 +146,8 @@ class TestBuildError(RunbotCase):
         ok_build._parse_logs()
         build_error = self.BuildError.search([('build_ids', 'in', [ko_build.id])])
         self.assertTrue(build_error)
+        self.assertTrue(build_error.fingerprint.startswith('af0e88f3'))
+        self.assertTrue(build_error.cleaned_content.startswith('%'), 'The cleaner should have replace "FAIL: " with a "%" sign by default')
         self.assertIn(ko_build, build_error.build_ids, 'The parsed build should be added to the runbot.build.error')
         self.assertFalse(self.BuildError.search([('build_ids', 'in', [ok_build.id])]), 'A successful build should not associated to a runbot.build.error')
         self.assertEqual(error_team, build_error.team_id)

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -221,6 +221,7 @@
               <group name="build_regex_group">
                 <field name="regex"/>
                 <field name="re_type"/>
+                <field name="replacement" attrs="{'invisible': [('re_type', '!=', 'cleaning')]}"/>
               </group>
             </sheet>
             <div class="oe_chatter">
@@ -239,6 +240,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="regex"/>
                 <field name="re_type"/>
+                <field name="replacement"/>
             </tree>
         </field>
     </record>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -166,6 +166,7 @@
                 <field name="fixing_pr_id"/>
                 <field name="fixing_pr_alive" invisible="1"/>
                 <field name="fixing_pr_url" widget="url" text="view PR" readonly="1" attrs="{'invisible': [('fixing_pr_url', '=', False)]}"/>
+                <field name="fingerprint" optional="hide"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
- when build errors are re-cleaned, they are also merged if the recomputed fingerprints are matching
- Also fixes the ir_logging compute that associate a build error so that the active build error is preferred over an inactive one.
- Allow to choose the replacement string in cleaning regexes
- optionally shows the fingerprint column in build error list view 