### PR TITLE
17.0 fix merge content menu moc

### DIFF
--- a/runbot/data/error_link.xml
+++ b/runbot/data/error_link.xml
@@ -39,4 +39,14 @@
             records.action_assign()
         </field>
     </record>
+        <record model="ir.actions.server" id="action_deduplicate">
+        <field name="name">Deduplicate Error Contents</field>
+        <field name="model_id" ref="runbot.model_runbot_build_error_content" />
+        <field name="binding_model_id" ref="runbot.model_runbot_build_error_content" />
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="code">
+            records.action_deduplicate()
+        </field>
+    </record>
 </odoo>

--- a/runbot/data/error_link.xml
+++ b/runbot/data/error_link.xml
@@ -11,8 +11,8 @@
     </record>
     <record model="ir.actions.server" id="action_link_build_errors_contents">
         <field name="name">Link build errors contents</field>
-        <field name="model_id" ref="runbot.model_runbot_build_error" />
-        <field name="binding_model_id" ref="runbot.model_runbot_build_error" />
+        <field name="model_id" ref="runbot.model_runbot_build_error_content" />
+        <field name="binding_model_id" ref="runbot.model_runbot_build_error_content" />
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="code">

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -451,10 +451,10 @@ class BuildErrorContent(models.Model):
     def _search_trigger_ids(self, operator, value):
         return [('build_error_link_ids.trigger_id', operator, value)]
 
-    def _merge(self):
+    def _relink(self):
         if len(self) < 2:
             return
-        _logger.debug('Merging errors %s', self)
+        _logger.debug('Relinking error contents %s', self)
         base_error_content = self[0]
         base_error = base_error_content.error_id
         errors = self.env['runbot.build.error']
@@ -515,7 +515,7 @@ class BuildErrorContent(models.Model):
             to_merge.append(errors_content_by_fingerprint.filtered(lambda r: r.fingerprint == fingerprint))
         # this must be done in other iteration since filtered may fail because of unlinked records from _merge
         for errors_content_to_merge in to_merge:
-            errors_content_to_merge._merge()
+            errors_content_to_merge._relink()
 
     def action_find_duplicates(self):
         rg = [r['id_arr'] for r in self.env['runbot.build.error.content'].read_group([], ['id_count:count(id)', 'id_arr:array_agg(id)', 'fingerprint'], ['fingerprint']) if r['id_count'] >1]

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -482,6 +482,11 @@ class BuildErrorContent(models.Model):
             if not error.error_content_ids:
                 base_error._merge(error)
 
+    def _get_duplicates(self):
+        """ returns a list of lists of duplicates"""
+        domain = [('id', 'in', self.ids)] if self else []
+        return [r['id_arr'] for r in self.env['runbot.build.error.content'].read_group(domain, ['id_count:count(id)', 'id_arr:array_agg(id)', 'fingerprint'], ['fingerprint']) if r['id_count'] >1]
+
     ####################
     #   Actions
     ####################
@@ -517,8 +522,13 @@ class BuildErrorContent(models.Model):
         for errors_content_to_merge in to_merge:
             errors_content_to_merge._relink()
 
+    def action_deduplicate(self):
+        rg = self._get_duplicates()
+        for ids_list in rg:
+            self.env['runbot.build.error.content'].browse(ids_list)._relink()
+
     def action_find_duplicates(self):
-        rg = [r['id_arr'] for r in self.env['runbot.build.error.content'].read_group([], ['id_count:count(id)', 'id_arr:array_agg(id)', 'fingerprint'], ['fingerprint']) if r['id_count'] >1]
+        rg = self._get_duplicates()
         duplicate_ids = []
         for ids_lists in rg:
             duplicate_ids += ids_lists

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -462,7 +462,8 @@ class BuildErrorContent(models.Model):
         content_to_remove = self.env['runbot.build.error.content']
         for error_content in self[1:]:
             assert base_error_content.fingerprint == error_content.fingerprint, f'Errors {base_error_content.id} and {error_content.id} have a different fingerprint'
-            links_to_relink = error_content.build_error_link_ids.filtered(lambda rec: rec.build_id.id not in base_error_content.build_error_link_ids.build_id.ids)
+            existing_build_ids = set(base_error_content.build_error_link_ids.build_id.ids)
+            links_to_relink = error_content.build_error_link_ids.filtered(lambda rec: rec.build_id.id not in existing_build_ids)
             links_to_remove |= error_content.build_error_link_ids - links_to_relink  # a link already exists to the base error
 
             links_to_relink.error_content_id = base_error_content

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -512,6 +512,21 @@ class BuildErrorContent(models.Model):
         for errors_content_to_merge in to_merge:
             errors_content_to_merge._merge()
 
+    def action_find_duplicates(self):
+        rg = [r['id_arr'] for r in self.env['runbot.build.error.content'].read_group([], ['id_count:count(id)', 'id_arr:array_agg(id)', 'fingerprint'], ['fingerprint']) if r['id_count'] >1]
+        duplicate_ids = []
+        for ids_lists in rg:
+            duplicate_ids += ids_lists
+
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "runbot.build.error.content",
+            "domain": [('id', 'in', duplicate_ids)],
+            "context": {"create": False, 'group_by': ['fingerprint']},
+            "name": "Duplicate Error contents",
+            'view_mode': 'tree,form'
+        }
+
 
 class BuildErrorTag(models.Model):
 

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -458,22 +458,26 @@ class BuildErrorContent(models.Model):
         base_error_content = self[0]
         base_error = base_error_content.error_id
         errors = self.env['runbot.build.error']
+        links_to_remove = self.env['runbot.build.error.link']
+        content_to_remove = self.env['runbot.build.error.content']
         for error_content in self[1:]:
             assert base_error_content.fingerprint == error_content.fingerprint, f'Errors {base_error_content.id} and {error_content.id} have a different fingerprint'
-            for build_error_link in error_content.build_error_link_ids:
-                if build_error_link.build_id not in base_error_content.build_error_link_ids.build_id:
-                    build_error_link.error_content_id = base_error_content
-                else:
-                    # as the relation already exists and was not transferred we can remove the old one
-                    build_error_link.unlink()
+            links_to_relink = error_content.build_error_link_ids.filtered(lambda rec: rec.build_id.id not in base_error_content.build_error_link_ids.build_id.ids)
+            links_to_remove |= error_content.build_error_link_ids - links_to_relink  # a link already exists to the base error
+
+            links_to_relink.error_content_id = base_error_content
+
             if error_content.error_id != base_error_content.error_id:
                 base_error.message_post(body=Markup('Error content coming from %s was merged into this one') % error_content.error_id._get_form_link())
                 if not base_error.active and error_content.error_id.active:
                     base_error.active = True
             errors |= error_content.error_id
-            error_content.unlink()
+            content_to_remove |= error_content
+        content_to_remove.unlink()
+        links_to_remove.unlink()
+
         for error in errors:
-            error.message_post(body=Markup('Some error contents from this error where merged into %s') % base_error._get_form_link())
+            error.message_post(body=Markup('Some error contents from this error where moved into %s') % base_error._get_form_link())
             if not error.error_content_ids:
                 base_error._merge(error)
 

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -195,6 +195,7 @@ class BuildError(models.Model):
                     error.team_id = previous_error.team_id
             previous_error.error_content_ids.write({'error_id': self})
             if not previous_error.test_tags:
+                previous_error.message_post(body=Markup('Error merged into %s') % error._get_form_link())
                 previous_error.active = False
 
     @api.model

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -219,6 +219,7 @@
               <field name="error_count" readonly="1"/>
               <field name="build_count" readonly="1"/>
               <field name="team_id"/>
+              <field name="responsible" optional="show"/>
               <field name="test_tags" optional="hide"/>
               <field name="tags_min_version_id" string="Tags Min" optional="hide"/>
               <field name="tags_max_version_id" string="Tags Max" optional="hide"/>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -241,6 +241,7 @@
                   create="false"
                   >
                 <header>
+                  <button name="action_find_duplicates" type="object" string="Find duplicates" display="always"/>
                 </header>
                 <field name="error_display_id" optional="show"/>
                 <field name="module_name" optional="show" readonly="1"/>
@@ -393,7 +394,15 @@
         <field name="view_mode">tree,form</field>
     </record>
 
-
+    <record id="action_find_duplicates" model="ir.actions.server">
+      <field name="name">Find Duplicates</field>
+      <field name="model_id" ref="runbot.model_runbot_build_error_content"/>
+      <field name="type">ir.actions.server</field>
+      <field name="state">code</field>
+      <field name="code">
+          action = model._find_duplicates()
+      </field>
+    </record>
 
   </data>
 </odoo>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -309,6 +309,7 @@
           <field name="module_name"/>
           <field name="function"/>
           <field name="version_ids"/>
+          <field name="fingerprint"/>
           <filter name="group_error" string="By error" context="{'group_by':'error_id'}"/>
           <filter string="Undeterministic" name="random_error" domain="[('random', '=', True)]"/>
           <filter string="Deterministic" name="random_error" domain="[('random', '=', False)]"/>

--- a/runbot/views/menus.xml
+++ b/runbot/views/menus.xml
@@ -37,7 +37,6 @@
     <menuitem name="Manage errors" id="runbot_menu_manage_errors" parent="runbot_menu_root" sequence="900"/>
     <menuitem name="Errors" id="runbot_menu_build_error_tree" parent="runbot_menu_manage_errors" sequence="5" action="open_view_build_error_tree"/>
     <menuitem name="Errors contents" id="runbot_menu_build_error_content_tree" parent="runbot_menu_manage_errors" sequence="10" action="open_view_build_error_content_tree"/>
-    <menuitem name="Error Logs" id="runbot_menu_error_contents" parent="runbot_menu_manage_errors" sequence="20" action="open_view_error_log_tree"/>
 
     <menuitem name="Teams" id="runbot_menu_teams" parent="runbot_menu_root" sequence="1000"/>
     <menuitem name="Teams" id="runbot_menu_team_tree" parent="runbot_menu_teams" sequence="30" action="open_view_runbot_team"/>


### PR DESCRIPTION
1. [IMP] runbot: add a message when a build error is merged
    When digging into deactivated build errors, one cannot easily find why
    an error was deactivated and to which one it was merged.
2. [FIX] runbot: bind the link error content action to the right model
3. [IMP] runbot: add possibility to search errors for fingerprints
4. [IMP] runbot: find duplicate error contents
5. [IMP] runbot: reorganize build errors menus
6. [FIX] runbot: refactor error content merge
7. [IMP] runbot: rename _merge method into _relink on error_content
8. [IMP] runbot: add a deduplicate server action
9. [IMP] runbot: add responsible in error list view

