### PR TITLE
[IMP] runbot: improve host form view loading speedup

### DIFF
--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -63,7 +63,7 @@ class Host(models.Model):
 
     def _compute_build_ids(self):
         for host in self:
-            host.build_ids = self.env['runbot.build'].search([('host', '=', host.name), ('local_state', '!=', 'done')])
+            host.build_ids = self.env['runbot.build'].search([('host', '=', host.name), ('local_state', 'in', ('pending', 'testing', 'running'))])
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
The host form view was loading slowly because of the domain != "done" whitch doesn't benefit from any index.

Switching it to a list of state that are not done solves the issue.