### PR TITLE
[IMP] runbot: log docker file identifier

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -692,10 +692,12 @@ class Runbot(Controller):
         '/runbot/dockerfile',
         '/runbot/dockerfile/<int:dockerfile_id>',
         '/runbot/dockerfile/tag/<string:docker_tag>',
+        '/runbot/dockerfile/result/<string:dockerfile_result_id>',
         '/runbot/dockerfile/version/<string:version>',
     ], type='http', auth='public', sitemap=False)
-    def dockerfile_content(self, dockerfile_id=None, version=None, docker_tag=None, **kwargs):
+    def dockerfile_content(self, dockerfile_id=None, version=None, docker_tag=None, dockerfile_result_id=None, **kwargs):
         dockerfile_sudo = request.env['runbot.dockerfile'].sudo()
+        dockerfile_result = None
         if 'id' in kwargs:
             dockerfile_id = int(kwargs['id'])
         if dockerfile_id:  # keep 'id' for historical reasons
@@ -704,16 +706,51 @@ class Runbot(Controller):
             dockerfile = dockerfile_sudo.search([('image_tag', '=', docker_tag)])
         elif version:
             dockerfile = dockerfile_sudo.search([('version_ids.name', '=', version)])
+        elif dockerfile_result_id:
+            dockerfile_result = request.env['runbot.docker_build_result'].sudo().browse(int(dockerfile_result_id)).exists()
+            dockerfile = dockerfile_result.dockerfile_id
         else:
             raise NotFound
 
-        if dockerfile.public_visibility:
-            return Response(response=dockerfile.layer_ids.render_layers({
+        if dockerfile.public_visibility or request.env.user.has_group('runbot.group_runbot_admin'):
+            if dockerfile_result:
+                render = dockerfile_result.content
+            else:
+                render = dockerfile.layer_ids.render_layers({
                 'USERUID': '${USERUID}',
                 'USERGID': '${USERGID}',
                 'USERNAME': '${USERNAME}',
-            }), status=200, mimetype='text/plain')
+            })
+            return Response(response=render, status=200, mimetype='text/plain')
 
         if dockerfile:
             _logger.error('Trying to access a non public docker image')
         raise NotFound
+
+    @route([
+        '/runbot/dockerfile_result/<int:dockerfile_result_id>',
+        '/runbot/dockerfile_result/<dockerfile_tag>/<dockerfile_hash>',
+    ], type='http', auth='public', sitemap=False)
+    def dockerfile_result(self, dockerfile_result_id=None, dockerfile_tag=None, dockerfile_hash=None, **kwargs):
+        dockerfile_result_sudo = request.env['runbot.docker_build_result'].sudo()
+        if dockerfile_result_id:
+            dockerfile_result = dockerfile_result_sudo.browse(dockerfile_result_id).exists()
+        elif dockerfile_tag and dockerfile_hash:
+            dockerfile_result = dockerfile_result_sudo.search([('dockerfile_id.image_tag', '=', dockerfile_tag), ('identifier', '=', dockerfile_hash[:12])], limit=1, order='id desc')
+        else:
+            raise NotFound
+
+        if not dockerfile_result:
+            raise NotFound
+
+        dockerfile = dockerfile_result.dockerfile_id
+
+        if not (dockerfile_result.dockerfile_id.public_visibility or request.env.user.has_group('runbot.group_runbot_admin')):
+            raise NotFound
+
+        return request.render("runbot.docker_result_template", {
+            'dockerfile_result': dockerfile_result,
+            'dockerfile': dockerfile,
+            'future_result': dockerfile._get_last_successful_result_for_ident(dockerfile.image_future_identifier),
+            'current_result': dockerfile._get_last_successful_result_for_ident(dockerfile.image_identifier),
+        })

--- a/runbot/docker_manager.py
+++ b/runbot/docker_manager.py
@@ -3,6 +3,7 @@ import getpass
 import logging
 import time
 import warnings
+import re
 
 # unsolved issue https://github.com/docker/docker-py/issues/2928
 with warnings.catch_warnings():
@@ -65,6 +66,15 @@ class DockerManager:
         self.result['duration'] = self.duration
         if self.result['success']:
             self.result['image'] = self.docker_client.images.get(self.image_tag)
-            if 'image_id' in self.result and self.result['image_id'] not in self.result['image'].id:
-                _logger.warning('Image id does not match %s %s', self.result['image_id'], self.result['image'].id)
+            if 'image_id' in self.result:
+                if self.result['image_id'] not in self.result['image'].id:
+                    _logger.warning('Image id does not match %s %s', self.result['image_id'], self.result['image'].id)
+            elif self.result['image']:
+                match = re.search(
+                    r'^sha256:([0-9a-f]+)$',
+                    self.result['image'].id,
+                )
+                if match:
+                    self.result['image_id'] = match.group(1)
+
                 # if this never triggers, we could remove or simplify the success check from docker_build

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -855,14 +855,17 @@ class BuildResult(models.Model):
             kwargs.update({'image_tag': self.params_id.dockerfile_id.image_tag})
         if self.params_id.config_data.get('docker_use_future') and not kwargs['image_tag'].endswith('.future'):
             kwargs['image_tag'] += '.future'
-        self._log('Preparing', 'Using Dockerfile Tag [%s](/runbot/dockerfile/tag/%s)', kwargs['image_tag'], kwargs['image_tag'], log_type='markdown')
         docker_registry_url = self.host_id._get_docker_registry_url()
+        image_id = None
         if docker_registry_url and self.host_id.use_remote_docker_registry:
             result = docker_pull(f"{docker_registry_url}/{kwargs['image_tag']}")
             if result['success']:
                 result['image'].tag(kwargs['image_tag'])
             if result.get('log_progress'):
                 self._log('Docker Run', f'Docker image was pulled {"" if result["success"] else "with errors"}')
+            image_id = result.get('image_id')
+
+        self._log('Preparing', 'Using Dockerfile Tag [%s](/runbot/dockerfile_result/%s/%s)', kwargs['image_tag'], kwargs['image_tag'], image_id, log_type='markdown')
 
         containers_memory_limit = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_memory', 0)
         if containers_memory_limit and 'memory' not in kwargs:

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -124,7 +124,7 @@ class BuildError(models.Model):
     similar_content_ids = fields.One2many('runbot.build.error.content', compute='_compute_similar_content_ids', string="Similar Error Contents", help="Similar Error contents based on common qualifiers")
     unique_qualifiers = JsonDictField('Non conflicting Qualifiers', compute='_compute_unique_qualifiers', store=True, help="Non conflicting qualifiers in common needed to link error content.")
     analogous_ids = fields.One2many('runbot.build.error', compute='_compute_analogous_ids', string="Analogous Errors", help="Analogous Errors based on unique qualifiers")
-    analogous_content_ids= fields.One2many('runbot.build.error.content', compute='_compute_analogous_content_ids', string="Analogous Error Contents", help="Analogous Error contents based on unique qualifiers")
+    analogous_content_ids = fields.One2many('runbot.build.error.content', compute='_compute_analogous_content_ids', string="Analogous Error Contents", help="Analogous Error contents based on unique qualifiers")
 
     # Build error related data
     build_error_link_ids = fields.Many2many('runbot.build.error.link', compute=_compute_related_error_content_ids('build_error_link_ids'), search=_search_related_error_content_ids('build_error_link_ids'))

--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -168,9 +168,12 @@ class Dockerfile(models.Model):
             ['id:max'],
         )
         result_ids = dict(rg)
-
         for record in self:
             record.last_successful_result = result_ids.get(record)
+
+    def _get_last_successful_result_for_ident(self, identifier=None):
+        domain = [('result', '=', 'success'), ('dockerfile_id', 'in', self.ids), ('identifier', '=', identifier)]
+        return self.env['runbot.docker_build_result'].search(domain, order='id desc', limit=1)
 
     @api.depends('bundle_ids', 'referencing_dockerlayer_ids', 'project_ids', 'version_ids')
     def _compute_use_count(self):

--- a/runbot/templates/build_error.xml
+++ b/runbot/templates/build_error.xml
@@ -151,5 +151,47 @@
         </div>
       </t>
     </template>
+    <template id="runbot.docker_result_template">
+      <t t-call='runbot.layout'>
+        <div class="container-fluid">
+          <div class="row">
+            <div class='col-md-12'>
+              <h4><t t-esc="dockerfile.image_tag"/></h4>
+              <t t-if="dockerfile_result.identifier not in (dockerfile.image_identifier, dockerfile.image_future_identifier)">
+                <div class="alert alert-warning">
+                  This version of the docker image is outdated and was modified since, latest version <a t-attf-href="/runbot/dockerfile_result/{{dockerfile.last_successful_result.id}}">here</a>
+                </div>
+              </t>
+              <t t-else="">
+                <t t-if="dockerfile.image_identifier == dockerfile.image_future_identifier">
+                  <div class="alert alert-success">
+                    This is the latest version of the docker image
+                  </div>
+                </t>
+                <t t-else="">
+                  <t t-if="dockerfile.image_identifier == dockerfile_result.identifier">
+                    <div class="alert alert-info">
+                      This is the latest stable version of the docker image, but <a t-attf-href="/runbot/dockerfile_result/{{future_result.id}}">another future version</a> exists
+                    </div>
+                  </t>
+                  <t t-else="">
+                    <div class="alert alert-info">
+                      This is the future version of the docker image, <a t-attf-href="/runbot/dockerfile_result/{{current_result.id}}">current version here</a>
+                    </div>
+                  </t>
+                </t>
+              </t>
+            </div>
+          </div>
+          <div class="row">
+            <div class='col-md-12'>
+              <b>Identifier</b>: <t t-esc="dockerfile_result.identifier"></t><br/>
+              <b>Dockerfile</b>: <a t-attf-href="/runbot/dockerfile/result/{{current_result.id}}">raw</a><br/>
+              <b>Metadata</b>: <pre><t t-esc="json.dumps((dockerfile_result.metadata.dict), indent=3)"></t></pre>
+            </div>
+          </div>
+        </div>
+      </t>
+    </template>
   </data>
 </odoo>


### PR DESCRIPTION
The current log of the docker file used in a branch is only the docker
tag, it is difficult to know what was the exact version used in this
build.

This commit changes that to log a link to the current identifier in use
as well as adding some pages to consult docker result from frontend