### PR TITLE
[IMP] runbot: add tracking on upgrade exception elements

### DIFF
--- a/runbot/models/upgrade.py
+++ b/runbot/models/upgrade.py
@@ -9,7 +9,7 @@ class UpgradeExceptions(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
 
     active = fields.Boolean('Active', default=True, tracking=True)
-    elements = fields.Text('Elements', required=True)
+    elements = fields.Text('Elements', required=True, tracking=True)
     bundle_id = fields.Many2one('runbot.bundle', index=True)
     create_build_id = fields.Many2one('runbot.build', 'Build')
     pr_ids = fields.Many2many('runbot.branch', string='Pull requests', default=lambda self: self.default_pr_ids())


### PR DESCRIPTION
Tracking the field as it can happen that we modify the elements instead of creating a new upgrade when it is necessary in forward ports. For example a new computed field on a mixin changed in stable, and the mixin is implemented in more models in later versions.

Making a single exception makes it easier to track, but it is not known at which point which elements have been added.