### PR TITLE
[IMP] runbot: prevent saving on switching tab

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -64,6 +64,7 @@
     'assets': {
         'web.assets_backend': [
             'runbot/static/src/libs/diff_match_patch/diff_match_patch.js',
+            'runbot/static/src/js/views/**/*',
             'runbot/static/src/js/fields/*',
         ],
         'runbot.assets_frontend': [

--- a/runbot/static/src/js/views/form_controller.js
+++ b/runbot/static/src/js/views/form_controller.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+
+import { FormController } from '@web/views/form/form_controller';
+import { patch } from '@web/core/utils/patch';
+
+
+patch(FormController.prototype, {
+    // Prevent saving on tab switching
+    beforeVisibilityChange: () => {},
+    // Prevent closing page with dirty fields
+    async beforeUnload(ev) {
+        if (await this.model.root.isDirty()) {
+            ev.preventDefault();
+            ev.returnValue = 'Unsaved changes';
+        } else {
+            super.beforeUnload(ev);
+        }
+    }
+})


### PR DESCRIPTION
Auto save mechanism when switching tab is unwanted in runbot, most of the time we will use other tabs to get the data necessary for the record we are modifying/creating and we don't care about saving yet. Auto save in pager and context switch is still kept.