### PR TITLE
[IMP] runbot: custom triger without branch changes

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -226,13 +226,13 @@ class Runbot(Controller):
         '/runbot/bundle/<model("runbot.bundle"):bundle>/force',
         '/runbot/bundle/<model("runbot.bundle"):bundle>/force/<int:auto_rebase>',
     ], type='http', auth="user", methods=['GET', 'POST'], csrf=False)
-    def force_bundle(self, bundle, auto_rebase=False, **_post):
+    def force_bundle(self, bundle, auto_rebase=False, use_base_commits=False,**_post):
         if not request.env.user.has_group('runbot.group_runbot_advanced_user') and ':' not in bundle.name:
             raise Forbidden("Only users with a specific group can do that. Please contact runbot administrators")
         _logger.info('user %s forcing bundle %s', request.env.user.name, bundle.name)  # user must be able to read bundle
         batch = bundle.sudo()._force()
         batch._log('Batch forced by %s', request.env.user.name)
-        batch._prepare(auto_rebase)
+        batch._prepare(auto_rebase=bool(auto_rebase), use_base_commits=bool(use_base_commits))
         batch._process()
         return werkzeug.utils.redirect('/runbot/batch/%s' % batch.id)
 

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -358,6 +358,7 @@ class Batch(models.Model):
             for commit_link in self.commit_link_ids:
                 commit_link.commit_id = commit_link.commit_id._rebase_on(commit_link.base_commit_id)
         commit_link_by_repos = {commit_link.commit_id.repo_id.id: commit_link for commit_link in self.commit_link_ids}
+        base_commit_link_by_repos = {commit_link.commit_id.repo_id.id: commit_link for commit_link in self.base_reference_batch_id.commit_link_ids}
         version_id = self.bundle_id.version_id.id
         project_id = self.bundle_id.project_id.id
         trigger_customs = {}
@@ -373,6 +374,10 @@ class Batch(models.Model):
             config = trigger_custom.config_id or trigger.config_id
             extra_params = trigger_custom.extra_params or ''
             config_data = dict(trigger.config_data or {}) | dict(trigger_custom.config_data or {})
+            trigger_commit_link_by_repos = commit_link_by_repos
+            if trigger_custom.use_base_commits and self.base_reference_batch_id:
+                trigger_commit_link_by_repos = base_commit_link_by_repos
+            commits_links = [trigger_commit_link_by_repos[repo.id].id for repo in trigger_repos]
             params_value = {
                 'version_id':  version_id,
                 'extra_params': extra_params,
@@ -380,7 +385,7 @@ class Batch(models.Model):
                 'project_id': project_id,
                 'trigger_id': trigger.id,  # for future reference and access rights
                 'config_data': config_data,
-                'commit_link_ids': [(6, 0, [commit_link_by_repos[repo.id].id for repo in trigger_repos])],
+                'commit_link_ids': [(6, 0, commits_links)],
                 'modules': bundle.modules,
                 'dockerfile_id': dockerfile_id,
                 'create_batch_id': self.id,

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -174,8 +174,10 @@ class Batch(models.Model):
             build._github_status()
         return link_type, build
 
-    def _prepare(self, auto_rebase=False):
+    def _prepare(self, auto_rebase=False, use_base_commits=False):
         _logger.info('Preparing batch %s', self.id)
+        if use_base_commits:
+            self._warning('This batch will use base commits instead of bundle commits')
         if not self.bundle_id.base_id:
             # in some case the base can be detected lately. If a bundle has no base, recompute the base before preparing
             self.bundle_id._compute_base_id()
@@ -359,6 +361,8 @@ class Batch(models.Model):
                 commit_link.commit_id = commit_link.commit_id._rebase_on(commit_link.base_commit_id)
         commit_link_by_repos = {commit_link.commit_id.repo_id.id: commit_link for commit_link in self.commit_link_ids}
         base_commit_link_by_repos = {commit_link.commit_id.repo_id.id: commit_link for commit_link in self.base_reference_batch_id.commit_link_ids}
+        if use_base_commits:
+            commit_link_by_repos = base_commit_link_by_repos
         version_id = self.bundle_id.version_id.id
         project_id = self.bundle_id.project_id.id
         trigger_customs = {}
@@ -376,6 +380,7 @@ class Batch(models.Model):
             config_data = dict(trigger.config_data or {}) | dict(trigger_custom.config_data or {})
             trigger_commit_link_by_repos = commit_link_by_repos
             if trigger_custom.use_base_commits and self.base_reference_batch_id:
+                self._warning(f'This batch will use base commits instead of bundle commits for trigger {trigger.name}')
                 trigger_commit_link_by_repos = base_commit_link_by_repos
             commits_links = [trigger_commit_link_by_repos[repo.id].id for repo in trigger_repos]
             params_value = {

--- a/runbot/models/custom_trigger.py
+++ b/runbot/models/custom_trigger.py
@@ -9,6 +9,7 @@ class BundleTriggerCustomization(models.Model):
 
     trigger_id = fields.Many2one('runbot.trigger')
     start_mode = fields.Selection([('disabled', 'Disabled'), ('auto', 'Auto'), ('force', 'Force')], required=True, default='auto')
+    use_base_commits = fields.Boolean("Use base commits",  help="Allow to test a trigger without the branch changes", default=False)
     bundle_id = fields.Many2one('runbot.bundle')
     config_id = fields.Many2one('runbot.build.config')
     extra_params = fields.Char("Custom parameters")

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -16,10 +16,13 @@
                                           <i class="fa fa-list"/>
                                         </a>
                                         <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Force A New Batch">
-                                            <i class="fa fa-refresh"/>
+                                            <i class="fa fa-play"/>
                                         </a>
-                                        <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force/1" title="Force A New Batch with automatic rebase">
+                                        <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" title="Force A New Batch with automatic rebase">
                                             <i class="fa fa-fast-forward"/>
+                                        </a>
+                                        <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force A New Batch using base commits">
+                                            <i class="fa fa-fast-backward"/>
                                         </a>
                                         <t t-call="runbot.branch_copy_button">
                                             <t t-set="btn_size" t-value="'btn'"/>

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -77,6 +77,7 @@
                             <field name="trigger_custom_ids" nolabel="1">
                                 <list editable="bottom">
                                     <field name="start_mode"/>
+                                    <field name="use_base_commits"/>
                                     <field name="trigger_id" domain="[('project_id', '=', parent.project_id)]"/>
                                     <field name="config_id"/>
                                     <field name="extra_params"/>


### PR DESCRIPTION
This allows to configure a custom trigger to use the base commits. This can be useful to test a config on a branch that has some changes to ensure it works properly.