### PR TITLE
WIP - add the possibility to disable a test per version

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -454,7 +454,7 @@ class ConfigStep(models.Model):
                 test_tags += self.test_tags.replace(' ', '').split(',')
             if self.enable_auto_tags and not build.params_id.config_data.get('disable_auto_tags', False):
                 if grep(config_path, "[/module][:class]"):
-                    auto_tags = self.env['runbot.build.error']._disabling_tags()
+                    auto_tags = self.env['runbot.build.error']._disabling_tags(build)
                     if auto_tags:
                         test_tags += auto_tags
 

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -25,6 +25,8 @@
                     <field name="active"/>
                     <field name="test_tags" decoration-danger="True" readonly="1" groups="!runbot.group_runbot_admin"/>
                     <field name="test_tags" decoration-danger="True" groups="runbot.group_runbot_admin" readonly="parent_id and not test_tags"/>
+                    <field name="tags_min_version_id" invisible="not test_tags"/>
+                    <field name="tags_max_version_id" invisible="not test_tags"/>
                   </group>
                   <group>
                     <field name="version_ids" widget="many2many_tags"/>
@@ -147,8 +149,8 @@
         <field name="name">runbot.build.error.tree</field>
         <field name="model">runbot.build.error</field>
         <field name="arch" type="xml">
-            <tree string="Errors" 
-                  decoration-danger="test_tags and (fixing_pr_alive or not fixing_pr_id)" 
+            <tree string="Errors"
+                  decoration-danger="test_tags and (fixing_pr_alive or not fixing_pr_id)"
                   decoration-success="fixing_pr_id and not test_tags and not fixing_pr_alive"
                   decoration-warning="test_tags and fixing_pr_id and not fixing_pr_alive"
                   multi_edit="1"
@@ -157,14 +159,17 @@
                 <header>
                   <button name="%(runbot.runbot_open_bulk_wizard)d" string="Bulk Update" type="action" groups="runbot.group_runbot_admin,runbot.group_runbot_error_manager"/>
                 </header>
-                <field name="module_name" readonly="1"/>
-                <field name="summary" readonly="1"/>
+                <field name="module_name" optional="show" readonly="1"/>
+                <field name="summary" optional="show" readonly="1"/>
                 <field name="random" string="Random"/>
+                <field name="first_seen_date" string="First Seen" optional="hide" readonly="1"/>
                 <field name="last_seen_date" string="Last Seen" readonly="1"/>
                 <field name="build_count" readonly="1"/>
                 <field name="responsible"/>
                 <field name="team_id"/>
                 <field name="test_tags"/>
+                <field name="tags_min_version_id" string="Tags Min" optional="show"/>
+                <field name="tags_max_version_id" string="Tags Max" optional="show"/>
                 <field name="fixing_pr_id"/>
                 <field name="fixing_pr_alive" invisible="1"/>
                 <field name="fixing_pr_url" widget="url" text="view PR" readonly="1" invisible="not fixing_pr_url"/>


### PR DESCRIPTION
When disabling tests on runbot by using the test_tags on a build error, the tests are disabled on every tested version. This can be annoying when a test only fails from one version up to another.

With this commit, a min and max version can be specified on a build_error when the test_tags field is used.
If the min and max are not used, the test will be disabled cross versions.