### PR TITLE
[IMP] add reviewer on runbot build tasks

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -50,6 +50,7 @@ class BuildError(models.Model):
     fingerprint = fields.Char('Error fingerprint', index=True)
     random = fields.Boolean('underterministic error', tracking=True)
     responsible = fields.Many2one('res.users', 'Assigned fixer', tracking=True)
+    customer = fields.Many2one('res.users', 'Customer', tracking=True)
     team_id = fields.Many2one('runbot.team', 'Assigned team', tracking=True)
     fixing_commit = fields.Char('Fixing commit', tracking=True)
     fixing_pr_id = fields.Many2one('runbot.branch', 'Fixing PR', tracking=True, domain=[('is_pr', '=', True)])
@@ -87,6 +88,12 @@ class BuildError(models.Model):
         for record in self:
             record.tags_min_version_id = min(record.version_ids, key=lambda rec: rec.number)
             record.tags_max_version_id = max(record.version_ids, key=lambda rec: rec.number)
+
+    @api.onchange('customer')
+    def _onchange_customer(self):
+        for record in self:
+            if not self.responsible:
+                self.responsible = self.customer
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -29,6 +29,7 @@
                     <field name="tags_max_version_id" invisible="not test_tags"/>
                   </group>
                   <group>
+                    <field name="customer"/>
                     <field name="version_ids" widget="many2many_tags"/>
                     <field name="trigger_ids" widget="many2many_tags"/>
                     <field name="tag_ids" widget="many2many_tags" readonly="1"/>


### PR DESCRIPTION
Idea is to help runbot/QA team to monitor other peoples tasks easier. This way we will have a responsible person for each task that someone else has assigned.
The goal of pr is twofold:
1) We need to be able to better monitor the progress of tasks that are not our own.
2) It introduces another metric with which we can measure individual progress, and this can become main measuring metric for future non-technical employees whose main goal will be making sure that none of the tasks become rotten.