### PR TITLE
[IMP] runbot: add charset to content-type

### DIFF
--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -7,6 +7,7 @@ error_log <t t-esc="nginx_dir"/>/error.log;
 worker_processes  1;
 events { worker_connections  1024; }
 http {
+charset utf-8;
 include /etc/nginx/mime.types;
 server_names_hash_max_size 512;
 server_names_hash_bucket_size 256;
@@ -24,6 +25,8 @@ autoindex on;
 
 gzip on;
 gzip_types text/css text/plain application/xml application/json application/javascript;
+
+charset_types text/plain;
 
 map $http_x_forwarded_proto $real_scheme {
   default $http_x_forwarded_proto;


### PR DESCRIPTION
This commit adds the utf-8 Content-Type to nginx response headers for txt files. That way, the logs files can be properly viewed in browsers.