### PR TITLE
[IMP] runbot: assign teams to error from qualifiers

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -12,7 +12,7 @@ from markupsafe import Markup
 from werkzeug.urls import url_join
 from odoo import models, fields, api
 from odoo.exceptions import ValidationError, UserError
-from odoo.tools import SQL
+from odoo.tools import SQL, lazy
 
 from ..fields import JsonDictField
 
@@ -107,7 +107,9 @@ class BuildError(models.Model):
 
     responsible = fields.Many2one('res.users', 'Assigned fixer', tracking=True)
     customer = fields.Many2one('res.users', 'Customer', tracking=True)
-    team_id = fields.Many2one('runbot.team', 'Assigned team', tracking=True)
+    team_id = fields.Many2one('runbot.team', 'Assigned team', compute='_compute_team_id', inverse='_inverse_team_id', store=True, tracking=True)
+    manual_team_id = fields.Many2one('runbot.team', 'Manually assigned team')
+    auto_team_id = fields.Many2one('runbot.team', 'Automatically assigned team', readonly=True) # This is a computed field but not really
     fixing_commit = fields.Char('Fixing commit', tracking=True)
     fixing_pr_id = fields.Many2one('runbot.branch', 'Fixing PR', tracking=True, domain=[('is_pr', '=', True)])
     fixing_pr_alive = fields.Boolean('Fixing PR alive', related='fixing_pr_id.alive')
@@ -496,20 +498,35 @@ class BuildError(models.Model):
             'name': 'Similary Qualified Contents'
         }
 
+    @api.depends('manual_team_id', 'auto_team_id')
+    def _compute_team_id(self):
+        for error in self:
+            error.team_id = error.manual_team_id or error.auto_team_id
+
+    def _inverse_team_id(self):
+        self.manual_team_id = self.team_id
+
     def action_assign(self):
-        teams = None
-        repos = None
-        for record in self:
-            if not record.responsible and not record.team_id:
-                for error_content in record.error_content_ids:
-                    if error_content.file_path:
-                        if teams is None:
-                            teams = self.env['runbot.team'].search(['|', ('path_glob', '!=', False), ('module_ownership_ids', '!=', False)])
-                            repos = self.env['runbot.repo'].search([])
-                        team = teams._get_team(error_content.file_path, repos)
-                        if team:
-                            record.team_id = team
-                            break
+        teams = lazy(self.env['runbot.team'].search, ['|', ('path_glob', '!=', False), ('module_ownership_ids', '!=', False)])
+        repos = lazy(self.env['runbot.repo'].search, [])
+
+        def _get_team(*, file_path: str = None, module: str = None): # Get team from file path or module, teams and repos are cached
+            team = False
+            if module:
+                team = teams._get_team_from_module(module)
+            if not team and file_path:
+                team = teams._get_team(file_path, repos)
+            return team
+
+        for error in self:
+            for content in error.error_content_ids:
+                team = _get_team(
+                    file_path=content.file_path,
+                    module=content.qualifiers.dict.get('module')
+                )
+                if team:
+                    error.auto_team_id = team
+                    break
 
     def action_copy_canonical_tag(self):
         for record in self:

--- a/runbot/models/team.py
+++ b/runbot/models/team.py
@@ -53,7 +53,12 @@ class RunbotTeam(models.Model):
                 vals['dashboard_id'] = dashboard.id
         return super().create(vals_list)
 
-    @api.model
+    def _get_team_from_module(self, module: str):
+        for ownership in self.module_ownership_ids.sorted(lambda t: t.is_fallback):
+            if module == ownership.module_id.name:
+                return ownership.team_id
+        return False
+
     def _get_team(self, file_path, repos=None):
         # path = file_path.removeprefix('/data/build/')
         path = file_path
@@ -70,10 +75,8 @@ class RunbotTeam(models.Model):
             module = repo._get_module(path)
             if module:
                 break
-        if module:
-            for ownership in self.module_ownership_ids.sorted(lambda t: t.is_fallback):
-                if module == ownership.module_id.name:
-                    return ownership.team_id
+        if module and (owner_team := self._get_team_from_module(module)):
+            return owner_team
 
         for team in self:
             if not team.path_glob:

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -646,6 +646,7 @@ class TestBuildError(RunbotCase):
         self.assertFalse(teams._get_team('/data/build/odoo/addons/web_studio/tests/test_ui.py'))
         self.assertEqual(website_team, teams._get_team('/data/build/odoo/addons/website_crm/tests/test_website_crm'))
         self.assertEqual(sale_team, teams._get_team('/data/build/enterprise/website_sale/tests/test_sale_process.py'))
+        self.assertEqual(website_team, teams._get_team_from_module('website_crm'))
 
     def test_dashboard_tile_simple(self):
         self.additionnal_setup()


### PR DESCRIPTION
Uses the 'module' key from qualifier to define the team to assign if it is available, as we consider qualifiers to be more precise than file path it also takes precedence over the latter.