### PR TITLE
[FIX] runbot: fix errors first and last seen dates

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': "runbot",
     'summary': "Runbot",
-    'description': "Runbot for Odoo 16.0",
+    'description': "Runbot for Odoo 17.0",
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -177,7 +177,7 @@ class BuildError(models.Model):
         for build_error in self:
             build_error.last_seen_build_id = build_error.children_build_ids and build_error.children_build_ids[0] or False
 
-    @api.depends('build_error_link_ids', 'child_ids')
+    @api.depends('build_error_link_ids', 'child_ids.build_error_link_ids')
     def _compute_seen_date(self):
         for build_error in self:
             error_dates = (build_error.build_error_link_ids | build_error.child_ids.build_error_link_ids).mapped('log_date')


### PR DESCRIPTION
Because of a bad dependency on the compute, the first seen date and last seen date are not always updated.

e.g.: a new build is scanned and a build is added to a linked error, the parent error seen dates are not updated.

A test is added to reproduce the case.