### PR TITLE
[FIX] runbot: adapt build error search for link model

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -277,10 +277,10 @@ class BuildError(models.Model):
         if operator == '=':
             exclude_ids = self.env['runbot.build.error'].search([('version_ids', '!=', value)])
             exclude_domain = [('id', 'not in', exclude_ids.ids)]
-        return [('build_ids.version_id', operator, value)] + exclude_domain
+        return [('build_error_link_ids.version_id', operator, value)] + exclude_domain
 
     def _search_trigger_ids(self, operator, value):
-        return [('build_ids.trigger_id', operator, value)]
+        return [('build_error_link_ids.trigger_id', operator, value)]
 
     def _get_form_url(self):
         self.ensure_one()


### PR DESCRIPTION
Since c6f9d1f0c a new model was added to link build errors and builds. The _search_version and _search_trigger_ids were not adapted to work with this new model.