### PR TITLE
[FIX] runbot: wakeup child without parent db

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1001,7 +1001,7 @@ class BuildResult(models.Model):
         self._log('wake_up', f'Wake up initiated by {user.name}')
         if self.local_state != 'done':
             self._log('wake_up', 'Impossibe to wake up, state is not done')
-        elif self.parent_id and not user.has_group('runbot.group_runbot_advanced_user'):
+        elif self.parent_id.database_ids and not user.has_group('runbot.group_runbot_advanced_user'):
             self._log('wake_up', 'Waking up child builds is for advanced users only')
         else:
             self.requested_action = 'wake_up'

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -219,7 +219,7 @@
                     <a t-if="bu.static_run" t-att-href="bu.static_run" class="btn btn-info" title="View result" aria-label="View result">
                         <i class="fa fa-sign-in"/>
                     </a>
-                    <a groups="base.group_user" t-if="bu.local_state=='done' and (not bu.parent_id or user_id.has_group('runbot.group_runbot_advanced_user')) and bu.requested_action != 'wake_up' and bu.database_ids" href="#" data-runbot="wakeup" t-att-data-runbot-build="bu.id" class="btn btn-default" title="Wake up this build" aria-label="Wake up this build">
+                    <a groups="base.group_user" t-if="bu.local_state=='done' and (not bu.parent_id.database_ids or user_id.has_group('runbot.group_runbot_advanced_user')) and bu.requested_action != 'wake_up' and bu.database_ids" href="#" data-runbot="wakeup" t-att-data-runbot-build="bu.id" class="btn btn-default" title="Wake up this build" aria-label="Wake up this build">
                         <i class="fa fa-coffee"/>
                     </a>
                     <a t-attf-href="/runbot/build/{{bu['id']}}" class="btn btn-default" title="Build details" aria-label="Build details">
@@ -295,13 +295,13 @@
                     </t>
                 </t>
                 <t t-if="bu.global_state == 'done'">
-                    <t t-if="bu.requested_action != 'wake_up'">
+                    <t t-if="bu.requested_action != 'wake_up' and bu.database_ids">
                         <a groups="base.group_user" class="dropdown-item" href="#" data-runbot="wakeup" t-att-data-runbot-build="bu['id']">
                             <i class="fa fa-coffee"/>
                             Wake up
                         </a>
                     </t>
-                    <t t-else="">
+                    <t t-if="bu.requested_action == 'wake_up'">
                         <a groups="base.group_user" class="dropdown-item disabled">
                             <i class="fa fa-spinner fa-spin"/>
                             Waking up


### PR DESCRIPTION
A check was add to avoid to wakeup a child if there is a parent database Most of the time, it was a mistake.

In some case it can be legit, if the parent only creates subbuid without installing any database.
This commit fixes that by allowing to wake up child if the parent has no database.