### PR TITLE
[FIX] runbot: mathplotlib packaging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-matplotlib==3.5.0
+matplotlib==3.5.1
+numpy==1.21.5 # for matplotlib compatibility
 unidiff
 docker==4.1.0; python_version < '3.10'
 docker==5.0.3; python_version >= '3.10'  # (Jammy)


### PR DESCRIPTION
A new version of numpy (2.0.0) was released in june 2024

Since matplotib requires a version of numpy >= 1.17, this new version is installed instead of the 1.x.

Pinning the numpy version to the expected one in ubuntu jammy should solve the issue.

Failed to initialize database `65188118-17-0-runbot`. Traceback (most recent call last):
  File "/data/build/odoo/odoo/service/server.py", line 1313, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/data/build/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/data/build/odoo/odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/data/build/odoo/odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/data/build/odoo/odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/data/build/odoo/odoo/modules/loading.py", line 185, in load_module_graph
    load_openerp_module(package.name)
  File "/data/build/odoo/odoo/modules/module.py", line 395, in load_openerp_module
    __import__(qualname)
  File "/data/build/runbot/runbot/__init__.py", line 3, in <module>
    from . import controllers
  File "/data/build/runbot/runbot/controllers/__init__.py", line 5, in <module>
    from . import badge
  File "/data/build/runbot/runbot/controllers/badge.py", line 5, in <module>
    from matplotlib.font_manager import FontProperties
  File "/home/odoo/.local/lib/python3.10/site-packages/matplotlib/__init__.py", line 109, in <module>
    from . import _api, _version, cbook, docstring, rcsetup
  File "/home/odoo/.local/lib/python3.10/site-packages/matplotlib/rcsetup.py", line 27, in <module>
    from matplotlib.colors import Colormap, is_color_like
  File "/home/odoo/.local/lib/python3.10/site-packages/matplotlib/colors.py", line 56, in <module>
    from matplotlib import _api, cbook, scale
  File "/home/odoo/.local/lib/python3.10/site-packages/matplotlib/scale.py", line 23, in <module>
    from matplotlib.ticker import (
  File "/home/odoo/.local/lib/python3.10/site-packages/matplotlib/ticker.py", line 136, in <module>
    from matplotlib import transforms as mtransforms
  File "/home/odoo/.local/lib/python3.10/site-packages/matplotlib/transforms.py", line 46, in <module>
    from matplotlib._path import (
ImportError: numpy.core.multiarray failed to import