### PR TITLE
[FIX] runbot: remove keepquery from navbar main

### DIFF
--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -51,7 +51,7 @@
                 <body>
                     <header>
                         <nav class="navbar navbar-expand-md bg-body-tertiary">
-                            <a t-if="project" t-att-href="qu(search=search)">
+                            <a t-if="project" t-att-href="qu(search='')">
                                 <b class="active_project">
                                     <t t-out="project.name"/>
                                 </b>


### PR DESCRIPTION
When doing a search on runbot, the main navbar item (for the current project) keeps the search, making it less convenient to arrive back at the homepage.