### PR TITLE
[IMP] runbot: faketime offset for children

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -11,6 +11,7 @@ import time
 import uuid
 
 from collections import defaultdict
+from dateutil import parser
 from pathlib import Path
 from psycopg2 import sql
 from psycopg2.extensions import TransactionRollbackError
@@ -1125,6 +1126,9 @@ class BuildResult(models.Model):
 
         faketime = []
         if faketime_params := self.params_id.config_data.get('faketime'):
+            if self.parent_id:
+                parent_time_offset = (self.parent_id.build_end or self.create_date) - self.parent_id.build_start
+                faketime_params = (parser.parse(faketime_params) + parent_time_offset).strftime('%Y-%m-%d %H:%M %Z')
             faketime = ['faketime', faketime_params]
 
         addons_paths = self._get_addons_path()

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -693,6 +693,17 @@ class TestBuildResult(RunbotCase):
         cmd = build._cmd(py_version=3)
         self.assertIn('faketime "2024-02-04 02:42 UTC" python3 server/server.py', str(cmd))
 
+        # let's ensure that a time offset is added to a child build
+        build.build_start = datetime.datetime(2025, 1, 1, 12, 00)
+        child_build = build._add_child({})
+        child_build.create_date = datetime.datetime(2025, 1, 1, 13, 00)
+        child_cmd = child_build._cmd(py_version=3)
+        self.assertIn('faketime "2024-02-04 03:42 UTC" python3 server/server.py', str(child_cmd))
+
+        build.build_end = datetime.datetime(2025, 1, 1, 14, 00)
+        second_child = build._add_child({})
+        second_child_cmd = second_child._cmd(py_version=3)
+        self.assertIn('faketime "2024-02-04 04:42 UTC" python3 server/server.py', str(second_child_cmd))
 
 class TestGc(RunbotCaseMinimalSetup):
 


### PR DESCRIPTION
In order to make the "faketime" builds more realistic, a time offset is added to the children builds. This offset is based on the difference between the parent build creation date and the child build creation date.