### PR TITLE
[IMP] runbot: allow to customize repo filters from

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -24,7 +24,7 @@ def route(routes, **kw):
         @o_route(routes, **kw)
         @functools.wraps(f)
         def response_wrap(*args, **kwargs):
-            projects = request.env['runbot.project'].search([])
+            projects = request.env['runbot.project'].search([('hidden', '=', False)])
             more = request.httprequest.cookies.get('more', False) == '1'
             filter_mode = request.httprequest.cookies.get('filter_mode', 'all')
             keep_search = request.httprequest.cookies.get('keep_search', False) == '1'

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -20,6 +20,8 @@ class Project(models.Model):
     always_use_foreign = fields.Boolean('Use foreign bundle', help='By default, check for the same bundle name in another project to fill missing commits.', default=False)
     tmp_prefix = fields.Char('tmp branches prefix', default="tmp.")
     staging_prefix = fields.Char('staging branches prefix', default="staging.")
+    hidden = fields.Boolean('Hidden', help='Hide this project from the main page')
+    active = fields.Boolean("Active", default=True)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/runbot/security/ir.model.access.csv
+++ b/runbot/security/ir.model.access.csv
@@ -67,6 +67,9 @@ access_runbot_build_stat_regex_admin,access_runbot_build_stat_regex_admin,runbot
 access_runbot_trigger_user,access_runbot_trigger_user,runbot.model_runbot_trigger,runbot.group_user,1,0,0,0
 access_runbot_trigger_runbot_admin,access_runbot_trigger_runbot_admin,runbot.model_runbot_trigger,runbot.group_runbot_admin,1,1,1,1
 
+access_runbot_module_filter_user,access_runbot_module_filter_user,runbot.model_runbot_module_filter,runbot.group_user,1,0,0,0
+access_runbot_module_filter_runbot_admin,access_runbot_module_filter_runbot_admin,runbot.model_runbot_module_filter,runbot.group_runbot_admin,1,1,1,1
+
 access_runbot_repo_user,access_runbot_repo_user,runbot.model_runbot_repo,runbot.group_user,1,0,0,0
 access_runbot_repo_runbot_admin,access_runbot_repo_runbot_admin,runbot.model_runbot_repo,runbot.group_runbot_admin,1,1,1,1
 

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -189,6 +189,8 @@ class TestBuildResult(RunbotCase):
     def test_filter_modules(self, mock_get_available_modules):
         """ test module filtering """
 
+        self.addons_params.trigger_id = self.trigger_addons
+
         build = self.Build.create({
             'params_id': self.addons_params.id,
         })
@@ -211,6 +213,23 @@ class TestBuildResult(RunbotCase):
         # star to get all available mods
         modules_to_test = build._get_modules_to_test(modules_patterns='*, -hw_*, hw_explicit')
         self.assertEqual(modules_to_test, sorted(['good_module', 'bad_module', 'other_good', 'l10n_be', 'hwgood', 'hw_explicit', 'other_mod_1', 'other_mod_2']))
+
+        self.env['runbot.module.filter'].create([{
+            'trigger_id': self.trigger_addons.id,
+            'repo_id': self.repo_server.id,
+            'modules': '-*',
+        }, {
+            'trigger_id': self.trigger_addons.id,
+            'repo_id': self.repo_addons.id,
+            'modules': '*',
+        }, {
+            'trigger_id': self.trigger_addons.id,
+            'repo_id': self.repo_addons.id,
+            'modules': '-other_mod_1',
+        }])
+        modules_to_test = build._get_modules_to_test(modules_patterns='')
+
+        self.assertEqual(modules_to_test, sorted(['other_mod_2']))
 
     def test_build_cmd_log_db(self, ):
         """ test that the log_db parameter is set in the .odoorc file """

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -14,6 +14,8 @@
                     <field name="trigger_ids"/>
                     <field name="sequence"/>
                     <field name="token" password="True"/>
+                    <field name="hidden"/>
+                    <field name="active"/>
                 </group>
             </form>
         </field>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -33,6 +33,16 @@
                 <group string="Dependencies">
                   <field name="dependency_ids" nolabel="1" colspan="2"/>
                 </group>
+                <group string="Module filters">
+                  <field name="module_filters" nolabel="1" colspan="4">
+                    <tree string="Module filters" editable="bottom">
+                      <field name="repo_id"  domain="['|', ('id', 'in', parent.repo_ids), ('id', 'in', parent.dependency_ids)]"/>
+                      <field name="modules"/>
+                      <field name="description"/>
+                    </tree>
+                  </field>
+                </group>
+                <button class="btn btn-sm btn-primary" type="object" name="action_test_modules_filters" title="Test filters">List modules</button>
               </group>
               <group>
                 <group>


### PR DESCRIPTION
When using a repo as a dependency for another trigger, the default module filter for a repo is not always ideal

As an example, when using odoo as a dependency for another repo, we may only want to install the module from the new repo.

This iss done right now by creating a custom config but this lead to duplicates config and steps only to customize the module to install.

This commit proposes a new model to store the filters.

Note that this may be used later as module blacklist on repo too.