### PR TITLE
[18.0][FIX] runbot: Wrong syntax in the batch template.

### DIFF
--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -129,7 +129,7 @@
                             </td>
                             <td>
                                 <t t-foreach="reference_batch_ids.sorted(lambda b: b.bundle_id.version_id.number, reverse=True)" t-as="reference_batch">
-                                    <div t-att-title="f'Created {s2human(reference_batch.create_date - batch.create_date)} before this one'">
+                                    <div t-attf-title="Created {{s2human(reference_batch.create_date - batch.create_date)}} before this one">
                                          <a t-attf-href="/runbot/batch/{{reference_batch.id}}"><t t-out="reference_batch.bundle_id.version_id.name"/> (<t t-out="reference_batch.id"/>)</a>
                                     </div>
                                 </t>


### PR DESCRIPTION
![Screenshot from 2025-03-12 11-06-26](https://github.com/user-attachments/assets/b9542c8d-71b9-48a4-8c41-cfceecc84108)
