### PR TITLE
[IMP] Make dockerfiles more platform independent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.5.1
-numpy==1.21.5 # for matplotlib compatibility
+numpy>=1.17.0,<2.0.0 # for matplotlib compatibility
 unidiff
 docker==4.1.0; python_version < '3.10'
 docker==5.0.3; python_version >= '3.10'  # (Jammy)

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -137,9 +137,7 @@ class Host(models.Model):
 
         docker_append = f"""
             RUN groupadd -g {os.getgid()} {user} \\
-            && useradd -u {os.getuid()} -g {user} -G audio,video {user} \\
-            && mkdir /home/{user} \\
-            && chown -R {user}:{user} /home/{user}
+            && useradd -m -u {os.getuid()} -g {user} -G audio,video {user}
             USER {user}
             ENV COVERAGE_FILE /data/build/.coverage
             """


### PR DESCRIPTION
Currently when generating the docker files the following is appended:
```    
    RUN groupadd -g {os.getgid()} {user} \\
            && useradd -u {os.getuid()} -g {user} -G audio,video {user} \\
            && mkdir /home/{user} \\
            && chown -R {user}:{user} /home/{user}
            USER {user}
            ENV COVERAGE_FILE /data/build/.coverage
```

useradd will automatically create the home directory unless CREATE_HOME in `/etc/login.defs` is set to no. See [here](https://linux.die.net/man/8/useradd) 

On systems where CREATE_HOME isn't set to no the mkdir operation will results in a failure `mkdir: cannot create directory ‘/home/runbot’: File exists `

This change simply replaces the mkdir and chown commands with the `-m` flag to `useradd` which will always create the home directory if it does not exist regardless of the setting in `/etc/login.defs`, and give the user ownership of it.

