### PR TITLE
[FIX] runbot: properly join log args

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -996,7 +996,7 @@ class BuildResult(models.Model):
                 message = message % args
             except TypeError:
                 _logger.exception(f'Error while formating `{message}` with `{args}`')
-                message = ' ' .join([message] + args)
+                message = ' ' .join([message] + list(args))
 
         message = truncate(message)
 


### PR DESCRIPTION
When a type error occurs when trying to format a message in a build log, the suspicious are are joined with the message. But as the args may be a tuple, an errors occurs when concatenating the message with the args during the join.

With this commit, we ensure that the args are casted into a list.