### PR TITLE
[REF] runbot: remove link type ir.logging

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -925,13 +925,15 @@ class ConfigStep(models.Model):
             build._logger('Step %s finished in %s' % (self.name, s2human(build.job_time)))
             return
 
-        kwargs = dict(message='Step %s finished in %s' % (self.name, s2human(build.job_time)))
+        message = 'Step %s finished in %s'
+        args = [self.name, s2human(build.job_time)]
+        log_type = 'runbot'
         if self.job_type == 'install_odoo':
-            kwargs['message'] += ' $$fa-download$$'
             db_suffix = build.params_id.config_data.get('db_name') or (build.params_id.dump_db.db_suffix if not self.create_db else False) or self.db_name
-            kwargs['path'] = '%s%s-%s.zip' % (build._http_log_url(), build.dest, db_suffix)
-            kwargs['log_type'] = 'link'
-        build._log('', **kwargs)
+            message += ' [@icon-download](%s%s-%s.zip)'
+            args += [build._http_log_url(), build.dest, db_suffix]
+            log_type = 'markdown'
+        build._log('', message, *args, log_type=log_type)
 
         if self.coverage:
             xml_url = '%scoverage.xml' % build._http_log_url()

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -286,6 +286,7 @@
                         <a t-att-href="href" t-attf-title="Func: {{l.func}}"><t t-esc="l.name"/>:<t t-esc="l.line"/></a>
                       </t>
                     </t>
+                    <!-- DEPRECATED: Will be removed once no ir.logging is concerned. -->
                     <span class="log_message" t-if="l.type == 'link' and len(l.message.split('$$')) == 3">
                       <t t-set="message" t-value="l.message.split('$$')"/>
                       <t t-if="message[1].startswith('fa-')">


### PR DESCRIPTION
1: Stop using the special \$\$icon\$ \$ syntax when logging the download url for
the database dump.

2: Removes the link type in ir.logging as they were using some weird dark
magic instead of the more generic markdown logging type.