### PR TITLE
[FIX] runbot: fix running builds to always enable network

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -426,7 +426,7 @@ class ConfigStep(models.Model):
         except Exception:
             _logger.exception('An error occured while reloading nginx')
             build._log('', "An error occured while reloading nginx, skipping")
-        return dict(cmd=cmd, exposed_ports=[build_port, build_port + 1], ro_volumes=exports, env_variables=env_variables, cpu_limit=None)
+        return dict(cmd=cmd, exposed_ports=[build_port, build_port + 1], ro_volumes=exports, env_variables=env_variables, cpu_limit=None, network_enabled=True)
 
     def _run_install_odoo(self, build):
         exports = build._checkout()

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -96,7 +96,7 @@
         <field name="name">runbot.dockerfile.list</field>
         <field name="model">runbot.dockerfile</field>
         <field name="arch" type="xml">
-          <list string="Dockerfile" decoration-danger="dockerfile == '' or image_identifier != image_future_identifier" decoration-warning="in_error == True">
+          <list string="Dockerfile" decoration-danger="dockerfile == '' or in_error == True" decoration-warning="image_identifier != image_future_identifier">
             <field name="image_tag"/>
             <field name="name"/>
             <field name="parent_id"/>


### PR DESCRIPTION
The running builds should always have the network enabled.

Also, while at it:
[FIX] runbot: fix colors in docker tree view
