### PR TITLE
[FIX] runbot: replace target new with _blank

### DIFF
--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -13,7 +13,7 @@
                                 <a t-out="batch.bundle_id.name" t-attf-href="/runbot/bundle/{{batch.bundle_id.id}}"/>
                                 &amp;emsp;
                                 <a groups="runbot.group_runbot_advanced_user"
-                                    t-attf-href="/odoo/runbot.batch/{{batch.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" class="btn btn-default btn-sm" target="new" title="View Batch in Backend">
+                                    t-attf-href="/odoo/runbot.batch/{{batch.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" class="btn btn-default btn-sm" target="_blank" title="View Batch in Backend">
                                           <i class="fa fa-list"/>
                                 </a>
                             </td>

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -12,7 +12,7 @@
                   <div class="btn-group" role="group">
                     <a t-att-href="branch.branch_url" class="btn btn-sm text-start" title="View Branch on Github"><i class="fa fa-github"/></a>
                     <a groups="runbot.group_runbot_admin" class="btn btn-sm fa fa-list text-start"
-                      t-attf-href="/odoo/runbot.branch/{{branch.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="new" title="View Branch in Backend"/>
+                      t-attf-href="/odoo/runbot.branch/{{branch.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank" title="View Branch in Backend"/>
                   </div>
                 </h3>
               </div>

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -327,10 +327,10 @@
                     <td/><td/><td/>
                     <td t-attf-class="bg-{{'info' if error.active else 'success'}}-subtle" colspan="2">
                       This error is already <em t-attf-title="{{'Was detected by runbot in nightly builds.' if error.active else 'Either the error is not properly fixed or the branch does not contain the fix.'}}"><t t-out="'known' if error.active else 'fixed'"/></em>.
-                      <!--a groups="runbot.group_user" t-attf-href="/web#id={{error_content.id}}&amp;view_type=form&amp;model=runbot.build.error.content&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="new">
+                      <!--a groups="runbot.group_user" t-attf-href="/web#id={{error_content.id}}&amp;view_type=form&amp;model=runbot.build.error.content&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="_blank">
                         <i t-attf-class="fa fa-search"/>
                       </a-->
-                      <a groups="runbot.group_user" t-attf-href="/web#id={{error.id}}&amp;view_type=form&amp;model=runbot.build.error&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="new">
+                      <a groups="runbot.group_user" t-attf-href="/web#id={{error.id}}&amp;view_type=form&amp;model=runbot.build.error&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="_blank">
                         <i t-attf-class="fa fa-list"/>
                       </a>
                       <span groups="runbot.group_runbot_admin" t-if="error.responsible or error.responsible.id == uid">(<i t-out="error.responsible.name"/>)</span>

--- a/runbot/templates/build_error.xml
+++ b/runbot/templates/build_error.xml
@@ -36,7 +36,7 @@
                 <div class="col">
                   <a t-att-href="build_error.last_seen_build_id.build_url" t-attf-title="View last affected build ({{build_error.last_seen_build_id.id}})"><i class="fa fa-external-link"/></a>
                   <a groups="base.group_user"
-                    t-attf-href="/odoo/runbot.build.error/{{build_error.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="new" title="View in Backend">
+                    t-attf-href="/odoo/runbot.build.error/{{build_error.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank" title="View in Backend">
                     <span class="badge text-bg-info" t-out="build_error.build_count" t-attf-title="This error was seen {{build_error.build_count}} View in backend"/>
                   </a>
                   <span groups="!base.group_user" class="badge text-bg-info" t-out="build_error.build_count" t-attf-title="This error was seen {{build_error.build_count}}"/>
@@ -113,7 +113,7 @@
               <div class="col-lg-12 text-center mb16">
                 <h2>Team <t t-out="team.name.capitalize()"/>
                   <a groups="base.group_user"
-                    t-attf-href="/odoo/runbot.team/{{team.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="new" title="View in Backend">
+                    t-attf-href="/odoo/runbot.team/{{team.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank" title="View in Backend">
                     <i class="fa fa-list"/>
                   </a>
                 </h2>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -12,7 +12,7 @@
                                     <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
                                     <div class="btn-group" role="group">
                                         <a groups="runbot.group_runbot_advanced_user"
-                                            t-attf-href="/odoo/runbot.bundle/{{bundle.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" class="btn btn-default" target="new" title="View in Backend">
+                                            t-attf-href="/odoo/runbot.bundle/{{bundle.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" class="btn btn-default" target="_blank" title="View in Backend">
                                           <i class="fa fa-list"/>
                                         </a>
                                         <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Force A New Batch">
@@ -69,7 +69,7 @@
                                                             <div class="btn-group btn-group-ssm" role="group">
                                                                 <a t-att-href="branch.branch_url" class="btn btn-default text-start" title="View Branch on Github"><i class="fa fa-github"/></a>
                                                                 <a groups="runbot.group_runbot_admin" class="btn btn-default fa fa-list text-start"
-                                                                    t-attf-href="/odoo/runbot.branch/{{branch.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="new" title="View Branch in Backend"/>
+                                                                    t-attf-href="/odoo/runbot.branch/{{branch.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank" title="View Branch in Backend"/>
                                                                 <a href="#" t-out="branch.remote_id.short_name" class="btn btn-default disabled text-start"/>
                                                                 <a t-attf-href="/runbot/branch/{{branch.id}}" class="btn btn-default text-start" title="View Branch Details"><span t-att-class="'' if branch.alive else 'line-through'" t-out="branch.name"/> <i t-if="not branch.alive" title="deleted/closed" class="fa fa-ban text-danger"/></a>
                                                                 <t t-if="not any (b.is_pr and b.alive for b in group[1]) and not branch.is_pr">

--- a/runbot/templates/commit.xml
+++ b/runbot/templates/commit.xml
@@ -33,7 +33,7 @@
                   <div class="btn-group" role="group">
                     <a t-att-href="'' if not reflogs else 'https://%s/commit/%s' % (reflogs[0].branch_id.remote_id.base_url, commit.name)" class="btn btn-sm text-start" title="View Commit on Github"><i class="fa fa-github"/></a>
                     <a groups="runbot.group_runbot_admin" class="btn btn-sm fa fa-list text-start"
-                      t-attf-href="/odoo/runbot.commit/{{commit.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="new" title="View Commit in Backend"/>
+                      t-attf-href="/odoo/runbot.commit/{{commit.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank" title="View Commit in Backend"/>
                   </div>
                 </td>
               </tr>

--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -196,7 +196,7 @@
               <t t-set="failed_builds" t-value="tile.build_ids.filtered(lambda b: b.top_parent.slot_ids.batch_id.bundle_id == bundle)"/>
               <h4 class="card-title" t-if="failed_builds" t-out="bundle.name"/>
               <p t-foreach="failed_builds" t-as="build" class="my-0">
-                  <a class="text-danger" t-attf-href="/runbot/build/{{build.id}}" target="new">
+                  <a class="text-danger" t-attf-href="/runbot/build/{{build.id}}" target="_blank">
                     <t t-out="build.description or build.id"/>
                   </a>
               </p>

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -366,7 +366,7 @@
                         Find similar builds
                     </a>
                     <a class="dropdown-item"
-                        t-attf-href="/odoo/runbot.build/{{bu['id']}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="new">
+                        t-attf-href="/odoo/runbot.build/{{bu['id']}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank">
                         <i class="fa fa-list"/>
                         View in backend
                     </a>


### PR DESCRIPTION
`target="new"` had the very confusing behavior of updating the same tab within the same browser context (tab).
The commit replaces all `target="new"` occurences with `target="_blank"` within the runbot templates.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target