### PR TITLE
[FIX] runbot: prevent massive tag from taking screen space

### DIFF
--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -53,7 +53,7 @@
                 </group>
               </group>
               <group name="test_tags_group" string="Disabling">
-                <field name="canonical_tags"/>
+                <field name="canonical_tags" class="text-nowrap overflow-x-auto"/>
                 <button name="action_copy_canonical_tag" type="object" groups="runbot.group_runbot_admin">Disable test using canonical tag</button>
                 <field name="test_tags" decoration-danger="True" readonly="1" groups="!runbot.group_runbot_admin"/>
                 <field name="test_tags" decoration-danger="True" groups="runbot.group_runbot_admin"/>


### PR DESCRIPTION
Removes wrapping and add a horizontal scrollbar if the canonical tag is way too long.