### PR TITLE
[IMP] runbot: allow to use the faketime tool

### DIFF
--- a/runbot/data/dockerfile_data.xml
+++ b/runbot/data/dockerfile_data.xml
@@ -62,7 +62,7 @@
         <field name="dockerfile_id" ref="runbot.docker_default"/>
         <field name="layer_type">reference_layer</field>
         <field name="name">Install base debian packages</field>
-        <field name="packages">apt-transport-https build-essential ca-certificates curl file fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release npm ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev</field>
+        <field name="packages">apt-transport-https build-essential ca-certificates curl faketime file fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release npm ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev</field>
         <field name="reference_docker_layer_id" ref="runbot.docker_layer_debian_packages_template"/>
     </record>
 

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1116,12 +1116,16 @@ class BuildResult(models.Model):
                     requirement_path = os.sep.join([repo_dir, 'requirements.txt'])
                     pres.append([f'python{py_version}', '-m', 'pip', 'install', '--progress-bar', 'off', '-r', f'{requirement_path}'])
 
+        faketime = []
+        if faketime_params := self.params_id.config_data.get('faketime'):
+            faketime = ['faketime', faketime_params]
+
         addons_paths = self._get_addons_path()
         (server_commit, server_file) = self._get_server_info()
         server_dir = self._docker_source_folder(server_commit)
 
         # commandline
-        cmd = ['python%s' % py_version] + python_params + [os.sep.join([server_dir, server_file])]
+        cmd = faketime + ['python%s' % py_version] + python_params + [os.sep.join([server_dir, server_file])]
         if sub_command:
             cmd += [sub_command]
 

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -680,6 +680,20 @@ class TestBuildResult(RunbotCase):
         self.assertEqual('done', build1_1_1.global_state)
         self.assertEqual('done', rebuild1_1_1.global_state)
 
+    def test_build_cmd_faketime(self):
+        """ test that the faketime command is properly added"""
+        self.server_params.config_data = {
+            'skip_requirements': True,
+            'faketime': '2024-02-04 02:42 UTC',
+        }
+        self.env.flush_all()
+        build = self.Build.create({
+            'params_id': self.server_params.id,
+        })
+        cmd = build._cmd(py_version=3)
+        self.assertIn('faketime "2024-02-04 02:42 UTC" python3 server/server.py', str(cmd))
+
+
 class TestGc(RunbotCaseMinimalSetup):
 
     def test_repo_gc_testing(self):

--- a/runbot/tests/test_dockerfile.py
+++ b/runbot/tests/test_dockerfile.py
@@ -37,7 +37,7 @@ ENV LANG C.UTF-8
 USER root
 RUN set -x ; \
     apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-transport-https build-essential ca-certificates curl file fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release npm ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-transport-https build-essential ca-certificates curl faketime file fonts-freefont-ttf fonts-noto-cjk gawk gnupg gsfonts libldap2-dev libjpeg9-dev libsasl2-dev libxslt1-dev lsb-release npm ocrmypdf sed sudo unzip xfonts-75dpi zip zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN set -x ; \
     apt-get update \


### PR DESCRIPTION
This commit allows to use the `faketime` command line tool to simulate a build at fake date and/or time.

This can be done by passing a config_data like:

`
{
    'faketime': '2024-06-01 02:42 UTC'
}
`

Note that runbot will not suport advanced timestamp specification format but only the simple DATESTRING format of the `/bin/date` utility.

Pay attention that this will only alter the datetime of the executed Python code and its subprocesses, the postgresql server is not affected by the faketime tool.

See:
- https://manpages.ubuntu.com/manpages/noble/man1/faketime.1.html
- https://manpages.ubuntu.com/manpages/questing/en/man1/date.1.html