### PR TITLE
[IMP] runbot: improve make_result

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -70,8 +70,8 @@ def rfind(filename, pattern):
     if os.path.isfile(filename):
         regexp = re.compile(pattern, re.M)
         with file_open(filename, 'r') as f:
-            if regexp.findall(f.read()):
-                return True
+            result = regexp.findall(f.read())
+            return result or False
     return False
 
 

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -90,7 +90,7 @@ class Trigger(models.Model):
 
     report_view_id = fields.Many2one('ir.ui.view',
                                   help="custom view to render result",
-                                  string='Docker Template',
+                                  string='Report view',
                                   domain=[('type', '=', 'qweb')],
                                   context={'default_type': 'qweb', 'default_arch_base': '<t></t>'},
     )


### PR DESCRIPTION
The "Error or traceback found in logs" message is sometimes confusing since we don't know what is the cause of the issue.

The first idea is to split the two concept, error and traceback to have a better idea of the cause of the issue

The second one will also log the content of the line in the error message. For traceback, tries to get the complete traceback, getting all indentend lines and one last non idented one.

While working on it, cleaning slighty to partially get rid of returning a dict, artefact from odoo < 13.0