### PR TITLE
[IMP] runbot: allow to use dev foreign branches

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -7,8 +7,6 @@ from collections import defaultdict
 from odoo import models, fields, api, tools
 from ..common import dt2time, s2human_long
 
-_logger = logging.getLogger(__name__)
-
 
 class Bundle(models.Model):
     _name = 'runbot.bundle'
@@ -23,6 +21,7 @@ class Bundle(models.Model):
     no_build = fields.Boolean('No build')
     no_auto_run = fields.Boolean('No run')
     build_all = fields.Boolean('Force all triggers')
+    always_use_foreign = fields.Boolean('Use foreigh bundle', help='By default, check for the same bundle name in another project to fill missing commits.', default=lambda self: self.project_id.always_use_foreign)
     modules = fields.Char("Modules to install", help="Comma-separated list of modules to install and test.")
 
     batch_ids = fields.One2many('runbot.batch', 'bundle_id')

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -17,6 +17,8 @@ class Project(models.Model):
     token = fields.Char("Github token", groups="runbot.group_runbot_admin")
     master_bundle_id = fields.Many2one('runbot.bundle', string='Master bundle')
     dummy_bundle_id = fields.Many2one('runbot.bundle', string='Dummy bundle')
+    always_use_foreign = fields.Boolean('Use foreigh bundle', help='By default, check for the same bundle name in another project to fill missing commits.', default=False)
+
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -8,6 +8,7 @@
                 <group>
                     <field name="name"/>
                     <field name="keep_sticky_running"/>
+                    <field name="always_use_foreign"/>
                     <field name="dockerfile_id"/>
                     <field name="group_ids"/>
                     <field name="trigger_ids"/>
@@ -58,6 +59,7 @@
                             <field name="no_auto_run"/>
                             <field name="priority"/>
                             <field name="build_all"/>
+                            <field name="always_use_foreign"/>
                             <field name="dockerfile_id"/>
                             <field name="host_id" readonly="0"/>
                             <field name="commit_limit"/>


### PR DESCRIPTION
Using dev branch from foreign project to fill missing commits looks like a bad idea, mainly because the lifecycle of the branches is not the same

In some case, it can be useful to allow that to test a branch with a future change in the base project that will be needed to make the branch work. As an example introducing a small api change in odoo to make an override easier, or introducing a module that may be needed to use the feature.

This commit changes that by allowing to configure on the project or bundle if we allow to use foreign bundle as reference *before* checking the base bundle.