### PR TITLE
[REM] runbot: remove get_duplicate features

### DIFF
--- a/runbot/data/error_link.xml
+++ b/runbot/data/error_link.xml
@@ -51,16 +51,7 @@
             records.action_assign()
         </field>
     </record>
-    <record model="ir.actions.server" id="action_deduplicate">
-        <field name="name">Deduplicate Error Contents</field>
-        <field name="model_id" ref="runbot.model_runbot_build_error_content" />
-        <field name="binding_model_id" ref="runbot.model_runbot_build_error_content" />
-        <field name="type">ir.actions.server</field>
-        <field name="state">code</field>
-        <field name="code">
-            records.action_deduplicate()
-        </field>
-    </record>
+
     <record model="ir.actions.server" id="action_view_build_errors">
         <field name="name">View build errors</field>
         <field name="model_id" ref="runbot.model_runbot_build"/>

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -890,11 +890,6 @@ class BuildErrorContent(models.Model):
             if not error.error_content_ids:
                 base_error._merge(error)
 
-    def _get_duplicates(self):
-        """ returns a list of lists of duplicates"""
-        domain = [('id', 'in', self.ids)] if self else []
-        return [r[1] for r in self._read_group(domain, ('fingerprint', 'canonical_tag'), ('id:array_agg'), [('id:count', '>', 1)])]
-
     def _qualify(self, vals=None):
         if vals is None:
             vals = self
@@ -965,26 +960,6 @@ class BuildErrorContent(models.Model):
         # this must be done in other iteration since filtered may fail because of unlinked records from _merge
         for errors_content_to_merge in to_merge:
             errors_content_to_merge._relink()
-
-    def action_deduplicate(self):
-        rg = self._get_duplicates()
-        for ids_list in rg:
-            self.env['runbot.build.error.content'].browse(ids_list)._relink()
-
-    def action_find_duplicates(self):
-        rg = self._get_duplicates()
-        duplicate_ids = []
-        for ids_lists in rg:
-            duplicate_ids += ids_lists
-
-        return {
-            "type": "ir.actions.act_window",
-            "res_model": "runbot.build.error.content",
-            "domain": [('id', 'in', duplicate_ids)],
-            "context": {"create": False, 'group_by': ['fingerprint', 'canonical_tag']},
-            "name": "Duplicate Error contents",
-            'view_mode': 'list,form',
-        }
 
     def action_qualify(self):
         self._qualify()

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -384,7 +384,6 @@
                   expand="1"
                   >
                 <header>
-                  <button name="action_find_duplicates" type="object" string="Find duplicates" display="always"/>
                   <button name="action_qualify" string="Qualify" type="object" groups="runbot.group_runbot_admin,runbot.group_runbot_error_manager"/>
                 </header>
                 <field name="error_display_id" optional="show"/>
@@ -542,17 +541,6 @@
         <field name="res_model">runbot.error.regex</field>
         <field name="view_mode">list,form</field>
     </record>
-
-    <record id="action_find_duplicates" model="ir.actions.server">
-      <field name="name">Find Duplicates</field>
-      <field name="model_id" ref="runbot.model_runbot_build_error_content"/>
-      <field name="type">ir.actions.server</field>
-      <field name="state">code</field>
-      <field name="code">
-          action = model._find_duplicates()
-      </field>
-    </record>
-
     <record id="build_error_qualify_regex_tree" model="ir.ui.view">
         <field name="name">runbot.error.qualify.regex.list</field>
         <field name="model">runbot.error.qualify.regex</field>


### PR DESCRIPTION
This feature was broken for a while and unused since the same action can be done automaticaly with the error merge feature