### PR TITLE
[FIX] runbot: move error message to the end

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -121,7 +121,7 @@ def _docker_build(build_dir, image_tag):
         return (False, e.explanation)
     except docker.errors.BuildError as e:
         _logger.error('Build of image %s failed', image_tag)
-        msg = f"{e.msg}\n{''.join(l.get('stream') or '' for l in e.build_log)}"
+        msg = f"{''.join(l.get('stream') or '' for l in e.build_log)}\nERROR:{e.msg}"
         return (False, msg)
 
 


### PR DESCRIPTION
When building a docker image the error is part of the stream, and at the end.

The current behaviour will append the error message at the begining of the "result log" breaking the temporality of the output. Adding it at the end should be more intuitive to read. This will also help to get a more  usefull error sumary in some cases.