### PR TITLE
[IMP] runbot: add config_data to trigger form

### DIFF
--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -17,6 +17,7 @@
                   <field name="category_id" required='1'/>
                   <field name="project_id" default=""/>
                   <field name="config_id"/>
+                  <field name="config_data" widget="runbotjsonb"/>
                   <field name="report_view_id"/>
                 </group>
                 <group>


### PR DESCRIPTION
Adds the missing field `config_data` to trigger's form view.