### PR TITLE
[FIX] runbot: remove --user from pip

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1105,7 +1105,7 @@ class BuildResult(models.Model):
                 if os.path.isfile(commit_id._source_path('requirements.txt')):
                     repo_dir = self._docker_source_folder(commit_id)
                     requirement_path = os.sep.join([repo_dir, 'requirements.txt'])
-                    pres.append([f'python{py_version}', '-m', 'pip', 'install', '--user', '--progress-bar', 'off', '-r', f'{requirement_path}'])
+                    pres.append([f'python{py_version}', '-m', 'pip', 'install', '--progress-bar', 'off', '-r', f'{requirement_path}'])
 
         addons_paths = self._get_addons_path()
         (server_commit, server_file) = self._get_server_info()

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -397,7 +397,7 @@ class TestBuildResult(RunbotCase):
             'params_id': self.server_params.id,
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('python3 -m pip install --user --progress-bar off -r server/requirements.txt'.split(), cmd.pres)
+        self.assertIn('python3 -m pip install --progress-bar off -r server/requirements.txt'.split(), cmd.pres)
         self.assertIn(custom_pre, cmd.pres)
         self.assertIn(custom_post, cmd.posts)
 


### PR DESCRIPTION
Experimentations are done to use venv inside the docker to avoid having a strong dependency on the user creation to install pip.

The default --user option of pip is not compatible with the venv causing error when the install really need to make some operation.

Looking at the commit that introduced it e1161a03e it wasn't really usefull but mostly added as a good practice in case we wish to use the same command on a non debian based system.