### PR TITLE
[FIX] runbot: fix threehash export date

### DIFF
--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -124,8 +124,10 @@ class Commit(models.Model):
 
         export_sha = export_commit.tree_hash
 
-        p1 = subprocess.Popen(['git', '--git-dir=%s' % self.repo_id.path, 'archive', export_sha], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
-        p2 = subprocess.Popen(['tar', '--mtime', self.date.strftime('%Y-%m-%d %H:%M:%S'), '-xC', export_path], stdin=p1.stdout, stdout=subprocess.PIPE)
+        p1 = subprocess.Popen(['git', '--git-dir=%s' % self.repo_id.path, 'archive', export_sha, '--mtime', self.date.strftime('%Y-%m-%d %H:%M:%S')], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(['tar', '-xC', export_path], stdin=p1.stdout, stdout=subprocess.PIPE)
+
+
         p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
         (_, err) = p2.communicate()
         p1.poll()  # fill the returncode


### PR DESCRIPTION
The export date of the commit was broken since we are exporting threehash instead of commit.

The main reason is that the initiall --mtime never worked, changing the -xmC to -xC was the only needed change since git archive will set the mtime of the file to the commit date by default.

To fix this issue, we need to add a --mtime on the git archive command

Note that since commit date are used, it is still possible to have a date missmatch, since the first commit to export will set the date.

To fix this we may need to fix a more apropriate date, to define.

Note that issue already exist when restoring a database from another branch (multi split, ...)

We should either use a filehash (cashed by date) when computing the asset bundle hash, or export with the last file modification date if possible