### PR TITLE
[IMP] runbot: custom trigger view

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -655,3 +655,10 @@ class Runbot(Controller):
         bundle.sudo().no_build = bool(value)
         _logger.info('Bundle %s no_build set to %s by %s', bundle.name, bool(value), request.env.user.name)
         return werkzeug.utils.redirect(f'/runbot/bundle/{bundle_id}')
+
+    @route(['/runbot/trigger/report/<model("runbot.trigger"):trigger_id>'], type='http', auth='user', website=True, sitemap=False)
+    def report_view(self, trigger_id=None, **kwargs):
+        return request.render("runbot.trigger_report", {
+            'trigger': trigger_id,
+            'project': trigger_id.project_id,
+        })

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -88,6 +88,13 @@ class Trigger(models.Model):
     team_ids = fields.Many2many('runbot.team', string="Runbot Teams", help="Teams responsible of this trigger, mainly usefull for nightly")
     active = fields.Boolean("Active", default=True)
 
+    report_view_id = fields.Many2one('ir.ui.view',
+                                  help="custom view to render result",
+                                  string='Docker Template',
+                                  domain=[('type', '=', 'qweb')],
+                                  context={'default_type': 'qweb', 'default_arch_base': '<t></t>'},
+    )
+
     @api.depends('config_id.step_order_ids.step_id.make_stats')
     def _compute_has_stats(self):
         for trigger in self:

--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -162,5 +162,12 @@
                 </t>
             </t>
         </template>
+
+        <template id="runbot.trigger_report">
+            <t t-call="runbot.layout">
+                <t t-call="{{trigger.report_view_id.key}}">
+                </t>
+            </t>
+        </template>
     </data>
 </odoo>

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -219,6 +219,7 @@
                 <span t-else="" t-attf-class="btn btn-default disabled slot_name">
                     <span t-esc="slot.trigger_id.name"/>
                 </span>
+                <a t-if="slot.trigger_id.report_view_id" title="View last trigger report" t-attf-href="/runbot/trigger/report/{{slot.trigger_id.id}}" class="fa fa-eye btn btn-info"/>
                 <a t-if="bu.local_state == 'running' and bu.database_ids" t-attf-href="/runbot/run/{{bu.id}}" class="fa fa-sign-in btn btn-info"/>
                 <a t-if="bu.static_run" t-att-href="bu.static_run" class="fa fa-sign-in btn btn-info"/>
                 <t t-if="bu" t-call="runbot.build_menu"/>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -17,6 +17,7 @@
                   <field name="category_id" required='1'/>
                   <field name="project_id" default=""/>
                   <field name="config_id"/>
+                  <field name="report_view_id"/>
                 </group>
                 <group>
                   <field name="description"/>


### PR DESCRIPTION
Some trigger may have an important depth and nightly result can be long to check.

A custom view was already done for upgrade nightly, but this is hidden and the same logic could be applied to the distro builds, ...

This commit adds a custom view on the trigger and related controller to display a custom view for a trigger.