### PR TITLE
[IMP] runbot: remove auto tag if fixing match

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -209,8 +209,11 @@ class BuildError(models.Model):
     @api.model
     def _test_tags_list(self, build_id=False):
         version = build_id.params_id.version_id.number if build_id else False
+        branches = build_id.create_batch_id.bundle_id.branch_ids if build_id else self.env['runbot.branch']
 
         def filter_tags(e):
+            if e.fixing_pr_id in branches:
+                return False
             if version:
                 min_v = e.tags_min_version_id.number or ''
                 max_v = e.tags_max_version_id.number or '~'

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -500,6 +500,35 @@ class TestBuildError(RunbotCase):
         self.assertEqual(sorted(['-every', '-where', '-tag_17_up_to_master', '-tag_only_17.1']), sorted(self.BuildError._disabling_tags(build_saas_171)))
         self.assertEqual(sorted(['-every', '-where', '-tag_17_up_to_master']), sorted(self.BuildError._disabling_tags(build_master)))
 
+    def test_build_error_test_tags_fixing_pr(self):
+        fix_commit = self.env['runbot.commit'].create({
+            'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
+            'repo_id': self.repo_server.id
+        })
+        branch_pr = self.Branch.create({
+            'name': '1337',
+            'remote_id': self.remote_server.id,
+            'is_pr': True,
+            'head': fix_commit.id,
+        })
+        commit_link_id = self.env['runbot.commit.link'].create({
+            'commit_id': fix_commit.id,
+            'match_type': 'head',
+            'branch_id': branch_pr.id,
+        })
+        batch = self.env['runbot.batch'].create({
+            'bundle_id': branch_pr.bundle_id.id,
+        })
+        build_fixing = self.create_test_build({'params_id': self.create_params({'create_batch_id': batch.id, 'commit_link_ids': commit_link_id}).id})
+        build_random = self.create_test_build({})
+        self.BuildError.create({
+            'content': 'foo',
+            'test_tags': 'bar',
+            'fixing_pr_id': branch_pr.id,
+        })
+        self.assertEqual([], self.BuildError._disabling_tags(build_fixing))
+        self.assertEqual(['-bar'], self.BuildError._disabling_tags(build_random))
+
     def test_build_error_team_wildcards(self):
         website_team = self.RunbotTeam.create({
             'name': 'website_test',


### PR DESCRIPTION
Removes auto tags from a build if the build's branches match the build error's fixing branch.