### PR TITLE
[IMP] runbot: add customer is me filter

### DIFF
--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -193,6 +193,8 @@
           <field name="fixing_commit"/>
           <filter string="Assigned to me" name="my_errors" domain="[('responsible', '=', uid)]"/>
           <separator/>
+          <filter string="Customer is me" name="my_errors_customer" domain="[('customer', '=', uid)]"/>
+          <separator/>
           <filter string="No Parent" name="no_parent_error" domain="[('parent_id', '=', False)]"/>
           <separator/>
           <filter string="Undeterministic" name="random_error" domain="[('random', '=', True)]"/>


### PR DESCRIPTION
As we try to assign ourselves as customer to build errors it is useful to add a new filter to find errors on which we are the customer more easily.