### PR TITLE
[IMP] runbot: allow to disable docker network

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -234,7 +234,7 @@ def docker_run(*args, **kwargs):
     return _docker_run(*args, **kwargs)
 
 
-def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, cpu_period=100000, cpus=0, memory=None, preexec_fn=None, ro_volumes=None, env_variables=None):
+def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, cpu_period=100000, cpus=0, memory=None, preexec_fn=None, ro_volumes=None, env_variables=None, network_enabled=True):
     """Run tests in a docker container
     :param run_cmd: command string to run in container
     :param log_path: path to the logfile that will contain odoo stdout and stderr
@@ -248,6 +248,7 @@ def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False
     :param memory: memory limit in bytes for the container
     :params ro_volumes: dict of dest:source volumes to mount readonly in builddir
     :params env_variables: list of environment variables
+    :params network_enabled: enable network boolean.
     """
     assert cmd and log_path and build_dir and container_name
     image_tag = image_tag or 'odoo:DockerDefault'
@@ -306,6 +307,7 @@ def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False
         auto_remove=True,
         detach=True,
         user=USERNAME,
+        network_disabled=not network_enabled,
     )
     if container.status not in ('running', 'created') :
         _logger.error('Container %s started but status is not running or created:  %s', container_name, container.status)

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -874,6 +874,10 @@ class BuildResult(models.Model):
 
         self._log('Preparing', 'Using Dockerfile Tag [%s](/runbot/dockerfile_result/%s/%s)', kwargs['image_tag'], kwargs['image_tag'], image_id, log_type='markdown')
 
+        if not kwargs.get('network_enabled', False):
+            # we don't check config data if we explicitely enable the network (e.g.: restore step)
+            kwargs['network_enabled'] = self.params_id.config_data.get('network_enabled', kwargs.get('network_enabled', True))
+
         containers_memory_limit = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_memory', 0)
         if containers_memory_limit and 'memory' not in kwargs:
             kwargs['memory'] = int(float(containers_memory_limit) * 1024 ** 3)

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -880,7 +880,7 @@ class ConfigStep(models.Model):
 
             ])
 
-        return dict(cmd=cmd)
+        return dict(cmd=cmd, network_enabled=True)
 
     def _reference_builds(self, batch, trigger):
         upgrade_dumps_trigger_id = trigger.upgrade_dumps_trigger_id

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -779,6 +779,49 @@ def run():
         self.assertNotIn('--with-demo', cmd)
         self.assertIn('--without-demo', cmd)
 
+    @patch('odoo.addons.runbot.models.build.BuildResult._checkout')
+    def test_network_can_be_disabled(self, mock_checkout):
+        """ test that network can be disabled with config_data """
+        config_step = self.ConfigStep.create({
+            'name': 'default',
+            'job_type': 'install_odoo',
+        })
+
+        # by default, network is enabled (will be changed in a near future)
+        def first_docker_run(cmd, log_path, *args, **kwargs):
+            self.assertTrue(kwargs['network_enabled'])
+
+        self.patchers['docker_run'].side_effect = first_docker_run
+        config_step._run_step(self.parent_build)()
+
+        def second_docker_run(cmd, log_path, *args, **kwargs):
+            self.assertFalse(kwargs['network_enabled'])
+
+        self.patchers['docker_run'].side_effect = second_docker_run
+
+        parent_build_params = self.parent_build.params_id.copy({'config_data': {'network_enabled': False}})
+        parent_build = self.parent_build.copy({'params_id': parent_build_params.id})
+        config_step._run_step(parent_build)()
+
+
+    @patch('odoo.addons.runbot.models.build.BuildResult._checkout')
+    def test_run_python_networkcan_be_disabled(self, mock_checkout):
+        """test that docker network can be disabled from python step"""
+        test_code = """cmd = build._cmd()
+docker_params = dict(cmd=cmd, network_enabled=False)
+        """
+        config_step = self.ConfigStep.create({
+            'name': 'default',
+            'job_type': 'python',
+            'python_code': test_code,
+        })
+
+        def docker_run(cmd, *args, **kwargs):
+            self.assertFalse(kwargs['network_enabled'])
+
+        self.patchers['docker_run'].side_effect = docker_run
+        config_step._run_step(self.parent_build)()
+
 class TestMakeResult(RunbotCase):
 
     def setUp(self):


### PR DESCRIPTION
In order to isolate runbot builds, this commit adds the possibility to start a docker container with the network disabled.