### PR TITLE
[FIX] runbot: adapt docker template for debian control

### DIFF
--- a/runbot/templates/dockerfile.xml
+++ b/runbot/templates/dockerfile.xml
@@ -87,7 +87,7 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 ADD https://raw.githubusercontent.com/odoo/odoo/<t t-esc="values['odoo_branch']"/>/debian/control /tmp/control.txt
 RUN apt-get update \
     &amp;&amp; sed -n '/^Depends:/,/^[A-Z]/p' /tmp/control.txt \
-       | awk '/^ [a-z]/ { gsub(/,/,"") ; print $1 }' | sort -u \
+       | awk '/^ [a-z]/ { gsub(/,/,"") ; gsub(" ", "") ; print $NF }' | sort -u \
        | egrep -v 'postgresql-client' \
        | sed 's/python-imaging/python-pil/'| sed 's/python-pypdf/python-pypdf2/' \
        | DEBIAN_FRONTEND=noninteractive xargs apt-get install -y -qq \


### PR DESCRIPTION
The Debian control file was changed in odoo/odoo@55849aca in order to work with Ubuntu Noble. Because of that, it was needed to have a more robust parsing of the Debian Control file format.