### PR TITLE
[IMP] runbot: reinforce version

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -1,7 +1,4 @@
-import time
-import logging
-import datetime
-import subprocess
+import re
 
 from collections import defaultdict
 from odoo import models, fields, api, tools
@@ -30,7 +27,7 @@ class Bundle(models.Model):
     last_done_batch = fields.Many2many('runbot.batch', 'Last batchs', compute='_compute_last_done_batch')
 
     sticky = fields.Boolean('Sticky', compute='_compute_sticky', store=True, index=True)
-    is_base = fields.Boolean('Is base', index=True)
+    is_base = fields.Boolean('Is base', index=True, readonly=True)
     defined_base_id = fields.Many2one('runbot.bundle', 'Forced base bundle', domain="[('project_id', '=', project_id), ('is_base', '=', True)]")
     base_id = fields.Many2one('runbot.bundle', 'Base bundle', compute='_compute_base_id', store=True)
     to_upgrade = fields.Boolean('To upgrade', compute='_compute_to_upgrade', store=True, index=False)

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_commit
 from . import test_upgrade
 from . import test_dockerfile
 from . import test_host
+from . import test_bundle

--- a/runbot/tests/test_bundle.py
+++ b/runbot/tests/test_bundle.py
@@ -1,0 +1,28 @@
+from .common import RunbotCase
+
+class TestBundleCreation(RunbotCase):
+    def test_version_at_bundle_creation(self):
+        saas_name = 'saas-27.2'
+        saas_bundle = self.Bundle.create({
+            'name': saas_name,
+            'project_id': self.project.id
+        })
+        saas_bundle.is_base = True
+        self.assertEqual(saas_bundle.version_id.name, saas_name, 'The bundle version_id should create base version')
+
+        dev_name = 'saas-27.2-brol-bro'
+        dev_bundle = self.Bundle.create({
+            'name': dev_name,
+            'project_id': self.project.id
+        })
+        self.assertEqual(dev_bundle.version_id.name, saas_name)
+
+        self.assertFalse(self.Version.search([('name', '=', dev_name)]), 'A dev bundle should not summon a new version')
+        dev_name = 'saas-27.2-brol-zzz'
+        dev_bundle = self.Bundle.create({
+            'name': dev_name,
+            'project_id': self.project.id,
+            'is_base': True
+        })
+        self.assertFalse(self.Version.search([('name', '=', dev_name)]), 'A dev bundle should not summon a new version, even if is_base is True')
+        self.assertEqual(dev_bundle.version_id.id, False)

--- a/runbot/tests/test_version.py
+++ b/runbot/tests/test_version.py
@@ -16,7 +16,7 @@ class TestVersion(RunbotCase):
 
         self.assertGreater(saas_version.number, major_version.number)
 
-        master_version = self.Version.create({'name': 'master'})
+        master_version = self.Version.search([('name', '=', 'master')])
         self.assertEqual(master_version.number, '~')
         self.assertGreater(master_version.number, saas_version.number)
 


### PR DESCRIPTION
When updating a bundle and changing the is_base field to True, it creates a new version based on the bundle name. This can potentially breaks builds and moreover, it can breaks the whole runbot when a duplicate version name is created.

With this commit:
- a constraint on the version name uniqueness is added
- the is_base field is hidden in the interface when the bundle name does not match the regular expression defined in the settings
- a version cannot be created by the compute version if the bundle name does not match the above mentioned regular expression