### PR TITLE
[FIX] runbot: fix parse log action window

### DIFF
--- a/runbot/data/error_link.xml
+++ b/runbot/data/error_link.xml
@@ -1,6 +1,6 @@
 <odoo>
     <record model="ir.actions.server" id="action_link_build_errors">
-        <field name="name">Link build errors</field>
+        <field name="name">Merge build errors</field>
         <field name="model_id" ref="runbot.model_runbot_build_error" />
         <field name="binding_model_id" ref="runbot.model_runbot_build_error" />
         <field name="type">ir.actions.server</field>
@@ -39,7 +39,7 @@
             records.action_assign()
         </field>
     </record>
-        <record model="ir.actions.server" id="action_deduplicate">
+    <record model="ir.actions.server" id="action_deduplicate">
         <field name="name">Deduplicate Error Contents</field>
         <field name="model_id" ref="runbot.model_runbot_build_error_content" />
         <field name="binding_model_id" ref="runbot.model_runbot_build_error_content" />
@@ -47,6 +47,15 @@
         <field name="state">code</field>
         <field name="code">
             records.action_deduplicate()
+        </field>
+    </record>
+    <record model="ir.actions.server" id="action_view_build_errors">
+        <field name="name">View build errors</field>
+        <field name="model_id" ref="runbot.model_runbot_build"/>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = records.action_view_build_errors()
         </field>
     </record>
 </odoo>

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1268,3 +1268,15 @@ class BuildResult(models.Model):
 
     def _parse_config(self):
         return set(findall(self._server("tools/config.py"), r'--[\w-]+', ))
+
+    def action_view_build_errors(self):
+        errors = self.env['runbot.build.error'].browse()
+        for record in self:
+            errors |= record.error_log_ids.error_content_id.error_id
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "runbot.build.error",
+            "domain": [('id', 'in', errors.ids)],
+            "name": "Build errors",
+            "view_mode": "list,form"
+        }

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -313,7 +313,7 @@ class BuildError(models.Model):
         if build_error_contents:
             window_action = {
                 "type": "ir.actions.act_window",
-                "res_model": "runbot.build.error",
+                "res_model": "runbot.build.error.content",
                 "views": [[False, "list"]],
                 "domain": [('id', 'in', build_error_contents.ids)]
             }


### PR DESCRIPTION
- Fix the model on parse_logs action window.
- Add a server action on build to open its errors
- Fix a bad indentation