### PR TITLE
[IMP] runbot: add a widget for pull requests url's

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -51,7 +51,7 @@ class Branch(models.Model):
     def _search_dname(self, operator, value):
         # Match format (owner?, repo, branch)
         owner = repo = branch = None
-        if (m := re.match(r'(?:([\w-]+)/)?([\w-]+):([\w\.-]+)', value)):
+        if (m := re.match(r'(?:([\w-]+)/)?([\w-]+)[:#]([\w\.-]+)', value)):
             owner, repo, branch = m.groups()
         # Match PR url format
         if (m := re.search(r'/([\w-]+)/([\w-]+)/pull/(\d+)', value)):

--- a/runbot/static/src/js/fields/fields.js
+++ b/runbot/static/src/js/fields/fields.js
@@ -14,6 +14,7 @@ import { useRef, xml, Component } from "@odoo/owl";
 import { useAutoresize } from "@web/core/utils/autoresize";
 import { getFormattedValue } from "@web/views/utils";
 
+import { UrlField } from "@web/views/fields/url/url_field";
 
 function stringify(obj) {
     return JSON.stringify(obj, null, '\t')
@@ -134,6 +135,29 @@ registry.category("fields").add("char_frontend_url", {
     supportedTypes: ["char"],
     component: FieldCharFrontendUrl,
 });
+
+
+// Pull Request URL Widget
+class PullRequestUrlField extends UrlField {
+    static template = xml`
+    <a class="o_field_widget o_form_uri" t-on-click.stop="" t-att-href="formattedHref" t-esc="props.record.data[props.name].replace('https://github.com/odoo','').replace('/pull','') || ''" target="_blank"/>
+    `;
+    static components = { UrlField }
+    setup() {
+        if (!this.props.readonly) {
+            throw new Error("This widget works only on readonly fields");
+        }
+    }
+}
+
+PullRequestUrlField.supportedTypes = ["char"];
+
+
+registry.category("fields").add("pull_request_url", {
+    supportedTypes: ["char"],
+    component: PullRequestUrlField,
+});
+
 
 //export class GithubTeamWidget extends CharField {
 

--- a/runbot/static/src/js/fields/fields.js
+++ b/runbot/static/src/js/fields/fields.js
@@ -138,15 +138,19 @@ registry.category("fields").add("char_frontend_url", {
 
 
 // Pull Request URL Widget
+const pullRequestRegex = /\/([a-zA-Z-_]+\/[a-zA-Z-_]+)\/pull\/(\d+)/;
 class PullRequestUrlField extends UrlField {
     static template = xml`
-    <a class="o_field_widget o_form_uri" t-on-click.stop="" t-att-href="formattedHref" t-esc="props.record.data[props.name].replace('https://github.com/odoo','').replace('/pull','') || ''" target="_blank"/>
+        <UrlField t-props="fieldProps"/>
     `;
     static components = { UrlField }
-    setup() {
-        if (!this.props.readonly) {
-            throw new Error("This widget works only on readonly fields");
+    get fieldProps() {
+        const props = {...this.props};
+        const parts = pullRequestRegex.exec(this.props.record.data[props.name])
+        if (parts) {
+            props.text = `${parts[1]}#${parts[2]}`;
         }
+        return props
     }
 }
 

--- a/runbot/tests/test_branch.py
+++ b/runbot/tests/test_branch.py
@@ -35,6 +35,10 @@ class TestBranch(RunbotCase):
             self.branch_server,
             self.Branch.search([('dname', '=', self.branch_server.dname)]),
         )
+        self.assertEqual(
+            self.branch_server,
+            self.Branch.search([('dname', '=', self.branch_server.dname.replace(':', '#'))]),
+        )
         # Basic pr
         self.assertEqual(
             self.dev_pr,

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -33,7 +33,7 @@
                   <field name="customer"/>
                   <field name="team_id"/>
                   <field name="fixing_pr_id"/>
-                  <field name="fixing_pr_url" widget="url"/>
+                  <field name="fixing_pr_url" widget="pull_request_url"/>
                   <field name="active"/>
                   <field name="test_tags" decoration-danger="True" readonly="1" groups="!runbot.group_runbot_admin"/>
                   <field name="test_tags" decoration-danger="True" groups="runbot.group_runbot_admin"/>
@@ -236,7 +236,7 @@
               <field name="tags_max_version_id" string="Tags Max" optional="hide"/>
               <field name="fixing_pr_id" optional="hide"/>
               <field name="fixing_pr_alive" optional="hide"/>
-              <field name="fixing_pr_url" widget="url" text="view PR" readonly="1" invisible="not fixing_pr_url"/>
+              <field name="fixing_pr_url" widget="pull_request_url" text="view PR" readonly="1" invisible="not fixing_pr_url"/>
           </list>
       </field>
   </record>


### PR DESCRIPTION
While it's useful to have a clickable link to the fixing pull request on the runbot error list, we cannot display the entire url as it takes too much space. So a static text `View PR` is used.

As this static text is of limited use, this commit adds a new widget that displays a shortened URL for the github pull request only showing the repo and the PR number.