### PR TITLE
[IMP] runbot: allow to search other errors impacted by tags

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -16,7 +16,8 @@ from collections import OrderedDict
 from datetime import timedelta
 from markupsafe import Markup
 
-from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, file_open, html_escape
+from odoo.osv import expression
+from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, file_open, html_escape, OrderedSet
 
 _logger = logging.getLogger(__name__)
 
@@ -287,3 +288,70 @@ class ReProxy():
 
     VERBOSE = re.VERBOSE
     MULTILINE = re.MULTILINE
+
+
+# Based on Odoo TagsSelector from master on 2025-06-13
+class TestTagsParser:
+    filter_spec_re = re.compile(r'''
+                                ^
+                                ([+-]?)                     # operator_re
+                                (\*|\w*)                    # tag_re
+                                (\/[\w\/\.-]+.py)?           # file_re
+                                (?:\/(\w+))?                # module_re
+                                (?::(\w*))?                 # test_class_re
+                                (?:\.(\w*))?                # test_method_re
+                                (?:\[(.*)\])?               # parameters
+                                $''', re.VERBOSE)  # [-][tag][/module][:class][.method][[params]]
+
+    def __init__(self, test_tags):
+        parts = re.split(r',(?![^\[]*\])', test_tags)  # split on all comma not inside [] (not followed by ])
+        filter_specs = [t.strip() for t in parts if t.strip()]
+        self.exclude = set()
+        self.include = set()
+        self.parameters = OrderedSet()
+
+        for filter_spec in filter_specs:
+            match = self.filter_spec_re.match(filter_spec)
+            if not match:
+                _logger.error('Invalid tag %s', filter_spec)
+                continue
+
+            sign, tag, file_path, module, klass, method, parameters = match.groups()
+            is_include = sign != '-'
+            is_exclude = not is_include
+
+            if not tag and is_include:
+                # including /module:class.method implicitly requires 'standard'
+                tag = 'standard'
+            elif not tag or tag == '*':
+                # '*' indicates all tests (instead of 'standard' tests only)
+                tag = None
+            test_filter = (tag, module, klass, method, file_path)
+
+            if parameters:
+                # we could check here that test supports negated parameters
+                self.parameters.add((test_filter, ('-' if is_exclude else '+', parameters)))
+                is_exclude = False
+
+            if is_include:
+                self.include.add(test_filter)
+            if is_exclude:
+                self.exclude.add(test_filter)
+
+        if (self.exclude or self.parameters) and not self.include:
+            self.include.add(('standard', None, None, None, None))
+
+    def test_tags_to_search_domain(self, exclude_error_id=None):
+        search_domains = []
+        for include in self.include:
+            _, test_module, test_class, test_method, file_path = include
+            module_path = file_path or ((test_module or '') + '%')
+            test_class = test_class or '%'
+            test_method = test_method or '%'
+            search_pattern = f'{module_path}:{test_class}.{test_method}'
+            tag_domain = [('canonical_tags', 'like', f'{search_pattern}')]
+            if exclude_error_id:
+                tag_domain.append(('id', '!=', exclude_error_id))
+            search_domains.append(tag_domain)
+        search_domain = expression.OR(search_domains)
+        return search_domain

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -18,7 +18,7 @@ from odoo.tools import SQL, lazy
 from odoo.osv import expression
 
 from ..fields import JsonDictField
-from ..common import transactioncache
+from ..common import transactioncache, TestTagsParser
 
 _logger = logging.getLogger(__name__)
 
@@ -197,6 +197,7 @@ class BuildError(models.Model):
 
     test_tags = fields.Char(string='Test tags', help="Comma separated list of test_tags to use to reproduce/remove this error", tracking=True)
     canonical_tags = fields.Char('Canonical tag', compute='_compute_canonical_tags', store=True)
+    tags_match_count = fields.Integer('Nb errors matching the test_tags', compute='_compute_tags_match_count')
     tags_min_version_excluded_id = fields.Many2one('runbot.version', 'Tag min version (excluded)')
     tags_min_version_id = fields.Many2one('runbot.version', 'Tags Min version', compute="_compute_tags_min_version_id", inverse="_inverse_tags_min_version_id", help="Minimal version where the test tags will be applied.", tracking=True)
     tags_max_version_id = fields.Many2one('runbot.version', 'Tags Max version', help="Maximal version where the test tags will be applied.", tracking=True)
@@ -358,6 +359,29 @@ class BuildError(models.Model):
                 record.analogous_content_ids = self.env['runbot.build.error.content'].browse([rec[0] for rec in self.env.cr.fetchall()])
             else:
                 record.analogous_content_ids = False
+
+    @api.depends('test_tags')
+    def _compute_tags_match_count(self):
+        for record in self:
+            record.tags_match_count = 0
+            if record.test_tags:
+                tags_parser = TestTagsParser(record.test_tags)
+                search_domain = tags_parser.test_tags_to_search_domain(exclude_error_id=record.id)
+                if search_domain:
+                    record.tags_match_count = self.env['runbot.build.error'].search_count(search_domain)
+
+    def action_view_impacted_by_tag(self):
+        self.ensure_one()
+        if not self.test_tags:
+            return
+        tags_parser = TestTagsParser(self.test_tags)
+        return {
+            'type': 'ir.actions.act_window',
+            'views': [(False, 'list'), (False, 'form')],
+            'res_model': 'runbot.build.error',
+            'domain': tags_parser.test_tags_to_search_domain(exclude_error_id=self.id),
+            'name': 'Other Errors impacted by test-tag'
+        }
 
     @api.constrains('test_tags')
     def _check_test_tags(self):

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -55,7 +55,13 @@
               </group>
               <group name="test_tags_group" string="Disabling">
                 <field name="canonical_tags" class="text-nowrap overflow-x-auto"/>
-                <button name="action_copy_canonical_tag" type="object" groups="runbot.group_runbot_admin">Disable test using canonical tag</button>
+                <div />
+                <div name="button_box">
+                  <button name="action_copy_canonical_tag" type="object" groups="runbot.group_runbot_admin">Disable test using canonical tag</button>
+                  <button name="action_view_impacted_by_tag" type="object" class="oe_stat_button" invisible="tags_match_count == 0" title="View other errors impacted by test tags" icon="fa-list">
+                      <span class="o_stat_text text-danger"><field name="tags_match_count" string="Other impacted errors" widget="statinfo"/></span>
+                  </button>
+                </div>
                 <field name="test_tags" decoration-danger="True" readonly="1" groups="!runbot.group_runbot_admin"/>
                 <field name="test_tags" decoration-danger="True" groups="runbot.group_runbot_admin"/>
                 <field name="tags_min_version_id" invisible="not test_tags" options="{'no_create': True, 'no_create_edit':True}"/>


### PR DESCRIPTION
When re-enabling errors, one have to ensure that other errors are not impacted by the test-tag.

With this commit, a button is added on the build error view form in order to show the number of errors impacted by the current test-tag and when clicked, displays them.