### PR TITLE
[REF] runbot: replace deprecated _cr access

### DIFF
--- a/runbot/models/ir_logging.py
+++ b/runbot/models/ir_logging.py
@@ -168,8 +168,8 @@ class RunbotErrorLog(models.Model):
 
     def init(self):
         """ Create an SQL view for ir.logging """
-        tools.drop_view_if_exists(self._cr, 'runbot_error_log')
-        self._cr.execute(""" CREATE VIEW runbot_error_log AS (
+        tools.drop_view_if_exists(self.env.cr, 'runbot_error_log')
+        self.env.cr.execute(""" CREATE VIEW runbot_error_log AS (
             SELECT
                 l.id  AS id,
                 l.name  AS name,

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -250,12 +250,12 @@ class Remote(models.Model):
         remote = super().create(values_list)
         if not remote.repo_id.main_remote_id:
             remote.repo_id.main_remote_id = remote
-        remote._cr.postcommit.add(remote.repo_id._update_git_config)
+        remote.env.cr.postcommit.add(remote.repo_id._update_git_config)
         return remote
 
     def write(self, values):
         res = super().write(values)
-        self._cr.postcommit.add(self.repo_id._update_git_config)
+        self.env.cr.postcommit.add(self.repo_id._update_git_config)
         return res
 
     def _github(self, url, payload=None, ignore_errors=False, nb_tries=2, recursive=False, session=None):

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -105,7 +105,7 @@ All substitutions are tentatively applied sequentially to the input.
     def _auto_init(self):
         res = super()._auto_init()
         tools.create_unique_index(
-            self._cr, 'runbot_merge_unique_repo', self._table, ['name'])
+            self.env.cr, 'runbot_merge_unique_repo', self._table, ['name'])
         return res
 
     def _load_pr(
@@ -297,7 +297,7 @@ class Branch(models.Model):
     def _auto_init(self):
         res = super()._auto_init()
         tools.create_unique_index(
-            self._cr, 'runbot_merge_unique_branch_per_repo',
+            self.env.cr, 'runbot_merge_unique_branch_per_repo',
             self._table, ['name', 'project_id'])
         return res
 
@@ -1335,11 +1335,11 @@ For your own safety I've ignored *everything in your entire comment*.
 
         super()._auto_init()
         # incorrect index: unique(number, target, repository).
-        tools.drop_index(self._cr, 'runbot_merge_unique_pr_per_target', self._table)
+        tools.drop_index(self.env.cr, 'runbot_merge_unique_pr_per_target', self._table)
         # correct index:
         tools.create_unique_index(
-            self._cr, 'runbot_merge_unique_pr_per_repo', self._table, ['repository', 'number'])
-        self._cr.execute("CREATE INDEX IF NOT EXISTS runbot_merge_pr_head "
+            self.env.cr, 'runbot_merge_unique_pr_per_repo', self._table, ['repository', 'number'])
+        self.env.cr.execute("CREATE INDEX IF NOT EXISTS runbot_merge_pr_head "
                          "ON runbot_merge_pull_requests "
                          "USING hash (head)")
 
@@ -2037,12 +2037,12 @@ class Commit(models.Model):
 
     def _auto_init(self):
         res = super()._auto_init()
-        self._cr.execute("""
+        self.env.cr.execute("""
             CREATE INDEX IF NOT EXISTS runbot_merge_unique_statuses
             ON runbot_merge_commit
             USING hash (sha)
         """)
-        self._cr.execute("""
+        self.env.cr.execute("""
             CREATE INDEX IF NOT EXISTS runbot_merge_to_process
             ON runbot_merge_commit ((1)) WHERE to_check
         """)


### PR DESCRIPTION
`record._cr` is being deprecated in odoo/odoo#193636 this commit replaces the old `._cr` with `env.cr`.