### PR TITLE
[IMP] runbot: pull docker image only when needed

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -166,7 +166,7 @@ def _docker_pull(image_tag):
     """Pull a docker image from a registry.
     :param image_tag: the full image tag, including the registry host
     e.g.: `dockerhub.runbot102.odoo.com/odoo:PureNobleTest`
-    :return: tuple(success, image) where success is a boolean and image a Docker image object or None in case of failure
+    :return: DockerMager.result dict
     """
     with DockerManager(image_tag) as dm:
         for chunk in dm.consume(dm.docker_client.api.pull(image_tag, stream=True)):

--- a/runbot/docker_manager.py
+++ b/runbot/docker_manager.py
@@ -57,6 +57,7 @@ class DockerManager:
     def __exit__(self, exception_type, exception_value, exception_traceback):
         if self.log_progress:
             _logger.info('Finished in %.2fs', self.duration)
+            self.result['log_progress'] = self.log_progress
         if exception_value:
             self.result['success'] = False
             _logger.warning(exception_value)

--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -128,6 +128,7 @@ class Dockerfile(models.Model):
     arch_base = fields.Text(related='template_id.arch_base', readonly=False, related_sudo=True)
     dockerfile = fields.Text(compute='_compute_dockerfile', tracking=True)
     to_build = fields.Boolean('To Build', help='Build Dockerfile. Check this when the Dockerfile is ready.', default=False)
+    always_pull = fields.Boolean('Always pull', help='Always Pull on the hosts, not only at the use time', default=False, tracking=True)
     version_ids = fields.One2many('runbot.version', 'dockerfile_id', string='Versions')
     description = fields.Text('Description')
     view_ids = fields.Many2many('ir.ui.view', compute='_compute_view_ids', groups="runbot.group_runbot_admin")

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -13,6 +13,7 @@
                 <field name="name"/>
                 <field name="image_tag"/>
                 <field name="to_build"/>
+                <field name="always_pull"/>
                 <field name="version_ids" widget="many2many_tags"/>
                 <field name="project_ids" widget="many2many_tags"/>
                 <field name="template_id"/>
@@ -104,6 +105,8 @@
             <field name="image_tag"/>
             <field name="to_build" groups="!runbot.group_runbot_admin"/>
             <field name="to_build" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
+            <field name="always_pull" groups="!runbot.group_runbot_admin"/>
+            <field name="always_pull" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
             <field name="version_ids" widget="many2many_tags"/>
             <field name="project_ids" widget="many2many_tags"/>
             <field name="use_count"/>


### PR DESCRIPTION
When a lot of Docker images are updated at the same time, all runbot hosts will try to pull them at the same moment.

With this commit, only the images marked as `always_pull` will be pulled and if one of them takes too much time to be pulled, we let the host make another loop turn before continuing the images pull.

Finally, if a host uses the Docker registry, it will use the remote image when running a step, that way the image will be pulled automatically if needed.