### PR TITLE
[FIX] runbot: add another missing opcode

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -19,7 +19,7 @@ from odoo.tools.safe_eval import safe_eval, test_python_expr, _SAFE_OPCODES, to_
 # to simplify some python step by wraping the content in a function to allow return statement and get closer to other
 # steps
 
-_SAFE_OPCODES |= set(to_opcodes(['LOAD_DEREF', 'STORE_DEREF', 'LOAD_CLOSURE', 'MAKE_CELL']))
+_SAFE_OPCODES |= set(to_opcodes(['LOAD_DEREF', 'STORE_DEREF', 'LOAD_CLOSURE', 'MAKE_CELL', 'COPY_FREE_VARS']))
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The COPY_FREE_VARS code was also added in python 3.11 and is needed by some python steps.