### PR TITLE
[IMP] runbot: reference slot instead of builds

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -6,7 +6,7 @@
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '5.8',
+    'version': '5.9',
     'application': True,
     'depends': ['base', 'base_automation', 'website'],
     'data': [

--- a/runbot/migrations/18.0.5.9/post-migration.py
+++ b/runbot/migrations/18.0.5.9/post-migration.py
@@ -1,0 +1,22 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # copy infor from ol build_reference_ids to slot_reference_ids
+    # old table is runbot_build_params_references
+    # new table is runbot_build_params_slot_references
+    cr.execute("""
+        ALTER TABLE runbot_build_params_slot_references DISABLE TRIGGER ALL;
+        INSERT INTO runbot_build_params_slot_references (runbot_build_params_id, runbot_batch_slot_id)
+            SELECT ref.runbot_build_params_id, slot.id
+            FROM runbot_build_params_references ref
+            JOIN LATERAL (
+                SELECT id
+                FROM runbot_batch_slot sl
+                WHERE sl.build_id = ref.runbot_build_id
+                LIMIT 1
+            ) slot(id) ON TRUE;
+        ALTER TABLE runbot_build_params_slot_references ENABLE TRIGGER ALL;
+    """)

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -397,7 +397,7 @@ class Batch(models.Model):
                 'used_custom_trigger': bool(trigger_custom),
             }
 
-            params_value['builds_reference_ids'] = trigger._reference_builds(self)
+            params_value['slot_reference_ids'] = [(4, s.id) for s in trigger._reference_slots(self)]
 
             params = self.env['runbot.build.params'].create(params_value)
 

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -69,7 +69,9 @@ class BuildParameters(models.Model):
     used_custom_trigger = fields.Boolean('Custom trigger was used to generate this build')
 
     build_ids = fields.One2many('runbot.build', 'params_id')
-    builds_reference_ids = fields.Many2many('runbot.build', relation='runbot_build_params_references', copy=True)
+    #builds_reference_ids = fields.Many2many('runbot.build', relation='runbot_build_params_references', copy=True)
+    builds_reference_ids = fields.Many2many('runbot.build', compute='_compute_builds_reference_ids')
+    slot_reference_ids = fields.Many2many('runbot.batch.slot', relation='runbot_build_params_slot_references', copy=True)
     modules = fields.Char('Modules')
 
     upgrade_to_build_id = fields.Many2one('runbot.build', index=True)  # use to define sources to use with upgrade script
@@ -96,7 +98,7 @@ class BuildParameters(models.Model):
                 'config_data': param.config_data.dict,
                 'modules': param.modules or '',
                 'commit_link_ids': sorted(param.commit_link_ids.commit_id.ids),
-                'builds_reference_ids': sorted(param.builds_reference_ids.ids),
+                'slot_reference_ids': sorted(param.slot_reference_ids.ids),
                 'upgrade_from_build_id': param.upgrade_from_build_id.id,
                 'upgrade_to_build_id': param.upgrade_to_build_id.id,
                 'dump_db': param.dump_db.id,
@@ -109,6 +111,10 @@ class BuildParameters(models.Model):
                 cleaned_vals['used_custom_trigger'] = True
 
             param.fingerprint = hashlib.sha256(str(cleaned_vals).encode('utf8')).hexdigest()
+
+    def _compute_builds_reference_ids(self):
+        for params in self:
+            params.builds_reference_ids = params.slot_reference_ids.build_id
 
     @api.depends('commit_link_ids')
     def _compute_commit_ids(self):

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -855,16 +855,16 @@ class ConfigStep(models.Model):
 
         return dict(cmd=cmd)
 
-    def _reference_builds(self, batch, trigger):
+    def _reference_slots(self, batch, trigger):
         upgrade_dumps_trigger_id = trigger.upgrade_dumps_trigger_id
         refs_batches = self._reference_batches(batch, trigger)
-        refs_builds = refs_batches.mapped('slot_ids').filtered(
+        refs_slots = refs_batches.mapped('slot_ids').filtered(
             lambda slot: slot.trigger_id == upgrade_dumps_trigger_id
-            ).mapped('build_id')
+            )
         # should we filter on active? implicit. On match type? on skipped ?
         # is last_"done"_batch enough?
         # TODO active test false and take last done/running build limit 1 -> in case of rebuild
-        return refs_builds
+        return refs_slots
 
     def _is_upgrade_step(self):
         return self.job_type in ('configure_upgrade', 'configure_upgrade_complement')

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -118,13 +118,13 @@ class Trigger(models.Model):
             raise UserError('Upgrade trigger should have a config with step of type Configure Upgrade')
         return upgrade_step
 
-    def _reference_builds(self, batch):
+    def _reference_slots(self, batch):
         self.ensure_one()
         if self.upgrade_step_id:  # this is an upgrade trigger, add corresponding builds
             custom_config = next((trigger_custom.config_id for trigger_custom in batch.bundle_id.trigger_custom_ids if trigger_custom.trigger_id == self), False)
             step = self._upgrade_step_from_config(custom_config) if custom_config else self.upgrade_step_id
-            refs_builds = step._reference_builds(batch, self)
-            return [(4, b.id) for b in refs_builds]
+            refs_slots = step._reference_slots(batch, self)
+            return refs_slots
         return []
 
     def _get_version_domain(self):

--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -129,7 +129,7 @@
                             </td>
                             <td>
                                 <t t-foreach="reference_batch_ids.sorted(lambda b: b.bundle_id.version_id.number, reverse=True)" t-as="reference_batch">
-                                    <div t-att-title="f'Created {s2human(reference_batch.create_date - batch.create_date)} before this one'">
+                                    <div t-attf-title="Created {{s2human(reference_batch.create_date - batch.create_date)}} before this one">
                                          <a t-attf-href="/runbot/batch/{{reference_batch.id}}"><t t-out="reference_batch.bundle_id.version_id.name"/> (<t t-out="reference_batch.id"/>)</a>
                                     </div>
                                 </t>

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -134,10 +134,15 @@
                 <b>Extra params:</b>
                 <t t-out="build.params_id.extra_params"/>
                 <br/>
-                <t t-if="build.params_id.builds_reference_ids">
-                  <b>Reference builds:</b>
-                  <div t-foreach="build.params_id.builds_reference_ids" t-as="reference">
-                    <a t-attf-href="/runbot/build/{{reference.id}}"><t t-esc="reference.id"/></a> - <em t-out="reference.params_id.version_id.name"/>
+                <t t-if="build.params_id.slot_reference_ids">
+                  <b>Reference slots:</b>
+                  <div t-foreach="build.params_id.slot_reference_ids" t-as="slot_reference">
+                    <t t-if="slot_reference.build_id">
+                      <a t-attf-href="/runbot/build/{{slot_reference.build_id.id}}"><t t-esc="slot_reference.build_id.id"/></a> - <em t-out="slot_reference.params_id.version_id.name"/>
+                    </t>
+                    <t t-else="">
+                      <a t-attf-href="/runbot/batch/{{slot_reference.batch_id.id}}">Missing build for slot<t t-esc="slot_reference.trigger_id.name"/></a> - <em t-out="slot_reference.params_id.version_id.name"/>
+                    </t>
                   </div>
                 </t>
                 <t t-if="len(build.params_id.build_ids) > 1">


### PR DESCRIPTION
For upgrade, the reference builds are store as it is but we could store slots instead.

The slot has a link to the build, but also gives additionnal information, like the batch.

Moreover, it is possible to link a slot that has no build yet, which could be usefull in the future for cross versions builds.