### PR TITLE
[FIX] runbot: allow - in database name

### DIFF
--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -74,7 +74,7 @@ server {
 <t id="server_build_anchor"/>
 server {
   listen 8080;
-  server_name ~^<t t-out="re_escape(build.dest)"/>(-[a-z0-9_]+)?-<t t-esc="build._get_run_token()[0]"/>(-[a-z0-9_]+)\.<t t-esc="re_escape(build.host)"/>$;
+  server_name ~^<t t-out="re_escape(build.dest)"/>(-[a-z0-9_-]+)?-<t t-esc="build._get_run_token()[0]"/>(-[a-z0-9_]+)\.<t t-esc="re_escape(build.host)"/>$;
   <t id="build_anchor_authenticated"/>
   location / {
     <t id="build_anchor_authenticated_side_effect"/>
@@ -84,7 +84,7 @@ server {
 
 server {
     listen 8080;
-    server_name ~^<t t-out="re_escape(build.dest)"/>(-[a-z0-9_]+)?\.<t t-esc="re_escape(build.host)"/>$;
+    server_name ~^<t t-out="re_escape(build.dest)"/>(-[a-z0-9_-]+)?\.<t t-esc="re_escape(build.host)"/>$;
     <t id="build_anchor"/>
     location / { proxy_pass http://127.0.0.1:<t t-esc="build.port"/>; }
     location /longpolling { proxy_pass http://127.0.0.1:<t t-esc="build.port + 1"/>; }


### PR DESCRIPTION
The underscore was previously used in database name, but this is not a valid character for certificates (still need some investigation about the limitations)

If it worked to access it it was causing issues for IOT andother. _ is forbidden on saas actually.

The design_theme database was changed to design-theme, but this is not accessible through the nginx condig. This should solve the issue.