### PR TITLE
[IMP] runbot: fix display error in bundle toolbar

### DIFF
--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -418,3 +418,7 @@ body, .table {
 code {
 	white-space: pre-wrap;
 }
+
+.d-empty-none:empty {
+    display: none !important;
+}

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -40,9 +40,9 @@
                         <b t-out="bundle.name"/>
                       </a>
                     </div>
-                    <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-                      <div class="btn-group" role="group">
-                        <t t-foreach="categories" t-as="category">
+                    <div class="btn-toolbar gap-1" role="toolbar" aria-label="Toolbar with button groups">
+                      <!-- No space is necessary for d-empty-none to work properly. -->
+                      <div class="btn-group d-empty-none" role="group"><t t-foreach="categories" t-as="category">
                           <t t-if="active_category_id != category.id">
                             <t t-set="last_category_batch" t-value="bundle.with_context(category_id=category.id).last_done_batch"/>
                             <t t-if="last_category_batch">
@@ -50,12 +50,11 @@
                               <a t-else=""
                                 t-attf-title="View last {{category.name}} batch"
                                 t-attf-href="/runbot/batch/{{last_category_batch.id}}"
-                                t-attf-class="fa fa-{{category.icon}}"
+                                t-attf-class="btn btn-default btn-ssm fa fa-{{category.icon}}"
                                 />
                             </t>
                           </t>
-                        </t>
-                      </div>
+                        </t></div>
                       <div class="btn-group" role="group">
                         <t t-if="not bundle.sticky" t-call="runbot.branch_copy_button"/>
                         <t t-call="runbot.branch_github_menu"/>

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -375,7 +375,7 @@
         </template>
 
         <template id="runbot.branch_github_menu">
-          <button t-attf-class="btn btn-default btn-ssm" data-bs-toggle="dropdown" title="Github links" aria-label="Github links" aria-expanded="false">
+          <button t-attf-class="btn btn-default btn-ssm dropdown-toggle" data-bs-toggle="dropdown" title="Github links" aria-label="Github links" aria-expanded="false">
             <i t-attf-class="fa fa-github {{'text-primary' if any(branch_id.is_pr and branch_id.alive for branch_id in bundle.branch_ids) else 'text-secondary' if all(not branch_id.alive for branch_id in bundle.branch_ids) else ''}}"/>
             <span class="caret"/>
           </button>


### PR DESCRIPTION
- Add dropdown-toggle to the github tool button so that it doesn't appear as if a button should be following it.
- Add default btn classes to category icons, the button would otherwise be displayed as just an icon.
- Add a gap between the two toolbars.
- Add d-empty-none in case we have no category to display to remove the useless gap.