### PR TITLE
[IMP] runbot: add support for attributes on md url

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -212,8 +212,15 @@ def pseudo_markdown(text):
     text = re_icon.sub('<i class="fa fa-\\g<1>"></i>', text)
 
     # links
-    re_links = re.compile(rf'{escape}\[(.+?){escape}\]{escape}\(((http|/).+?{escape})\)')
-    text = re_links.sub('<a href="\\g<2>">\\g<1></a>', text)
+    re_links = re.compile(
+        rf'{escape}\[(?P<name>.+?){escape}\]{escape}\((?P<url>(?:http|\/).+?{escape})(?: (?P<target>\w+))?\)'
+    )
+    def compile_url(match):
+        groups = match.groupdict()
+        target = groups.get('target')
+        target_tag = f' target="{target}"' if target else ''
+        return f'<a href="{groups["url"]}"{target_tag}>{groups["name"]}</a>'
+    text = re_links.sub(compile_url, text)
 
     def code_replace(match):
         return f'<code>{codes[int(match.group(1))]}</code>'

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_commit
 from . import test_upgrade
 from . import test_dockerfile
 from . import test_host
+from . import test_utils

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -209,7 +209,6 @@ class TestCodeowner(TestBuildConfigStepCommon):
         ])
         self.config_step._run_codeowner(self.parent_build)
         logs = self.parent_build.log_ids
-        print
         self.assertEqual(
             logs[2]._markdown(),
             'Adding team_01, team_py to reviewers for file <a href="https://False/blob/dfdfcfcf/core/addons/module1/some/__init__.py">server/core/addons/module1/some/__init__.py</a>',

--- a/runbot/tests/test_utils.py
+++ b/runbot/tests/test_utils.py
@@ -1,0 +1,49 @@
+from odoo.tests.common import TransactionCase, Like
+
+from odoo.addons.runbot.common import pseudo_markdown
+
+
+class TestUtils(TransactionCase):
+
+    def test_md_formatting(self):
+        self.assertEqual(
+            pseudo_markdown(
+                "**strong** ~~delete~~ __italic__ \n"
+            ),
+            "<strong>strong</strong> "
+            "<del>delete</del> "
+            "<ins>italic</ins> "
+            "<br/>\n"
+        )
+
+    def test_md_icons(self):
+        self.assertEqual(
+            pseudo_markdown(
+                "@icon-star"
+            ),
+            '<i class="fa fa-star"></i>'
+        )
+
+    def test_md_urls(self):
+        # Basic
+        self.assertEqual(
+            pseudo_markdown(
+                "[name](https://runbot.odoo.com)"
+            ),
+            '<a href="https://runbot.odoo.com">name</a>'
+        )
+        # Test with target
+        self.assertEqual(
+            pseudo_markdown(
+                "[name](https://runbot.odoo.com fp)"
+            ),
+            '<a href="https://runbot.odoo.com" target="fp">name</a>'
+        )
+
+        # Everything at once
+        self.assertEqual(
+            pseudo_markdown(
+                "[@icon-star](https://runbot.odoo.com _blank)"
+            ),
+            '<a href="https://runbot.odoo.com" target="_blank"><i class="fa fa-star"></i></a>'
+        )


### PR DESCRIPTION
Adds support for attributes on our markdown implementation, mainly to add support for target="_blank" on urls.
This can be used to change the behavior of links when we want to differentiate between navigation and information.