### PR TITLE
[IMP] runbot: make stats when build timeout

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -736,6 +736,7 @@ class BuildResult(models.Model):
             if _docker_state == 'RUNNING':
                 timeout = min(build.active_step.cpu_limit, int(icp.get_param('runbot.runbot_timeout', default=10000)))
                 if build.local_state != 'running' and build.job_time > timeout:
+                    build.active_step._make_stats(build)
                     build._log('_schedule', '%s time exceeded (%ss)' % (build.active_step.name if build.active_step else "?", build.job_time))
                     build._kill(result='killed')
                 return False


### PR DESCRIPTION
The stats are only kept when the build finishes, this makes sence to avoid collecting stats of a manually killed build (or because of newer build found), but the stats mays be interresting when the build timeouts.

Adding a manual collection of stats in this case.