### PR TITLE
[ADD] runbot: smart button on build errors for build links list

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -38,6 +38,7 @@
         'templates/build_error.xml',
 
         'views/branch_views.xml',
+        'views/build_error_link_views.xml',
         'views/build_error_views.xml',
         'views/build_views.xml',
         'views/bundle_views.xml',

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -322,6 +322,16 @@ class BuildError(models.Model):
         self.ensure_one()
         return Markup('<a href="%s">%s</a>') % (self._get_form_url(), self.id)
 
+    def action_get_build_link_record(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'list,form,pivot',
+            'res_model': 'runbot.build.error.link',
+            'domain': [('id', 'in', self.unique_build_error_link_ids.ids)],
+            'context': "{'create': False}"
+        }
+
     def action_view_errors(self):
         return {
             'type': 'ir.actions.act_window',

--- a/runbot/views/build_error_link_views.xml
+++ b/runbot/views/build_error_link_views.xml
@@ -1,0 +1,50 @@
+<odoo>
+  <record id="runbot_build_error_link_tree" model="ir.ui.view">
+      <field name="name">Runbot Build Error Link List</field>
+      <field name="model">runbot.build.error.link</field>
+      <field name="arch" type="xml">
+          <list default_order="log_date desc,id desc" create="false" delete="false" edit="false">
+            <field name="log_date"/>
+            <field name="host" groups="base.group_no_one" optional="hide"/>
+            <field name="dest" optional="hide"/>
+            <field name="version_id"/>
+            <field name="trigger_id"/>
+            <field name="description"/>
+            <field name="error_content_id" widget="many2one" string="Linked Error log" optional="show" column_invisible="context.get('hide_linked_error', False)"/>
+            <field name="build_url" widget="url" readonly="1" text="View build"/>
+          </list>
+      </field>
+  </record>
+
+  <record id="runbot_build_error_link_search" model="ir.ui.view">
+      <field name="name">Runbot Build Error Link Search</field>
+      <field name="model">runbot.build.error.link</field>
+      <field name="arch" type="xml">
+          <search>
+              <field name="description"/>
+              <field name="version_id"/>
+              <field name="trigger_id"/>
+
+              <filter string="Today" name="filter_today" domain="[('log_date', '&gt;', (context_today() - datetime.timedelta(days=1)).strftime('%Y-%m-%d'))]"/>
+              <filter string="Last 7 days" name="filter_week" domain="[('log_date', '&gt;', (context_today() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]"/>
+              <filter string="Last 15 days" name="filter_2weeks" domain="[('log_date', '&gt;', (context_today() - datetime.timedelta(days=15)).strftime('%Y-%m-%d'))]"/>
+              <separator/>
+              <filter string="Single App builds" name="filter_single_app" domain="[('description', '=like', 'Testing module %')]"/>
+
+              <group expand="0" string="Group By">
+                  <filter string="Description" name="group_by_description" context="{'group_by': 'description'}"/>
+                  <filter string="Version" name="group_by_version_id" context="{'group_by': 'version_id'}"/>
+                  <filter string="Trigger" name="group_by_trigger_id" context="{'group_by': 'trigger_id'}"/>
+                  <separator/>
+                  <filter string="Log Date" name="group_by_log_date" context="{'group_by': 'log_date'}"/>
+              </group>
+          </search>
+      </field>
+  </record>
+
+  <record id="runbot_build_error_link_action" model="ir.actions.act_window">
+    <field name="name">Runbot Build Error Link</field>
+    <field name="res_model">runbot.build.error.link</field>
+    <field name="view_mode">list,pivot,form</field>
+  </record>
+</odoo>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -6,6 +6,11 @@
       <field name="arch" type="xml">
         <form>
           <sheet>
+              <div name="button_box">
+                <button class="oe_stat_button" type="object" icon="fa-exclamation-circle" name="action_get_build_link_record">
+                  <field string="Builds Link" name="build_count" widget="statinfo"/>
+                </button>
+              </div>
               <widget name="web_ribbon" title="Test-tags" bg_color="bg-danger" invisible="not test_tags"/>
               <button name="action_view_errors" string="See all linked errors" type="object" class="oe_highlight"/>
               <group string="Base info">
@@ -56,31 +61,10 @@
               </group>
               <notebook>
                 <page string="Builds">
-                  <field name="unique_build_error_link_ids" widget="one2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
-                    <list default_order="log_date desc,id desc">
-                      <field name="log_date"/>
-                      <field name="host" groups="base.group_no_one" optional="hide"/>
-                      <field name="dest" optional="hide"/>
-                      <field name="version_id"/>
-                      <field name="trigger_id"/>
-                      <field name="description"/>
-                      <field name="build_url" widget="url" readonly="1" text="View build"/>
-                    </list>
-                  </field>
+                  <field name="unique_build_error_link_ids" widget="one2many" context="{'hide_linked_error': 'True'}"/>
                 </page>
                 <page string="All links">
-                  <field name="build_error_link_ids" widget="one2many" options="{'not_delete': True, 'no_create': True}" readonly="1">
-                    <list default_order="log_date desc,id desc">
-                      <field name="log_date"/>
-                      <field name="host" groups="base.group_no_one" optional="hide"/>
-                      <field name="dest" optional="hide"/>
-                      <field name="version_id"/>
-                      <field name="trigger_id"/>
-                      <field name="description"/>
-                      <field name="error_content_id" widget="many2one" string="Linked Error log"/>
-                      <field name="build_url" widget="url" readonly="1" text="View build"/>
-                    </list>
-                  </field>
+                  <field name="build_error_link_ids" widget="one2many"/>
                 </page>
                 <page string="Similary qualified Errors" groups="runbot.group_runbot_admin,runbot.group_runbot_error_manager" invisible="not common_qualifiers">
                   <div class="btn-group">


### PR DESCRIPTION
Before this commit:
The only way to have details on the builds was to use the embed one2many widget in the build error form view.
This was pretty inconvenient for complicated search as there is no way to filter the records or group them

After this commit:
A list view now exist for the model `runbot.build.error.link` allowing to filter and group on convenient fields. This list view can be accessed on the runbot build error through a smart button