### PR TITLE
[FIX] runbot: fix log args

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -996,7 +996,7 @@ class BuildResult(models.Model):
                 message = message % args
             except TypeError:
                 _logger.exception(f'Error while formating `{message}` with `{args}`')
-                message = ' ' .join([message] + list(args))
+                message = ' ' .join([message, *map(str, args)])
 
         message = truncate(message)
 


### PR DESCRIPTION
Previous fix was not enough when one of the args is not a string.

Courtesy of xmo