### PR TITLE
[IMP] runbot: allow removal when cleaning build errors

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -391,12 +391,15 @@ class ErrorRegex(models.Model):
     regex = fields.Char('Regular expression')
     re_type = fields.Selection([('filter', 'Filter out'), ('cleaning', 'Cleaning')], string="Regex type")
     sequence = fields.Integer('Sequence', default=100)
-    replacement = fields.Char('Replacement string', help="String used as a replacment in cleaning. '%' if not set")
+    replacement = fields.Char('Replacement string', help="String used as a replacment in cleaning. Use '' to remove the matching string. '%' if not set")
 
     def _r_sub(self, s):
         """ replaces patterns from the recordset by replacement's or '%' in the given string """
         for c in self:
-            s = re.sub(c.regex, c.replacement or '%', s)
+            replacement = c.replacement or '%'
+            if c.replacement == "''":
+                replacement = ''
+            s = re.sub(c.regex, replacement, s)
         return s
 
     def _r_search(self, s):

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -10,6 +10,7 @@ Traceback (most recent call last):
     self.start_tour("/", 'rte_translator', login='admin', timeout=120)
   File "/data/build/odoo/odoo/tests/common.py", line 1062, in start_tour
     res = self.browser_js(url_path=url_path, code=code, ready=ready, **kwargs)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/data/build/odoo/odoo/tests/common.py", line 1046, in browser_js
     self.fail('%s\n%s' % (message, error))
 AssertionError: The test code "odoo.startTour('rte_translator')" failed
@@ -151,6 +152,12 @@ class TestBuildError(RunbotCase):
             're_type': 'cleaning',
         })
 
+        self.env['runbot.error.regex'].create({
+            'regex': r'\s*\^+',
+            're_type': 'cleaning',
+            'replacement': "''",
+        })
+
         error_team = self.BuildErrorTeam.create({
             'name': 'test-error-team',
             'path_glob': '*/test_ui.py'
@@ -178,6 +185,7 @@ class TestBuildError(RunbotCase):
         self.assertTrue(build_error)
         self.assertTrue(build_error.fingerprint.startswith('af0e88f3'))
         self.assertTrue(build_error.cleaned_content.startswith('%'), 'The cleaner should have replace "FAIL: " with a "%" sign by default')
+        self.assertFalse('^' in build_error.cleaned_content, 'The cleaner should have removed the "^" chars')
         error_link = self.env['runbot.build.error.link'].search([('build_id', '=', ko_build.id), ('build_error_id', '=', build_error.id)])
         self.assertTrue(error_link, 'An error link should exists')
         self.assertIn(ko_build, build_error.build_error_link_ids.mapped('build_id'), 'Ko build should be in build_error_link_ids')


### PR DESCRIPTION
When cleaning build errors before fingerprinting, it's only possible to replace the matching regex with something else but not an empty string.

Since the python 3.11 that may adds lines in error message in order to visually improve them, the fingerprint of those errors does not match anymore between different versions.

With this commit, when the replacement string is two consecutive simple quotes, the matching element is replaced by an empty sting, allowing to remove unwanted characters.