### PR TITLE
[IMP] OverrideRights: add helper method to extract partner_ids from commands

### DIFF
--- a/runbot_merge/models/res_partner.py
+++ b/runbot_merge/models/res_partner.py
@@ -4,7 +4,6 @@ from email.utils import parseaddr
 
 from markupsafe import Markup
 
-import odoo.tools
 from odoo import fields, models, tools, api, Command
 
 from .. import github
@@ -189,18 +188,13 @@ class OverrideRights(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        for partner, contexts in odoo.tools.groupby((
-            (partner_id, vals['context'], vals['repository_id'])
-            for vals in vals_list
-            # partner_ids is of the form [Command.set(ids)
-            for partner_id in vals.get('partner_ids', [(None, None, [])])[0][2]
-        ), lambda p: p[0]):
-            partner = self.env['res.partner'].browse(partner)
-            for _, context, repository in contexts:
-                repository = self.env['runbot_merge.repository'].browse(repository)
-                partner._message_log(body=f"added override rights for {context!r} on {repository.name}")
-
-        return super().create(vals_list)
+        records = super().create(vals_list)
+        for rec in records:
+            for partner in rec.partner_ids:
+                partner._message_log(
+                    body=f"added override rights for {rec.context!r} on {rec.repository_id.name}"
+                )
+        return records
 
     def write(self, vals):
         if 'partner_ids' in vals:


### PR DESCRIPTION
Before this PR, the create and write methods assumed that partner_ids would always be passed using a Command.SET. This caused issues when other types of Odoo commands (e.g., Command.LINK, Command.CREATE, etc.) were used — leading to errors during override rights assignment (see attached gif).

### Refactoring for partner ID extraction:

* [`runbot_merge/models/res_partner.py`](diffhunk://#diff-17930401fd68f04bea38c6138bce8862b47bf1e9c93985d01589f2f5a9d118e1R175-R192): Added a new helper method `get_partner_ids` to encapsulate the logic for extracting partner IDs from Odoo commands. This method handles various command types (`SET`, `LINK`, `UNLINK`) and ensures cleaner code.

### Updates to `create` and `write` methods:

* [`runbot_merge/models/res_partner.py`](diffhunk://#diff-17930401fd68f04bea38c6138bce8862b47bf1e9c93985d01589f2f5a9d118e1R198-R199): Updated the `create` method to use the new `get_partner_ids` helper for extracting partner IDs, replacing the inline logic with a call to the helper method.
* [`runbot_merge/models/res_partner.py`](diffhunk://#diff-17930401fd68f04bea38c6138bce8862b47bf1e9c93985d01589f2f5a9d118e1R209-L195): Modified the `write` method to use the `get_partner_ids` helper for handling partner ID updates, ensuring consistency and reducing code duplication.

![Steps to reproduce the error](https://github.com/user-attachments/assets/0250a7dd-45b0-4ac6-8171-460cbebb3df8)
