### PR TITLE
[IMP] runbot: reduce main page size

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -25,9 +25,7 @@ def route(routes, **kw):
         def response_wrap(*args, **kwargs):
             projects = request.env['runbot.project'].search([('hidden', '=', False)])
             more = request.httprequest.cookies.get('more', False) == '1'
-            filter_mode = request.httprequest.cookies.get('filter_mode', 'all')
-            keep_search = request.httprequest.cookies.get('keep_search', False) == '1'
-            cookie_search = request.httprequest.cookies.get('search', '')
+            filter_mode = request.httprequest.cookies.get('filter_mode', 'default')
             refresh = kwargs.get('refresh', False)
             nb_build_errors = request.env['runbot.build.error'].search_count([])
             nb_assigned_errors = request.env['runbot.build.error'].search_count([('responsible', '=', request.env.user.id)])
@@ -37,20 +35,13 @@ def route(routes, **kw):
 
             response = f(*args, **kwargs)
             if isinstance(response, Response):
-                if keep_search and cookie_search and 'search' not in kwargs:
-                    search = cookie_search
-                else:
-                    search = kwargs.get('search', '')
+                search = kwargs.get('search', '')
                 has_pr = kwargs.get('has_pr', None)
-                if keep_search and cookie_search != search:
-                    response.set_cookie('search', search)
-
                 project = response.qcontext.get('project') or projects and projects[0]
 
                 response.qcontext['theme'] = kwargs.get('theme', request.httprequest.cookies.get('theme', 'legacy'))
                 response.qcontext['projects'] = projects
                 response.qcontext['more'] = more
-                response.qcontext['keep_search'] = keep_search
                 response.qcontext['search'] = search
                 response.qcontext['current_path'] = request.httprequest.full_path
                 response.qcontext['refresh'] = refresh
@@ -85,10 +76,10 @@ class Runbot(Controller):
     @o_route([
         '/runbot/submit'
     ], type='http', auth="public", methods=['GET', 'POST'], csrf=False)
-    def submit(self, more=False, redirect='/', keep_search=False, category=False, filter_mode=False, update_triggers=False, **kwargs):
+    def submit(self, more=False, redirect='/', update_triggers=False, **kwargs):
         assert redirect.startswith('/')
         response = werkzeug.utils.redirect(redirect)
-        response.set_cookie('more', '1' if more else '0')
+        response.set_cookie('more', '1' if more else '0', expires=datetime.datetime.now() + datetime.timedelta(days=365 * 10))
         if update_triggers:
             enabled_triggers = []
             project_id = int(update_triggers)
@@ -97,10 +88,12 @@ class Runbot(Controller):
                     enabled_triggers.append(key.replace('trigger_', ''))
 
             key = 'trigger_display_%s' % project_id
-            if len(request.env['runbot.trigger'].search([('project_id', '=', project_id)])) == len(enabled_triggers):
+            default_trigger_ids = set(request.env['runbot.trigger'].search([('hide', '=', False), ('project_id', '=', project_id), ('manual', '=', False)]).ids)
+            selected_trigger_ids = set(map(int, enabled_triggers))
+            if default_trigger_ids == selected_trigger_ids:
                 response.delete_cookie(key)
             else:
-                response.set_cookie(key, '-'.join(enabled_triggers))
+                response.set_cookie(key, '-'.join(enabled_triggers), expires=datetime.datetime.now() + datetime.timedelta(days=365 * 10))
         return response
 
     @route(['/',
@@ -133,11 +126,13 @@ class Runbot(Controller):
             if has_pr is not None:
                 domain.append(('has_pr', '=', bool(has_pr)))
 
-            filter_mode = request.httprequest.cookies.get('filter_mode', False)
+            filter_mode = request.httprequest.cookies.get('filter_mode', 'default')
             if filter_mode == 'sticky':
                 domain.append(('sticky', '=', True))
             elif filter_mode == 'nosticky':
                 domain.append(('sticky', '=', False))
+            elif filter_mode == 'default' and not search:
+                domain.append(('sticky', '=', True))
 
             if for_next_freeze:
                 domain.append(('for_next_freeze', '=', True))

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -62,3 +62,4 @@ class Category(models.Model):
     name = fields.Char("Name")
     icon = fields.Char("Font awesome icon")
     view_id = fields.Many2one('ir.ui.view', "Link template")
+    active = fields.Boolean('active', default=True)

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -70,12 +70,12 @@
             <div class="build_details">
               <!-- Batch/bundles links-->
               <t t-if="len(bundles) > 1">
-                This build is referenced in <t t-out="len(bundles)"/> bundles
-                <ul>
+                This build is referenced in <t t-out="len(bundles)"/> bundles<br/>
+                <ul groups="base.group_user">
                   <li t-foreach="bundles" t-as="bundle" ><a t-out="bundle.name" t-attf-href="/runbot/bundle/{{bundle.id}}"/></li>
                 </ul>
               </t>
-              <t t-if="len(batches) > 1">
+              <t t-if="len(batches) > 1" groups="base.group_user">
                 <b>First apparition:</b> <a t-out="batches[0].bundle_id.name" t-attf-href="/runbot/batch/{{batches[0].id}}"/><br/>
                 <b>Last apparition:</b> <a t-out="batches[-1].bundle_id.name" t-attf-href="/runbot/batch/{{batches[-1].id}}"/><br/>
               </t>

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -71,6 +71,7 @@
                                         </t>
                                     </t>
                                     <li class="nav-item divider"/>
+                                    
                                     <li class="nav-item dropdown">
                                         <a data-bs-toggle="collapse" href="#collapsePreference" role="button" class="nav-link">
                                             <i class="fa fa-gear"/>
@@ -109,36 +110,57 @@
                             </div>
                         </nav>
                     </header>
-                    <div id="collapsePreference" class="collapse">
-                        <form class="px-4 py-3" method="post" action="/runbot/submit" id="preferences_form">
-                            <input type="hidden" name="redirect" t-att-value="current_path"/>
-
-                            <hr class="separator"/>
-                            <div class="form-check form-switch">
-                                <input onclick="document.getElementById('preferences_form').submit()" class="form-check-input" type="checkbox" role="switch" id="more" name="more" t-att-checked="more"/>
-                                <label class="form-check-label" for="flexSwitchCheckDefault" >More info</label>
-                            </div>
-
-                            <hr class="separator"/>
-                            <div class="text-nowrap btn-group btn-group-sm" role="group">
-                                <button onclick="document.cookie = 'theme=legacy; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='legacy' else 'secondary'}}">Legacy</button>
-                                <button onclick="document.cookie = 'theme=dark; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='dark' else 'secondary'}}">Dark</button>
-                                <button onclick="document.cookie = 'theme=light; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='light' else 'secondary'}}">Light</button>
-                                <button onclick="document.cookie = 'theme=red404; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='red404' else 'secondary'}}">Red404</button>
-                            </div>
-
-                            <hr class="separator"/>
-                            <div class="text-nowrap btn-group btn-group-sm" role="group">
+                    <t t-set="not_default_category" t-value="active_category_id and default_category != active_category_id"/>
+                    <t t-set="not_default_filter_mode" t-value="filter_mode and filter_mode not in ('default', 'all')"/>
+                    <div class="container-fluid" t-if="not_default_category or not_default_filter_mode">
+                    <div class="row">
+                        <div class="col-12">
+                            <t t-if="not_default_category">
+                                <div class="text-nowrap btn-group btn-group-sm" role="group">
+                                    <t t-foreach="categories" t-as="category">
+                                        <button t-attf-onclick="document.cookie = 'category={{category.id}}; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if category.id == active_category_id else 'secondary'}}" t-out="category.name"/>
+                                    </t>
+                                </div>
+                            </t>
+                            <div t-if="not_default_filter_mode" class="text-nowrap btn-group btn-group-sm" role="group">
+                                <button onclick="document.cookie = 'filter_mode=default; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='default' else 'secondary'}}" help="Only display sticky except if searching">Default</button>
                                 <button onclick="document.cookie = 'filter_mode=all; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='all' else 'secondary'}}">All</button>
                                 <button onclick="document.cookie = 'filter_mode=sticky; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='sticky' else 'secondary'}}">Sticky only</button>
                                 <button onclick="document.cookie = 'filter_mode=nosticky; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='nosticky' else 'secondary'}}">Dev only</button>
                             </div>
-
-                            <div class="text-nowrap btn-group btn-group-sm" role="group">
+                        </div>
+                    </div></div>
+                    <div id="collapsePreference" class="collapse">
+                        <form class="px-4 py-3" method="post" action="/runbot/submit" id="preferences_form">
+                            <input type="hidden" name="redirect" t-att-value="current_path"/>
+                            <div>
+                                <div class="form-check form-switch">
+                                <input onclick="document.getElementById('preferences_form').submit()" class="form-check-input" type="checkbox" role="switch" id="more" name="more" t-att-checked="more"/>
+                                <label class="form-check-label" >More info</label>
+                            </div></div>
+                            <div> 
+                                <label for="theme_selection" style="min-width: 80px">Theme:</label>
+                                <div id="theme_selection" class="text-nowrap btn-group btn-group-sm" role="group">
+                                <button onclick="document.cookie = 'theme=legacy; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='legacy' else 'secondary'}}">Legacy</button>
+                                <button onclick="document.cookie = 'theme=dark; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='dark' else 'secondary'}}">Dark</button>
+                                <button onclick="document.cookie = 'theme=light; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='light' else 'secondary'}}">Light</button>
+                                <button onclick="document.cookie = 'theme=red404; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if theme=='red404' else 'secondary'}}">Red404</button>
+                            </div></div>
+                            <div>
+                                <label for="theme_selection" style="min-width: 80px">Sticky:</label>
+                                <div class="text-nowrap btn-group btn-group-sm" role="group">
+                                <button onclick="document.cookie = 'filter_mode=default; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='default' else 'secondary'}}" help="Only display sticky except if searching">Default</button>
+                                <button onclick="document.cookie = 'filter_mode=all; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='all' else 'secondary'}}">All</button>
+                                <button onclick="document.cookie = 'filter_mode=sticky; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='sticky' else 'secondary'}}">Sticky only</button>
+                                <button onclick="document.cookie = 'filter_mode=nosticky; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if filter_mode=='nosticky' else 'secondary'}}">Dev only</button>
+                            </div></div>
+                            <div>
+                                <label for="theme_selection" style="min-width: 80px">Category:</label>
+                                <div class="text-nowrap btn-group btn-group-sm" role="group">
                                 <t t-foreach="categories" t-as="category">
                                     <button t-attf-onclick="document.cookie = 'category={{category.id}}; expires=Thu, 1 Dec 2942 12:00:00 UTC; path=/'; location.reload();" type="button" t-attf-class="btn btn-{{'primary' if category.id == active_category_id else 'secondary'}}" t-out="category.name"/>
                                 </t>
-                            </div>
+                            </div></div>
         
                             <hr class="separator"/>
                             <div t-if="triggers">
@@ -150,7 +172,7 @@
                                         <div class="row">
                                             <t t-foreach="category_triggers" t-as="trigger">
                                                 <div class="col-md-3 text-nowrap">
-                                                    <input t-attf-class="trigger_selection {{'trigger_selection_hide' if trigger.hide else 'trigger_selection_show'}}" type="checkbox" t-attf-name="trigger_{{trigger.id}}" t-attf-id="trigger_{{trigger.id}}" t-att-checked="trigger_display is None or trigger.id in trigger_display"/>
+                                                    <input t-attf-class="trigger_selection {{'trigger_selection_hide' if trigger.hide else 'trigger_selection_show'}}" type="checkbox" t-attf-name="trigger_{{trigger.id}}" t-attf-id="trigger_{{trigger.id}}" t-att-checked="not trigger.hide if trigger_display is None else trigger.id in trigger_display"/>
                                                     <label t-attf-for="trigger_{{trigger.id}}" t-out="trigger.name"/>
                                                 </div>
                                             </t>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -142,6 +142,7 @@
                 <field name="name"/>
                 <field name="icon"/>
                 <field name="view_id"/>
+                <field name="active"/>
               </group>
             </sheet>
           </form>


### PR DESCRIPTION
The main page will display the latest dev branches witch is not useful for most users. This is also a cause of excessive load on the server when the main page is crawled (many reachable links).

This commit removes the dev branches from the main page as well as the other bundle containing a branch.
This commit also adds an option to see all bundle to restore the previous behaviour. While on it, fixing the config menu:
- add a expires on the server side seted cookies to avoid loosing the configuration after closing the browser.
- fixes the triggers_ids selection to avoid displaying all of them when going into more models
- remove the trigger id cookie if the selected ones are the default ones
- allow to archive a category to hide it in the interface when not in use.