### PR TITLE
[IMP] runbot: add host filter on load_info

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -629,10 +629,14 @@ class Runbot(Controller):
         return request.render("runbot.modules_stats", context)
 
     @route(['/runbot/load_info'], type='http', auth="user", website=True, sitemap=False)
-    def load_infos(self, **post):
+    def load_infos(self, host: str | None = None, **post):
         build_by_bundle = {}
 
-        for build in request.env['runbot.build'].search([('local_state', 'in', ('pending', 'testing'))], order='id'):
+        domain = [('local_state', 'in', ('pending', 'testing'))]
+        if host:
+            domain.append(('host', '=', host))
+
+        for build in request.env['runbot.build'].search(domain, order='id'):
             build_by_bundle.setdefault(build.params_id.create_batch_id.bundle_id, []).append(build)
 
         build_by_bundle = list(build_by_bundle.items())

--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -87,11 +87,11 @@
                   <t t-if="host.nb_testing > host.nb_worker">
                     <t t-set="klass">danger</t>
                   </t>
-                  <span t-attf-class="badge text-bg-{{klass}}">
+                  <a t-attf-class="badge text-bg-{{klass}}" t-attf-href="/runbot/load_info?host={{host.name}}">
                     <span t-out="host.nb_testing"/>
                     /
                     <span t-out="host.nb_worker"/>
-                  </span>
+                  </a>
                   <t t-out="host.nb_running"/>
                   <t t-set="succes_time" t-value="int(datetime.datetime.now().timestamp() - host.last_success.timestamp())"/>
                   <t t-set="start_time" t-value="int(datetime.datetime.now().timestamp() - host.last_start_loop.timestamp())"/>


### PR DESCRIPTION
Makes it possible to filter on host on the load_info view. Monitoring was also adapted to have links to filtered load_info page.