### PR TITLE
[IMP] runbot: improve og data

### DIFF
--- a/runbot/models/__init__.py
+++ b/runbot/models/__init__.py
@@ -27,6 +27,7 @@ from . import team
 from . import upgrade
 from . import user
 from . import version
+from . import website
 
 # those imports have to be at the end otherwise the sql view cannot be initialised
 from . import build_stat

--- a/runbot/models/website.py
+++ b/runbot/models/website.py
@@ -1,0 +1,40 @@
+from odoo import models, fields, api
+from odoo.http import request
+from odoo.addons.web.controllers.utils import get_action_triples
+import re
+
+
+class Website(models.AbstractModel):
+    _inherit = "website.seo.metadata"
+
+    def get_website_meta(self):
+        # this is kind of hacky but should improve user experience when sharing runbot links
+        # right now, a backend link will lead to the login page creating a link preview of the login page.
+        # this override will hopefully remove the website image and try to improve the meta based on the record
+        # in the backend, if possible to extract
+        res = super().get_website_meta()
+        del res['opengraph_meta']['og:image']
+        del res['twitter_meta']
+        if request and request.params.get('redirect') and not request.params.get('login_success'):
+            redirect = request.params['redirect']
+            if redirect.startswith('/odoo/'):
+                try:
+                    actions = list(get_action_triples(self.env, redirect.split('?')[0].removeprefix('/odoo/')))
+                except ValueError:
+                    actions = None
+                if actions:
+                    _active_id, action, record_id = actions[-1]
+                    model = action.res_model
+                    record = self.env[model]
+                    if record_id and model.startswith('runbot.'):
+                        record = self.env[model].browse(record_id).exists()
+                        if record.sudo(False)._check_access('read'):
+                            record = self.env[model]
+                    title = f'{record._description}'
+                    if record:
+                        title = f'{record._description} | {record.display_name}'
+                        if 'description' in record._fields:
+                            res['opengraph_meta']['og:description'] = record.description
+                    res['opengraph_meta']['og:title'] = title
+                    res['opengraph_meta']['og:url'] = request.httprequest.url_root.strip('/') + redirect
+            return res

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -466,12 +466,14 @@
     <record id="open_view_build_error_tree" model="ir.actions.act_window">
       <field name="name">Errors</field>
       <field name="res_model">runbot.build.error</field>
+      <field name="path">error</field>
       <field name="view_mode">list,form</field>
       <field name="context">{'search_default_not_fixed_errors': True, 'active_test': False}</field>
     </record>
 
     <record id="open_view_build_error_content_tree" model="ir.actions.act_window">
         <field name="name">Build errors contents</field>
+        <field name="path">error_content</field>
         <field name="res_model">runbot.build.error.content</field>
         <field name="view_mode">list,form</field>
         <field name="context">{'search_default_not_fixed_errors': True, 'active_test': False}</field>


### PR DESCRIPTION
When adding an internal link in discord or other platform, a preview of the login page is given. This is not usefull nor elegant.

This commit proposes to remove the logo and give useful information instead