### PR TITLE
[IMP] less volatile reference databases

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -26,6 +26,13 @@ class Batch(models.Model):
     log_ids = fields.One2many('runbot.batch.log', 'batch_id')
     has_warning = fields.Boolean("Has warning")
     base_reference_batch_id = fields.Many2one('runbot.batch')
+    reference_batch_ids = fields.Many2many(
+        'runbot.batch',
+        string="Reference batches",
+        relation='batch__reference_batch_ids_rel',
+        column1='batch_id',
+        column2='referenced_batch_id',
+    )
 
     @api.depends('slot_ids.build_id')
     def _compute_all_build_ids(self):
@@ -232,6 +239,19 @@ class Batch(models.Model):
         self._update_commits_infos(base_head_per_repo)  # set base_commit, diff infos, ...
 
         # 2. FIND missing commit in a compatible base bundle
+        if bundle.is_base or auto_rebase:
+            self.reference_batch_ids = self.env['runbot.batch'].browse(result[1] for result in self.env['runbot.batch']._read_group(
+                domain=[
+                    ('state', '=', 'done'),
+                    ('bundle_id.project_id', '=', bundle.project_id.id),
+                    ('bundle_id.to_upgrade', '=', True),
+                    ('bundle_id.is_base', '=', True),
+                    ('category_id', '=', self.category_id.id),  # not 100% correct since it should match upgrade_dumps_trigger_id,
+                                                                # but all trigger should have upgrade_dumps_trigger_id in the same category
+                ],
+                groupby=['bundle_id'],
+                aggregates=['id:max'],
+            ))
         if not bundle.is_base:
             merge_base_commits = self.commit_link_ids.mapped('merge_base_commit_id')
             if self.base_reference_batch_id:

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -335,7 +335,8 @@ class Batch(models.Model):
                 'create_batch_id': self.id,
                 'used_custom_trigger': bool(trigger_custom),
             }
-            params_value['builds_reference_ids'] = trigger._reference_builds(bundle)
+
+            params_value['builds_reference_ids'] = trigger._reference_builds(self)
 
             params = self.env['runbot.build.params'].create(params_value)
 

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -86,12 +86,12 @@ class Trigger(models.Model):
             raise UserError('Upgrade trigger should have a config with step of type Configure Upgrade')
         return upgrade_step
 
-    def _reference_builds(self, bundle):
+    def _reference_builds(self, batch):
         self.ensure_one()
         if self.upgrade_step_id:  # this is an upgrade trigger, add corresponding builds
-            custom_config = next((trigger_custom.config_id for trigger_custom in bundle.trigger_custom_ids if trigger_custom.trigger_id == self), False)
+            custom_config = next((trigger_custom.config_id for trigger_custom in batch.bundle_id.trigger_custom_ids if trigger_custom.trigger_id == self), False)
             step = self._upgrade_step_from_config(custom_config) if custom_config else self.upgrade_step_id
-            refs_builds = step._reference_builds(bundle, self)
+            refs_builds = step._reference_builds(batch, self)
             return [(4, b.id) for b in refs_builds]
         return []
 


### PR DESCRIPTION
One a new batch is triggered, even if the commit head didn't change, the upgrade builds a frequently restarted because the reference builds are not the same once one of them changed. 

It's not a big issue, but it can generate useless load when passing pr from draft to ready for review, or starting a new batch manually, ...

This pr proposes to have reference batches on each base branches, that will be used as reference by dev branches instead of taking the last one.

The idea to search the latest batch created before the base batch was considered, but this won't work well for freshly rebased branches since the last done may change. The easiest solution is to store all last done base batch on each base bach. 

The question ss, should we filter them per category? 
1- before storing them? 
2- store all of them and filter when needed
The actual state of the database would make 1 more logical,  but looking at the current code it is possible to upgrade from the trigger from another category (use nightly databases)



This will only contains the model change, logic change will be contained in #869 to allow an incremental testing of changes
