### PR TITLE
[FIX] runbot: fix bundle without batch display

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -59,6 +59,8 @@ class Batch(models.Model):
 
     def _get_global_result(self):
         """Returns the worst result from the related builds and logs"""
+        if not self:
+            return 'ok'
         self.ensure_one()
         batch_result = 'warn' if any(log.level != 'INFO' for log in self.log_ids) else 'ok'
         if self.state == 'skipped':


### PR DESCRIPTION
In some case, when creating a bundle from the backend, it is possible that the bundle has no batch at all, making _get_global_result() fail.