### PR TITLE
[IMP] allow to add single version in foreign trigger dependencies

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -317,6 +317,11 @@ class Batch(models.Model):
                 base_foreign_bundles = bundle.search([('name', '=', bundle.base_id.name), ('project_id', 'in', foreign_projects.ids)])
                 _fill_missing({branch: branch.head for branch in base_foreign_bundles.mapped('branch_ids')}, 'base_head')
 
+        # 5. FIND missing commit in foreign project
+        if missing_repos and foreign_projects and missing_repos.mapped('single_version'):
+            base_foreign_bundles = bundle.search([('is_base', '=', True), ('version_id', 'in', missing_repos.mapped('single_version').ids), ('project_id', 'in', foreign_projects.ids)])
+            _fill_missing({branch: branch.head for branch in base_foreign_bundles.mapped('branch_ids')}, 'base_head')
+
         # CHECK missing commit
         if missing_repos:
             _logger.warning('Missing repo %s for batch %s', missing_repos.mapped('name'), self.id)


### PR DESCRIPTION
If a repo is marked as single version as upgrade util, the upgrade util will be taken from the corresponding version for all other versions. This was not working if the repo is in a foreign bundle.

Currently, single versions repo as filled as a side effect of 3.2 , fallbacking on master branch. We could make that more obvious and manage single version the same way. 