### PR TITLE
[IMP] runbot: reduce number of send states

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1291,7 +1291,7 @@ class BuildResult(models.Model):
                     state = 'error'
                     desc = "This build used custom config. Remove custom trigger to restore default ci"
                 elif build.global_result in ('ko', 'warn'):
-                    state = 'failure'
+                    state = 'error'
                 elif build.global_state in ('pending', 'testing'):
                     state = 'pending'
                 elif build.global_state in ('running', 'done'):
@@ -1344,7 +1344,7 @@ class BuildResult(models.Model):
                     else:
                         target_url = f"{self.get_base_url()}/runbot/build/{build.id}"
 
-                    commit._github_status(build, trigger.ci_context, state, target_url, desc)
+                    commit._github_status(build, trigger.ci_context, state, target_url, desc, ci_startegy=trigger.ci_startegy)
 
     def _parse_config(self):
         return set(findall(self._server("tools/config.py"), r'--[\w-]+', ))

--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -177,15 +177,27 @@ class Commit(models.Model):
         for commit in self:
             commit.dname = '%s:%s' % (commit.repo_id.name, commit.name[:8])
 
-    def _github_status(self, build, context, state, target_url, description=None):
+    def _github_status(self, build, context, state, target_url, description=None, ci_startegy="all"):
+        if state == 'failure':
+            state = 'error'  # github does not make a big difference between error and failure, lets simplify
         self.ensure_one()
+        build_id = build.id if build else False
         Status = self.env['runbot.commit.status']
         last_status = Status.search([('commit_id', '=', self.id), ('context', '=', context)], order='id desc', limit=1)
         if last_status and last_status.state == state:
             _logger.info('Skipping already sent status %s:%s for %s', context, state, self.name)
             return
+
+        if ci_startegy != 'all' and state == 'pending':
+            _logger.info("skipping github pending status for build %s and ci %s", build_id, context)
+            return
+
+        if ci_startegy == 'errors' and state != 'error' and last_status.state != 'error':
+            _logger.info("skipping github status for build %s, ci_startegy is failures", build_id)
+            return
+
         last_status = Status.create({
-            'build_id': build.id if build else False,
+            'build_id': build_id,
             'commit_id': self.id,
             'context': context,
             'state': state,
@@ -193,6 +205,7 @@ class Commit(models.Model):
             'description': description or context,
             'to_process': True,
         })
+        return last_status
 
     def _get_last_statuses(self):
         status_list = self.env['runbot.commit.status'].search([('commit_id', '=', self.id)], order='id desc')

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -87,6 +87,11 @@ class Trigger(models.Model):
     ci_url = fields.Char("CI url")
     ci_description = fields.Char("CI description")
     ci_send_all = fields.Boolean('Send ci on dependencies', default=False)
+    ci_startegy = fields.Selection([
+        ('all', 'All'),
+        ('no_pending', 'No pending'),
+        ('errors', 'Only errors'),
+    ], string="CI startegy", default='all', help="Strategy to use when sending CI status to github")
     has_stats = fields.Boolean('Has a make_stats config step', compute="_compute_has_stats", store=True)
 
     team_ids = fields.Many2many('runbot.team', string="Runbot Teams", help="Teams responsible of this trigger, mainly usefull for nightly")

--- a/runbot/tests/test_batch.py
+++ b/runbot/tests/test_batch.py
@@ -87,5 +87,5 @@ class TestBatch(RunbotCase):
         self.assertEqual(list(assert_status_info(commit_1).values()), [batch_1.id, build_1.id, 'success'])
         build_2.local_result = 'ko'
         build_2.local_state = 'done'
-        self.assertEqual(list(assert_status_info(commit_2).values()), [batch_2.id, build_2.id, 'failure'])  # batch_2 or batch_3 could make sense
-        self.assertEqual(list(assert_status_info(commit_4).values()), [batch_4.id, build_2.id, 'failure'])
+        self.assertEqual(list(assert_status_info(commit_2).values()), [batch_2.id, build_2.id, 'error'])  # batch_2 or batch_3 could make sense
+        self.assertEqual(list(assert_status_info(commit_4).values()), [batch_4.id, build_2.id, 'error'])

--- a/runbot/tests/test_commit.py
+++ b/runbot/tests/test_commit.py
@@ -107,3 +107,93 @@ class TestCommitStatus(HttpCase):
                 response = self.url_open('/runbot/commit/resend/%s' % last_commit_status.id)
                 self.assertEqual(response.status_code, 200)
                 send_patcher.assert_not_called()
+
+    def test_commit_status_strategy(self):
+        ci_startegy = "all"
+        commit = self.server_commit
+
+        def context():
+            return 'ci/test-' + ci_startegy
+
+        def last_status():
+            return self.env['runbot.commit.status'].search([('commit_id', '=', commit.id), ('context', '=', context())], order='id desc', limit=1) or self.env['runbot.commit.status']
+
+        # pending
+        new_status = commit._github_status(False, context(), 'pending', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'pending')
+        self.assertEqual(new_status, last_status())
+        # success
+        new_status = commit._github_status(False, context(), 'success', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'success')
+        self.assertEqual(new_status, last_status())
+        # pending
+        new_status = commit._github_status(False, context(), 'pending', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'pending')
+        self.assertEqual(new_status, last_status())
+        # error
+        new_status = commit._github_status(False, context(), 'error', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'error')
+        self.assertEqual(new_status, last_status())
+        # error again (skipped)
+        new_status = commit._github_status(False, context(), 'error', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'error')
+        self.assertEqual(new_status, None)
+
+        ci_startegy = "no_pending"
+
+        # pending (skipped)
+        new_status = commit._github_status(False, context(), 'pending', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, None)
+        self.assertEqual(last_status().state, False)
+
+        # success
+        new_status = commit._github_status(False, context(), 'success', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, last_status())
+        self.assertEqual(last_status().state, 'success')
+
+        # error
+        new_status = commit._github_status(False, context(), 'error', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, last_status())
+        self.assertEqual(last_status().state, 'error')
+
+        # pending (skipped)
+        new_status = commit._github_status(False, context(), 'pending', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, None)
+        self.assertEqual(last_status().state, 'error')
+
+        # error again (skipped)
+        new_status = commit._github_status(False, context(), 'error', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'error')
+        self.assertEqual(new_status, None)
+
+        ci_startegy = "errors"
+
+        # pending (skipped)
+        new_status = commit._github_status(False, context(), 'pending', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, None)
+        self.assertEqual(last_status().state, False)
+
+        # success (skipped)
+        new_status = commit._github_status(False, context(), 'success', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, None)
+        self.assertEqual(last_status().state, False)
+
+        # error
+        new_status = commit._github_status(False, context(), 'error', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, last_status())
+        self.assertEqual(last_status().state, 'error')
+
+        # pending (skipped)
+        new_status = commit._github_status(False, context(), 'pending', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, None)
+        self.assertEqual(last_status().state, 'error')
+
+        # error again (skipped)
+        new_status = commit._github_status(False, context(), 'error', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(last_status().state, 'error')
+        self.assertEqual(new_status, None)
+
+        # success (not skipped, reset failure)
+        new_status = commit._github_status(False, context(), 'success', '', description=None, ci_startegy=ci_startegy)
+        self.assertEqual(new_status, last_status())
+        self.assertEqual(last_status().state, 'success')

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -71,6 +71,7 @@
                   <field name="ci_url"/>
                   <field name="ci_description"/>
                   <field name="ci_send_all"/>
+                  <field name="ci_startegy"/>
                 </group>
               </group>
               <group string="Managing Team (nightly failure, manual start, ...)"></group>


### PR DESCRIPTION
Add different strategy to avoid to send all statuses to GitHub.

Some ci will be verry fast and don't need to send the pending signal Other ci are not mandatory and just there to inform the user, sending only errors is enough