### PR TITLE
[FIX] runbot: restore "error already known" message

### DIFF
--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -330,7 +330,7 @@
                       <a groups="runbot.group_user" t-attf-href="/web#id={{error.id}}&amp;view_type=form&amp;model=runbot.build.error&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="_blank">
                         <i t-attf-class="fa fa-list"/>
                       </a>
-                      <span groups="runbot.group_runbot_admin" t-if="error.responsible or error.responsible.id == uid">(<i t-out="error.responsible.name"/>)</span>
+                      <span t-if="error.responsible and (env.user.has_group('runbot.group_runbot_error_manager') or error.responsible.id == uid)">(<i t-out="error.responsible.name"/>)</span>
                     </td>
                   </tr>
                 </t>


### PR DESCRIPTION
Displays it for the error manager group as well as if you are assigned to it.