### PR TITLE
[FIX] runbot: remove record iteration in onchange

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -85,15 +85,13 @@ class BuildError(models.Model):
 
     @api.onchange('test_tags')
     def _onchange_test_tags(self):
-        for record in self:
-            record.tags_min_version_id = min(record.version_ids, key=lambda rec: rec.number)
-            record.tags_max_version_id = max(record.version_ids, key=lambda rec: rec.number)
+        self.tags_min_version_id = min(self.version_ids, key=lambda rec: rec.number)
+        self.tags_max_version_id = max(self.version_ids, key=lambda rec: rec.number)
 
     @api.onchange('customer')
     def _onchange_customer(self):
-        for record in self:
-            if not self.responsible:
-                self.responsible = self.customer
+        if not self.responsible:
+            self.responsible = self.customer
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -446,9 +444,8 @@ class ErrorBulkWizard(models.TransientModel):
 
     @api.onchange('fixing_commit', 'chatter_comment')
     def _onchange_commit_comment(self):
-        for record in self:
-            if record.fixing_commit or record.chatter_comment:
-                record.archive = True
+        if self.fixing_commit or self.chatter_comment:
+            self.archive = True
 
     def action_submit(self):
         error_ids = self.env['runbot.build.error'].browse(self.env.context.get('active_ids'))

--- a/runbot/models/custom_trigger.py
+++ b/runbot/models/custom_trigger.py
@@ -118,18 +118,16 @@ class CustomTriggerWizard(models.TransientModel):
 
     @api.onchange('trigger_id')
     def _onchange_trigger_id(self):
-        for wizard in self:
-            if wizard.trigger_id:
-                wizard.restore_trigger_id = wizard.trigger_id.restore_trigger_id
-                if wizard.restore_trigger_id and not wizard.restore_mode:
-                    wizard.restore_mode = 'auto'
+        if self.trigger_id:
+            self.restore_trigger_id = self.trigger_id.restore_trigger_id
+            if self.restore_trigger_id and not self.restore_mode:
+                self.restore_mode = 'auto'
         self._onchange_config_data()
         self._onchange_warnings()
 
     @api.onchange('number_build', 'extra_params', 'child_extra_params', 'restore_dump_url', 'child_config_id', 'restore_trigger_id', 'restore_database_suffix', 'restore_mode')
     def _onchange_config_data(self):
-       for wizard in self:
-           wizard.config_data = self._get_config_data()
+        self.config_data = self._get_config_data()
 
     def _get_config_data(self):
         config_data = {}


### PR DESCRIPTION
A recent task introduced a record loop using self inside.

It doesn't respect an api multi classic loop but it isn't an issue since onchange are always called on a single record.

Removing the loop on all onchange to clean it up.