### PR TITLE
[FIX] runbot: remove dead code

### DIFF
--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -308,29 +308,6 @@
                     <span class="log_message" t-else="">
                       <t t-if="'\n' not in l.message" t-esc="l.message"/>
                       <pre t-if="'\n' in l.message" style="margin:0;padding:0; border: none;"><t t-esc="l.message"/></pre>
-                      <t t-if="l.type == 'subbuild' and nb_subbuild &lt;= 20 and build.local_result != 'ok' and subbuild.sudo().error_log_ids">
-                        <a class="show" data-bs-toggle="collapse" t-attf-data-bs-target="#subbuild-{{subbuild.id}}">
-                          <i class="fa"/>
-                        </a>
-                        <div t-attf-id="subbuild-{{subbuild.id}}" class="collapse in">
-                          <table class="table table-condensed" style="margin-bottom:0;">
-                            <t t-foreach="subbuild.sudo().error_log_ids" t-as="sl">
-                              <tr>
-                                <td t-att-class="dict(CRITICAL='danger', ERROR='danger', WARNING='warning', OK='success', SEPARATOR='separator').get(sl.level)">
-                                  <t t-if="sl.type == 'server'">
-                                    <!--t-attf-href="https://{{repo.base_url}}/blob/{{build['name']}}/{{sl.path}}#L{{sl.line}}"-->
-                                    <a t-att-title="sl.func"><t t-esc="sl.name"/>:<t t-esc="sl.line"/></a>
-                                  </t>
-                                  <t t-if="'\n' not in sl.message" t-esc="sl.message"/>
-                                  <pre t-if="'\n' in sl.message" style="margin:0;padding:0; border: none;">
-                                    <t t-esc="sl.message"/>
-                                  </pre>
-                                </td>
-                              </tr>
-                            </t>
-                          </table>
-                        </div>
-                      </t>
                     </span>
                   </td>
                   <td t-attf-class="bg-{{message_class.strip() or logclass}}-subtle">


### PR DESCRIPTION
The template part was not reached only in certain cases and regardless the empty collapse toggle has not been visible for a while.. As handling subbuild error logs adds unnecessary load when rendering the page anyways (most people will not display the subbuild errors regardless if the collapse is showing or not), we decided to remove it completely.