### PR TITLE
[FIX] runbot: fix frontend team dashboards again

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -516,7 +516,7 @@ class Runbot(Controller):
         qctx = {
             'team': team,
             'teams': teams,
-            'build_assignment_ids': request.env['runbot.build.error'].search(domain, order=order),
+            'assignment_ids': request.env['runbot.build.error'].search(domain, order=order),
             'hide_empty': bool(hide_empty),
             'searchbar_sortings': searchbar_sortings,
             'sortby': sortby,


### PR DESCRIPTION
The previous fix in c9e8e1360 was not enough, while preventing a crash of the view, the view was empty.