### PR TITLE
[IMP] runbot: better log listing

### DIFF
--- a/runbot/tests/test_schedule.py
+++ b/runbot/tests/test_schedule.py
@@ -28,7 +28,8 @@ class TestSchedule(RunbotCase):
             'host': host.name,
             'job_start': datetime.datetime.now(),
             'active_step': self.env.ref('runbot.runbot_build_config_step_run').id,
-            'params_id': params.id
+            'docker_start': datetime.datetime.now(),
+            'params_id': params.id,
         })
         mock_docker_state.return_value = 'UNKNOWN'
         self.assertEqual(build.local_state, 'testing')
@@ -37,7 +38,7 @@ class TestSchedule(RunbotCase):
         self.assertEqual(build.local_result, 'ok')
 
         self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', [])  # the local logs have to be empty
-        build.write({'job_start': datetime.datetime.now() - datetime.timedelta(seconds=70)})  # docker never started
+        build.write({'docker_start': datetime.datetime.now() - datetime.timedelta(seconds=70)})  # docker never started
         build._schedule()
         self.assertEqual(build.local_state, 'done')
         self.assertEqual(build.local_result, 'ko')


### PR DESCRIPTION
The current logic to define if a build has logs or not is based on is_docker_step. This related logic is not always valid, since it is based on step type and step content, but there are many way to have a result that could be a docker start, one of them being to call another step. The main issue is that we don't always now if this other step is a docker step or not before runtime. Moreover the logic becamore more and more complex adding more conditions like commands, _run_, docker_params, ...

Moreover, the log list is completed before the build start, meaning that if the build is killed before completion, some logs may be missing but will be listed. This is also an issue when trying to access logs before the correspondong step ran.

This commit changes the logic by adding the log file to the list (and start log) when starting a docker, wich should give a more consistent result.