### PR TITLE
16.0 search logs moc

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -48,6 +48,7 @@
         'views/dockerfile_views.xml',
         'views/error_log_views.xml',
         'views/host_views.xml',
+        'views/ir_logging_views.xml',
         'views/repo_views.xml',
         'views/res_config_settings_views.xml',
         'views/stat_views.xml',

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -373,6 +373,25 @@ class BuildError(models.Model):
                     record.team_id = team
 
 
+    def action_search_ir_logs(self):
+        self.ensure_one()
+        context = {
+            'search_default_type': 'server',
+            'search_default_message': self.cleaned_content,
+            'search_default_filter_create_date': True,
+            'search_default_filter_sticky_bundles': True,
+            'search_default_filter_failed_builds': True
+        }
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Search Error In Build Error Views',
+            'view_mode': 'tree',
+            'res_model': 'runbot.error.log',
+            'target': 'fullscreen',
+            'context': context,
+        }
+
+
 class BuildErrorTag(models.Model):
 
     _name = "runbot.build.error.tag"

--- a/runbot/models/ir_logging.py
+++ b/runbot/models/ir_logging.py
@@ -189,7 +189,7 @@ class RunbotErrorLog(models.Model):
             JOIN
                 runbot_build bu ON l.build_id = bu.id
             WHERE
-                l.level = 'ERROR'
+                l.level in ('ERROR', 'WARNING')
         )""")
 
     def action_goto_build(self):

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -9,6 +9,7 @@
               <widget name="web_ribbon" title="Test-tags" bg_color="bg-danger" attrs="{'invisible': [('test_tags', '=', False)]}"/>
               <widget name="web_ribbon" title="Linked to another error" bg_color="bg-warning" attrs="{'invisible': [('parent_id', '=', False)]}"/>
               <header>
+                <button name="action_search_ir_logs" string="Search Error Logs" type="object" groups="runbot.group_runbot_admin"/>
               </header>
                 <group name="build_error_group" string="Base info" col="2">
                   <field name="content" readonly="1"/>

--- a/runbot/views/error_log_views.xml
+++ b/runbot/views/error_log_views.xml
@@ -65,15 +65,12 @@
           <field name="name" string="Module"/>
           <field name="func"/>
           <field name="build_id"/>
-          <filter string="Failed builds" name="failed_builds" domain="[('global_state', '=', 'done'), ('global_result', '=', 'ko')]"/>
+          <filter string="Failed builds" name="filter_failed_builds" domain="[('global_state', '=', 'done'), ('global_result', '=', 'ko')]"/>
           <separator/>
-          <filter string="Master bundle" name="master_bundle" domain="[('bundle_ids.name', '=', 'master')]"/>
-          <filter string="Sticky bundles" name="sticky_bundles" domain="[('sticky', '=', True)]"/>
+          <filter string="Master bundle" name="filter_master_bundle" domain="[('bundle_ids.name', '=', 'master')]"/>
+          <filter string="Sticky bundles" name="filter_sticky_bundles" domain="[('sticky', '=', True)]"/>
           <separator/>
-          <!-- <filter name="filter_log_create_date" date="log_create_date" string="Log Date" default_period="last_7_days"/> -->
-          <filter string="Last 7 Days" name="log_date" domain="[
-                        ('log_create_date', '>=', (datetime.datetime.combine(context_today() + relativedelta(days=-7), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                        ('log_create_date', '&lt;', (datetime.datetime.combine(context_today(), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+          <filter name="filter_create_date" string="Create Date" date="log_create_date" default_period="this_month"/>
         </search>
       </field>
     </record>
@@ -82,8 +79,7 @@
         <field name="name">Error Logs</field>
         <field name="res_model">runbot.error.log</field>
         <field name="view_mode">tree,form</field>
-        <!-- <field name="context">{'search_default_sticky_bundles': True, 'search_default_failed_builds': True, 'time_ranges': {'field': 'log_create_date', 'range': 'last_7_days'},}</field> -->
-        <field name="context">{'search_default_sticky_bundles': True, 'search_default_failed_builds': True, 'search_default_log_date': True}</field>
+        <field name="context">{'search_default_sticky_bundles': True, 'search_default_failed_builds': True, 'search_default_filter_create_date': True}</field>
     </record>
 
   </data>

--- a/runbot/views/ir_logging_views.xml
+++ b/runbot/views/ir_logging_views.xml
@@ -1,0 +1,41 @@
+<odoo>
+  <data>
+    <record model="ir.actions.act_window" id="open_view_ir_logging_tree">
+      <field name="name">Builds Ir Logging</field>
+      <field name="res_model">ir.logging</field>
+      <field name="view_mode">tree,form</field>
+      <field name="search_view_id" ref="base.ir_logging_search_view" />
+      <field name="context">{'search_default_type': 'server', 'search_default_filter_warning_or_error': True}</field>
+    </record>
+
+    <record id="ir_logging_tree_view_runbot" model="ir.ui.view">
+      <field name="name">ir.logging.tree.view</field>
+      <field name="model">ir.logging</field>
+      <field name="inherit_id" ref="base.ir_logging_tree_view" />
+      <field name="arch" type="xml">
+      <xpath expr="//tree" position="attributes">
+        <attribute name="create">0</attribute>
+      </xpath>
+      <xpath expr="//field[@name='func']" position="after">
+        <field name="error_id"/>
+      </xpath>
+      </field>
+    </record>
+
+    <record id="ir_logging_search_view_runbot" model="ir.ui.view">
+      <field name="name">ir.logging.tree.view</field>
+      <field name="model">ir.logging</field>
+      <field name="inherit_id" ref="base.ir_logging_search_view" />
+      <field name="arch" type="xml">
+      <xpath expr="//field[@name='message']" position="after">
+        <filter name="filter_create_date" string="Create Date" date="create_date" default_period="this_month"/>
+        <separator/>
+        <filter name="filter_warning_or_error" string="Warning or Error" domain="[('level', 'in', ('WARNING', 'ERROR'))]"/>
+        <filter name="filter_error" string="Error" domain="[('level', '=', 'ERROR')]"/>
+        <filter name="filter_warning" string="Warning"  domain="[('level', '=', 'WARNING')]"/>
+        <filter name="filter_info" string="Info"  domain="[('level', '=', 'INFO')]"/>
+      </xpath>
+      </field>
+    </record>
+  </data>
+</odoo>

--- a/runbot/views/menus.xml
+++ b/runbot/views/menus.xml
@@ -27,6 +27,7 @@
     <menuitem name="Manage errors" id="runbot_menu_manage_errors" parent="runbot_menu_root" sequence="900"/>
     <menuitem name="Build errors" id="runbot_menu_build_error_tree" parent="runbot_menu_manage_errors" sequence="10" action="open_view_build_error_tree"/>
     <menuitem name="Error Logs" id="runbot_menu_error_logs" parent="runbot_menu_manage_errors" sequence="20" action="open_view_error_log_tree"/>
+    <menuitem name="Builds Ir Logging" id="runbot_menu_ir_logging" parent="runbot_menu_manage_errors" sequence="30" action="open_view_ir_logging_tree"/>
 
     <menuitem name="Teams" id="runbot_menu_teams" parent="runbot_menu_root" sequence="1000"/>
     <menuitem name="Teams" id="runbot_menu_team_tree" parent="runbot_menu_teams" sequence="30" action="open_view_runbot_team"/>


### PR DESCRIPTION
When managing build errors, it's sometimes useful to search for other
occurrences of the error in all the build logs. Although it's possible
to do it manually, the operation is tedious.

With this commit, a button is added on the error page to automatically
perform the search for the same error in all the build error logs
(sql view).