### PR TITLE
[FIX] runbot: fix stats page following 17.0 upgrade

### DIFF
--- a/runbot/static/src/js/stats.js
+++ b/runbot/static/src/js/stats.js
@@ -16,35 +16,39 @@ var config = {
       mode: 'point'
     },
     scales: {
-      xAxes: [{
+      x: {
         display: true,
         scaleLabel: {
           display: true,
           labelString: 'Builds'
         }
-      }],
-      yAxes: [{
+      },
+      y: {
         display: true,
         scaleLabel: {
           display: true,
           labelString: 'Value'
         },
-      }]
-    }
-  }
+      },
+    },
+  },
 };
+
+var shifted = false;
+$(document).on('keyup keydown', function(e){shifted = e.shiftKey} );
 
 config.options.onClick = function(event, activeElements) {
     if (activeElements.length === 0){
-        var x_label_index = this.scales['x-axis-0'].getValueForPixel(event.x);
-        var build_id = config.data.labels[x_label_index]
-        if (event.layerY > this.chartArea.bottom && event.layerY < this.chartArea.bottom + this.scales['x-axis-0'].height){
-          config.searchParams['center_build_id'] = build_id;
-          fetchUpdateChart();
-        }
-        return;
+      return
     }
-    window.open('/runbot/build/stats/' + config.data.labels[activeElements[0]._index]);
+    const build_id = config.data.labels[activeElements[0].index];
+    if (shifted){ 
+      config.searchParams['center_build_id'] = build_id;
+      fetchUpdateChart();
+    } else {
+      window.open('/runbot/build/stats/' + build_id);
+    }
+
 };
 
 function fetch(path, data, then) {

--- a/runbot/templates/build_stats.xml
+++ b/runbot/templates/build_stats.xml
@@ -92,6 +92,7 @@
               <button id="fast_forward_button" class="btn btn-default" title="Previous Builds" aria-label="Previous Builds">
                 <i t-attf-class="fa fa-fast-forward"/>
               </button>
+              <p>Tips: click a bullet to see corresponding build stats, shift+click to center the graph on this build</p>
               <i id="chart_spinner" class="fa fa-2x fa-circle-o-notch fa-spin"/>
             </div>
           </nav>


### PR DESCRIPTION
Some issue where remaining regarding stats click events and scales.

Before that it was possible to click on the legend to center the graph on this build. This is no longer possible or would need more complex event handling, replacing this feature by a shift+click. 

Also fixes the stat detail link