### PR TITLE
[IMP] runbot: add warning on some config_views

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -52,6 +52,7 @@ class Config(models.Model):
     group = fields.Many2one('runbot.build.config', 'Configuration group', help="Group of config's and config steps")
     group_name = fields.Char('Group name', related='group.name')
     step_ids = fields.Many2many('runbot.build.config.step', compute='_compute_step_ids')
+    warning = fields.Html('Warning message', help="Warning message to display on build page")
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -234,6 +234,14 @@
             </table>
           </div>
           <t t-set="nb_subbuild" t-value="len(build.children_ids)"/>
+          <t t-set="warning" t-value="([b.config_id.warning for b in build.ancestors if b.config_id.warning] + [''])[0]"/>
+          <div class="col-md-12" t-if="warning">
+            <div class="row">
+              <div t-attf-class="alert alert-warning text-center">
+                  <b t-out="warning"/>
+              </div>
+            </div>
+          </div>
           <div class="col-md-12">
             <table class="table table-condensed">
               <tr>

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -20,6 +20,7 @@
                         </field>
                         <field name="protected"/>
                         <field name="group" groups="base.group_no_one"/>
+                        <field name="warning"/>
                     </group>
                 </sheet>
                 <chatter/>


### PR DESCRIPTION
The warning will appear on build (and children)
This is useful to explain the purpose of the build and special attention to give when reading the result. (templates)