### PR TITLE
[FIX] runbot: fix restore on temporary dns failures

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -862,7 +862,7 @@ class ConfigStep(models.Model):
         cmd = ' && '.join([
             'mkdir /data/build/restore',
             'cd /data/build/restore',
-            'wget %s' % dump_url,
+            'wget --retry-on-host-error %s' % dump_url,
             'unzip -q %s' % zip_name,
             'echo "### restoring filestore"',
             'mkdir -p /data/build/datadir/filestore/%s' % restore_db_name,

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -271,7 +271,7 @@ class TestBuildConfigStepRestore(TestBuildConfigStepCommon):
 
         docker_params = self.restore_config_step._run_restore(dev_build)
         cmds = docker_params['cmd'].split(' && ')
-        self.assertEqual(f'wget https://False/runbot/static/build/{reference_build.dest}/logs/{reference_build.dest}-suffix.zip', cmds[2])
+        self.assertEqual(f'wget --retry-on-host-error https://False/runbot/static/build/{reference_build.dest}/logs/{reference_build.dest}-suffix.zip', cmds[2])
         self.assertEqual(f'psql -q {dev_build.dest}-suffix < dump.sql', cmds[8])
         self.called=True
 

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -457,7 +457,7 @@ class TestUpgradeFlow(RunbotCase):
                     [
                         'mkdir /data/build/restore',
                         'cd /data/build/restore',
-                        f'wget {dump_url}',
+                        f'wget --retry-on-host-error {dump_url}',
                         f'unzip -q {zip_name}',
                         'echo "### restoring filestore"',
                         f'mkdir -p /data/build/datadir/filestore/{db_name}',


### PR DESCRIPTION
From times to times, it happens that a host has a temporary dns failure causing the restore step to fail.

With this commit, we add the `--retry-on-host-error` to the wget command which is designed for such a case. It will retry up to 20 times and will increase the waiting time between each time by one second up to 10 seconds.