### PR TITLE
[FIX] runbot: add missing opcode

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -19,7 +19,7 @@ from odoo.tools.safe_eval import safe_eval, test_python_expr, _SAFE_OPCODES, to_
 # to simplify some python step by wraping the content in a function to allow return statement and get closer to other
 # steps
 
-_SAFE_OPCODES |= set(to_opcodes(['LOAD_DEREF', 'STORE_DEREF', 'LOAD_CLOSURE']))
+_SAFE_OPCODES |= set(to_opcodes(['LOAD_DEREF', 'STORE_DEREF', 'LOAD_CLOSURE', 'MAKE_CELL']))
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The MAKE_CELL opcode appeared in python 3.11 and is needed in some python steps when using closures and generators.

Like:
`(all(s > e for e in [1,2]) for s in [0,1])`