### PR TITLE
[IMP] runbot: allow to mark an image as autosync

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -108,11 +108,11 @@ class Command():
         return res.read()
 
 
-def docker_build(build_dir, image_tag):
-    return _docker_build(build_dir, image_tag)
+def docker_build(build_dir, image_tag, pull=False):
+    return _docker_build(build_dir, image_tag, pull)
 
 
-def _docker_build(build_dir, image_tag):
+def _docker_build(build_dir, image_tag, pull=False):
     """Build the docker image
     :param build_dir: the build directory that contains Dockerfile.
     :param image_tag: name used to tag the resulting docker image
@@ -122,7 +122,7 @@ def _docker_build(build_dir, image_tag):
     with DockerManager(image_tag) as dm:
         last_step = None
         dm.result['success'] = False  # waiting for an image_id
-        for chunk in dm.consume(dm.docker_client.api.build(path=build_dir, tag=image_tag, rm=True)):
+        for chunk in dm.consume(dm.docker_client.api.build(path=build_dir, tag=image_tag, rm=True, pull=pull)):
             if 'stream' in chunk:
                 stream = chunk['stream']
                 if stream.startswith('Step '):

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -4,14 +4,16 @@ import hashlib
 import json
 import logging
 import re
-
 from collections import defaultdict
-from dateutil.relativedelta import relativedelta
+
 from dateutil import rrule
+from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
+
 from werkzeug.urls import url_join
-from odoo import models, fields, api
-from odoo.exceptions import ValidationError, UserError
+
+from odoo import api, fields, models
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import SQL, lazy
 
 from ..fields import JsonDictField

--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -124,6 +124,8 @@ class Dockerfile(models.Model):
 
     name = fields.Char('Dockerfile name', required=True, help="Name of Dockerfile")
     active = fields.Boolean('Active', default=True, tracking=True)
+    auto_sync = fields.Boolean('Auto sync', help='Automatically sync the identifier with the future identifier', default=False, tracking=True)
+    pull_on_build = fields.Boolean('Pull on build ', help='Add pull option when building to get the latest version of the FROM', default=False, tracking=True)
     image_identifier = fields.Char('Identifier', tracking=True)
     image_future_identifier = fields.Char('Future Identifier', tracking=True)
     image_previous_identifier = fields.Char('Previous Identifier', tracking=True)
@@ -362,7 +364,7 @@ class Dockerfile(models.Model):
 
         with open(self.env['runbot.runbot']._path('docker', self.image_tag, 'Dockerfile'), 'w') as Dockerfile:
             Dockerfile.write(content)
-        result = docker_build(docker_build_path, self.image_future_tag)
+        result = docker_build(docker_build_path, self.image_future_tag, self.pull_on_build)
         duration = result['duration']
         msg = result['msg']
         success = image_id = result.get('image_id')

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -172,6 +172,8 @@ class Host(models.Model):
                 if is_registry:
                     if future_identifier:
                         dockerfile.image_future_identifier = future_identifier
+                        if dockerfile.auto_sync:
+                            dockerfile.image_identifier = future_identifier
                     docker_tag(dockerfile.image_previous_identifier, dockerfile.image_previous_tag)
                     docker_tag(dockerfile.image_identifier, dockerfile.image_tag)
                     docker_tag(dockerfile.image_future_identifier, dockerfile.image_future_tag)


### PR DESCRIPTION
This is mainly to simplify the use in non critical environment. The image can still be rollbacked to the previous version if needed.