### PR TITLE
[IMP] runbot: differentiate the copy from the original

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -68,6 +68,7 @@ class Config(models.Model):
         # remove protection on copy
         copy = super(Config, self).copy()
         copy.sudo().write({'protected': False})
+        copy.name = f'{self.name} (copy)'
         return copy
 
     @api.depends('step_order_ids.sequence', 'step_order_ids.step_id')


### PR DESCRIPTION
When duplicating a config, the new config has the same name. This is very confusing in the interface that may lead to mistakes. With this commit, `(copy)' is appended to the name of the copy.