### PR TITLE
[IMP] runbot: change disabled network strategy

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -307,7 +307,7 @@ def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False
         auto_remove=True,
         detach=True,
         user=USERNAME,
-        network_disabled=not network_enabled,
+        network_mode=None if network_enabled else 'none'
     )
     if container.status not in ('running', 'created') :
         _logger.error('Container %s started but status is not running or created:  %s', container_name, container.status)


### PR DESCRIPTION
When using the argument `network_disabled` from the python docker interface, the `/etc/hosts` file is empty in the container and cannot even be filled with the `extra_hosts` parameter. In this situtation, the processes in the container are not able to resolve `localhost`.

With this commit, the `network_mode` is used instead. With this method, the `/etc/hosts` file is properly filled.

Notes:
- The `/etc/hosts` file cannot be manipulated at the build time of the image as it's used by Docker itself during build process.
- The file cannot be filled at runtime as it needs to be the root user.