### PR TITLE
[REF] runbot: remove deprecated calls

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -677,7 +677,7 @@ class BuildErrorContent(models.Model):
     def _get_duplicates(self):
         """ returns a list of lists of duplicates"""
         domain = [('id', 'in', self.ids)] if self else []
-        return [r['id_arr'] for r in self.env['runbot.build.error.content'].read_group(domain, ['id_count:count(id)', 'id_arr:array_agg(id)', 'fingerprint'], ['fingerprint']) if r['id_count'] >1]
+        return [r[1] for r in self._read_group(domain, ('fingerprint'), ('id:array_agg'), [('id:count', '>', 1)])]
 
     def _qualify(self):
         qualify_regexes = self.env['runbot.error.qualify.regex'].search([])

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -50,18 +50,17 @@ class Host(models.Model):
     docker_registry_url = fields.Char('Registry Url', help="Override global registry URL for this host.")
 
     def _compute_nb(self):
-        groups = self.env['runbot.build'].read_group(
+        # Array of tuple (host, state, count)
+        groups = self.env['runbot.build']._read_group(
             [('host', 'in', self.mapped('name')), ('local_state', 'in', ('testing', 'running'))],
             ['host', 'local_state'],
-            ['host', 'local_state'],
+            ['id:count'],
             lazy=False,
         )
-        count_by_host_state = {host.name: {} for host in self}
-        for group in groups:
-            count_by_host_state[group['host']][group['local_state']] = group['__count']
+        count_by_host_state = dict(((host, state), count) for host, state, count in groups)
         for host in self:
-            host.nb_testing = count_by_host_state[host.name].get('testing', 0)
-            host.nb_running = count_by_host_state[host.name].get('running', 0)
+            host.nb_testing = count_by_host_state.get((host.name, 'testing'), 0)
+            host.nb_running = count_by_host_state.get((host.name, 'running'), 0)
 
     def _compute_build_ids(self):
         for host in self:


### PR DESCRIPTION
Use `_read_group` instead of `read_group` as it is deprecated and will be removed between 18 and 19.