### PR TITLE
[IMP] runbot: get docker metadata after build

### DIFF
--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -354,7 +354,11 @@ class Dockerfile(models.Model):
             # identifier changed
             if image_id != previous_result.identifier:
                 should_save_result = True
-            if previous_result.output != docker_build_result_values['output']:  # to discuss
+            def clean_output(output):
+                if not output:
+                    return ''
+                return '\n'.join([line for line in output.split('\n') if not line.startswith('Downloading')])
+            if clean_output(previous_result.output) != clean_output(docker_build_result_values['output']):  # to discuss
                 should_save_result = True
             if previous_result.content != docker_build_result_values['content']:  # docker image changed
                 should_save_result = True

--- a/runbot/models/ir_logging.py
+++ b/runbot/models/ir_logging.py
@@ -61,8 +61,11 @@ class IrLogging(models.Model):
             if ir_logging.level in ('ERROR', 'CRITICAL', 'WARNING') and ir_logging.type == 'server':
                 fingerprints[self.env['runbot.build.error.content']._digest(cleaning_regexes._r_sub(ir_logging.message))].append(ir_logging)
         for build_error_content in self.env['runbot.build.error.content'].search([('fingerprint', 'in', list(fingerprints.keys()))]).sorted(lambda ec: not ec.error_id.active):
-            for ir_logging in fingerprints[build_error_content.fingerprint]:
+            ir_logs = fingerprints[build_error_content.fingerprint]
+            for ir_logging in ir_logs:
                 ir_logging.error_content_id = build_error_content.id
+            if ir_logs:
+                fingerprints.pop(build_error_content.fingerprint)
 
     def _prepare_create_values(self, vals_list):
         # keep the given create date

--- a/runbot/static/src/js/fields/fields.css
+++ b/runbot/static/src/js/fields/fields.css
@@ -1,4 +1,4 @@
 .o_field_widget.o_field_runbotjsonb {
     width: 100%;
     white-space: pre-wrap;
-  }
+}

--- a/runbot/static/src/js/fields/fields.css
+++ b/runbot/static/src/js/fields/fields.css
@@ -1,0 +1,4 @@
+.o_field_widget.o_field_runbotjsonb {
+    width: 100%;
+    white-space: pre-wrap;
+  }

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -187,6 +187,9 @@
               <page string="Content">
                 <field name="content"/>
               </page>
+              <page string="Metadata">
+                <field name="metadata"/>
+              </page>
             </notebook>
           </sheet>
         </form>


### PR DESCRIPTION
The docker metadata are currently computed only on **some** images during the nightly.

This pr aims to get metadata after each docker image build in order to be able to rely on them when needed, having metadata on **all** images **immediately**.