### PR TITLE
[IMP] runbot: allow leader to build docker images

### DIFF
--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -128,7 +128,7 @@ class Dockerfile(models.Model):
         help='This field is used to define variants of docker images. Variants implicitly inherit from the parent and have an implicit reference_file layer.'
     )
     active = fields.Boolean('Active', default=True, tracking=True)
-    auto_sync = fields.Boolean('Auto sync', help='Automatically sync the identifier with the future identifier', default=False, tracking=True)
+    auto_sync = fields.Boolean('Auto sync', help='Automatically sync the identifier with the future identifier', default=lambda self: not self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_dockerfile_disable_auto_sync_by_default', False), tracking=True)
     pull_on_build = fields.Boolean('Pull on build ', help='Add pull option when building to get the latest version of the FROM', default=False, tracking=True)
     image_identifier = fields.Char('Identifier', tracking=True)
     image_future_identifier = fields.Char('Future Identifier', tracking=True)
@@ -138,7 +138,7 @@ class Dockerfile(models.Model):
     image_previous_tag = fields.Char(compute='_compute_image_helper_tags')
     dockerfile = fields.Text(compute='_compute_dockerfile', recursive=True, tracking=True)
     in_error = fields.Boolean('In error', help='The last build failed.', default=False)
-    to_build = fields.Boolean('To Build', help='Build Dockerfile. Check this when the Dockerfile is ready.', default=False)
+    to_build = fields.Boolean('To Build', help='Build Dockerfile. Check this when the Dockerfile is ready.', default=True)
     always_pull = fields.Boolean('Always pull', help='Always Pull on the hosts, not only at the use time', default=False, tracking=True, copy=False)
     version_ids = fields.One2many('runbot.version', 'dockerfile_id', string='Versions')
     description = fields.Text('Description')

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -46,6 +46,10 @@ class Host(models.Model):
     paused = fields.Boolean('Paused', help='Host will stop scheduling while paused')
     profile = fields.Boolean('Profile', help='Enable profiling on this host')
 
+    is_leader = fields.Boolean('Is leader', help='This host is the leader of the cluster', default=False)
+    is_builder = fields.Boolean('Is builder', help='This host is a builder of the cluster', default=True)
+    is_registry = fields.Boolean('Is docker registry', help='This host is a docker regisrty', default=False)
+
     use_remote_docker_registry = fields.Boolean('Use remote Docker Registry', default=False, help="Use docker registry for pulling images")
     docker_registry_url = fields.Char('Registry Url', help="Override global registry URL for this host.")
 
@@ -148,10 +152,10 @@ class Host(models.Model):
         docker_registry_host = self.browse(int(icp.get_param('runbot.docker_registry_host_id', default=0)))
         docker_registry_url = self._get_docker_registry_url()
         # pull all images from the runbot docker registry
-        is_registry = docker_registry_host == self
+        is_main_registry = docker_registry_host == self
         all_docker_files = self.env['runbot.dockerfile'].search([])
         all_tags = set(all_docker_files.mapped('image_tag'))
-        if docker_registry_url and self.use_remote_docker_registry and not is_registry:
+        if docker_registry_url and self.use_remote_docker_registry and not is_main_registry:
             _logger.info('Pulling docker images...')
             total_duration = 0
             for dockerfile in all_docker_files.filtered('always_pull'):
@@ -170,7 +174,7 @@ class Host(models.Model):
                 future_identifier = None
                 if not dockerfile.in_error:
                     future_identifier = dockerfile._build(self)
-                if is_registry:
+                if self.is_registry:
                     if future_identifier:
                         dockerfile.image_future_identifier = future_identifier
                         if dockerfile.auto_sync:
@@ -181,12 +185,14 @@ class Host(models.Model):
                     for tag in [dockerfile.image_tag, dockerfile.image_future_tag]:
                         try:
                             docker_push(tag)  # for now, always push locally
-                            if self.docker_registry_url:
+                            if is_main_registry:
                                 docker_registry_url = self.docker_registry_url
-                            else:
-                                docker_registry_url = icp.get_param('runbot.docker_registry_url', default='').strip('/')
-                            if docker_registry_url:
-                                docker_push(tag, docker_registry_url)
+                                if self.docker_registry_url:
+                                    docker_registry_url = self.docker_registry_url
+                                else:
+                                    docker_registry_url = icp.get_param('runbot.docker_registry_url', default='').strip('/')
+                                if docker_registry_url:
+                                    docker_push(tag, docker_registry_url)
                         except ImageNotFound:
                             _logger.warning("Image tag `%s` not found. Skipping push", tag)
                 else:

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -79,6 +79,22 @@
                                     </li>
                                     <li class="nav-item divider" t-ignore="true"/>
                                     <t t-if="not user_id._is_public()">
+                                        <t t-if="env.user.has_group('runbot.group_runbot_admin')">
+                                            <t t-set="docker_files" t-value="env['runbot.dockerfile'].search([])"/>
+                                            <t t-set="out_of_sync_docker_files" t-value="docker_files.filtered(lambda d: d.image_identifier != d.image_future_identifier)"/>
+                                            <t t-set="in_error_docker_files" t-value="docker_files.filtered(lambda d: d.to_build and d.in_error)"/>
+                                            <li class="nav-item" t-if="out_of_sync_docker_files or in_error_docker_files">
+                                                <a class="nav-link" href="/odoo/docker">
+                                                    <i class="fa fa-warning"/>
+                                                    <t t-if="in_error_docker_files">
+                                                        <span class="text-danger" t-esc="len(in_error_docker_files)" title="In error docker files"/>
+                                                    </t>
+                                                    <t t-if="out_of_sync_docker_files">
+                                                        <span class="text-warning" t-esc="len(out_of_sync_docker_files)" title="Out of sync docker files"/>
+                                                    </t>
+                                                </a>
+                                            </li>
+                                        </t>
                                         <t t-call="runbot.build_errors_link"/>
                                         <li class="nav-item dropdown" t-ignore="true">
                                             <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">

--- a/runbot/tests/test_host.py
+++ b/runbot/tests/test_host.py
@@ -124,12 +124,14 @@ class TestHost(RunbotCase):
 
         icp = self.env['ir.config_parameter']
         icp.set_param('runbot.docker_registry_host_id', self.test_host.id)
+        self.test_host.is_registry = True
         icp.set_param('runbot.docker_registry_url', 'registryhost_nowhere')
         dockerfile = self.env['runbot.dockerfile'].create({
             'name': 'DockerTest',
             'to_build': True,
             'image_identifier': 'current',
-            'image_future_identifier': 'current'
+            'image_future_identifier': 'current',
+            'auto_sync': False,
         })
 
         self.assertEqual(dockerfile.image_tag, 'odoo:DockerTest')
@@ -149,7 +151,9 @@ class TestHost(RunbotCase):
 
         self.assertEqual(dockerfile.image_future_identifier, 'current')
 
-        self.patchers['build_patcher'].side_effect = lambda x: 'future'  # now simulate a success
+        def build_success(arg):
+            return 'future'
+        self.patchers['build_patcher'].side_effect = build_success  # now simulate a success
         self.patchers['docker_tag'].reset_mock()
         self.test_host._docker_update_images()
 
@@ -172,5 +176,3 @@ class TestHost(RunbotCase):
 
         self.patchers['docker_push'].assert_has_calls(expected_push_calls)
         self.patchers['docker_pull'].assert_not_called()
-
-

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -20,6 +20,7 @@
                 <field name="image_future_identifier"/>
                 <field name="auto_sync"/>
                 <field name="image_tag"/>
+                <field name="pull_on_build"/>
                 <field name="to_build"/>
                 <field name="in_error"/>
                 <field name="always_pull"/>
@@ -111,6 +112,8 @@
             <field name="use_count"/>
             <field name="dockerfile" invisible="True"/>
             <field name="public_visibility"/>
+            <field name="auto_sync" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
+            <field name="pull_on_build" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
           </list>
         </field>
     </record>
@@ -244,6 +247,7 @@
     <field name="name">Dockerfiles</field>
     <field name="res_model">runbot.dockerfile</field>
     <field name="view_mode">list,form</field>
+    <field name="path">docker</field>
   </record>
 
   <record id="open_view_docker_result_tree" model="ir.actions.act_window">

--- a/runbot/views/host_views.xml
+++ b/runbot/views/host_views.xml
@@ -12,6 +12,9 @@
                         <field name="disp_name"/>
                         <field name="active"/>
                         <field name="use_remote_docker_registry"/>
+                        <field name="is_leader"/>
+                        <field name="is_builder"/>
+                        <field name="is_registry"/>
                         <field name="docker_registry_url"/>
                         <field name="last_start_loop" readonly='1'/>
                         <field name="last_end_loop" readonly='1'/>
@@ -55,6 +58,11 @@
                 <field name="use_remote_docker_registry" widget="boolean_toggle"/>
                 <field name="nb_worker"/>
                 <field name="nb_run_slot"/>
+
+                <field name="is_leader"/>
+                <field name="is_builder"/>
+                <field name="is_registry"/>
+
             </list>
         </field>
     </record>

--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -12,41 +12,41 @@ _logger = logging.getLogger(__name__)
 class BuilderClient(RunbotClient):
 
     def on_start(self):
-        builds_path = self.env['runbot.runbot']._path('build')
-        monitoring_thread = threading.Thread(target=docker_monitoring_loop, args=(builds_path,), daemon=True)
-        monitoring_thread.start()
-
-        if self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_do_fetch'):
-            for repo in self.env['runbot.repo'].search([('mode', '!=', 'disabled')]):
-                repo._update(force=True)
-
         self.last_docker_updates = None
+        if self.host.is_builder:
+            builds_path = self.env['runbot.runbot']._path('build')
+            monitoring_thread = threading.Thread(target=docker_monitoring_loop, args=(builds_path,), daemon=True)
+            monitoring_thread.start()
+            if self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_do_fetch'):
+                for repo in self.env['runbot.repo'].search([('mode', '!=', 'disabled')]):
+                    repo._update(force=True)
 
     def loop_turn(self):
-        icp = self.env['ir.config_parameter']
-        docker_registry_host_id = icp.get_param('runbot.docker_registry_host_id', default=False)
-        is_registry = docker_registry_host_id == str(self.host.id)
-        if is_registry:
+        if self.host.is_registry:
+            self.env['runbot.runbot']._reload_nginx()
             self.env['runbot.runbot']._start_docker_registry()
-        last_docker_updates = self.env['runbot.dockerfile'].search([('to_build', '=', True)]).mapped('write_date')
-        if self.count == 1 or self.last_docker_updates != last_docker_updates:
-            self.last_docker_updates = last_docker_updates
-            self.host._docker_update_images()
-            self.env.cr.commit()
-        if self.count == 1:  # cleanup at second iteration
-            self.env['runbot.runbot']._source_cleanup()
-            self.env.cr.commit()
-            self.env['runbot.build']._local_cleanup()
-            self.env.cr.commit()
-            self.env['runbot.runbot']._docker_cleanup()
-            self.env.cr.commit()
-            self.host._set_psql_conn_count()
-            self.env.cr.commit()
-            self.env['runbot.repo']._update_git_config()
-            self.env.cr.commit()
-            self.git_gc()
-            self.env.cr.commit()
-        return self.env['runbot.runbot']._scheduler_loop_turn(self.host)
+        if self.host.is_registry or self.host.is_builder:
+            last_docker_updates = self.env['runbot.dockerfile'].search([('to_build', '=', True)]).mapped('write_date')
+            if self.count == 1 or self.last_docker_updates != last_docker_updates:
+                self.last_docker_updates = last_docker_updates
+                self.host._docker_update_images()
+                self.env.cr.commit()
+        if self.host.is_builder:
+            if self.count == 1:  # cleanup at second iteration
+                self.env['runbot.runbot']._source_cleanup()
+                self.env.cr.commit()
+                self.env['runbot.build']._local_cleanup()
+                self.env.cr.commit()
+                self.env['runbot.runbot']._docker_cleanup()
+                self.env.cr.commit()
+                self.host._set_psql_conn_count()
+                self.env.cr.commit()
+                self.env['runbot.repo']._update_git_config()
+                self.env.cr.commit()
+                self.git_gc()
+                self.env.cr.commit()
+            return self.env['runbot.runbot']._scheduler_loop_turn(self.host)
+        return 10
 
 
 if __name__ == '__main__':

--- a/runbot_builder/leader.py
+++ b/runbot_builder/leader.py
@@ -5,6 +5,7 @@ import time
 
 _logger = logging.getLogger(__name__)
 
+
 class LeaderClient(RunbotClient):  # Conductor, Director, Main, Maestro, Lead
     def __init__(self, env):
         self.pull_info_failures = {}
@@ -18,6 +19,9 @@ class LeaderClient(RunbotClient):  # Conductor, Director, Main, Maestro, Lead
             _logger.info('update finished')
 
     def loop_turn(self):
+        if not self.host.is_leader:
+            _logger.warning('Leader client is not a leader host, skipping loop_turn')
+            return 10
         if self.count == 0:
             self.env['runbot.repo']._update_git_config()
             self.env.cr.commit()

--- a/runbot_builder/main.py
+++ b/runbot_builder/main.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+from tools import run
+from builder import BuilderClient
+from leader import LeaderClient
+
+
+class MainClient(LeaderClient, BuilderClient):
+    def on_start(self):
+        if self.host.is_leader:
+            LeaderClient.on_start(self)
+        if self.host.is_builder or self.host.is_registry:
+            BuilderClient.on_start(self)
+
+    def loop_turn(self):
+        sleeps = [10]
+        if self.host.is_leader:
+            sleeps.append(LeaderClient.loop_turn(self))
+        if self.host.is_builder or self.host.is_registry:
+            sleeps.append(BuilderClient.loop_turn(self))
+        return min(sleeps)
+
+
+if __name__ == '__main__':
+    run(MainClient)

--- a/runbot_builder/tools.py
+++ b/runbot_builder/tools.py
@@ -30,7 +30,7 @@ class RunbotClient():
     def __init__(self, env):
         self.env = env
         self.ask_interrupt = threading.Event()
-        self.host = None
+        self.host = self.env['runbot.host']._get_current()
         self.count = 0
         self.max_count = 60
 


### PR DESCRIPTION
This pr mainly targets to allow to run the leader/builder/docker registry on the same machine

This is a partial work that will be further improved in 19.0