### PR TITLE
[IMP] runbot: add a commit link details page

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -37,6 +37,7 @@
         'templates/nginx.xml',
         'templates/build_error.xml',
         'templates/batches_by_date.xml',
+        'templates/commit_link_details.xml',
 
         'views/branch_views.xml',
         'views/build_error_link_views.xml',

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -2,6 +2,7 @@ import datetime
 import functools
 import logging
 from collections import OrderedDict
+from subprocess import CalledProcessError
 from urllib.parse import urlsplit
 
 import werkzeug
@@ -11,10 +12,11 @@ from dateutil.relativedelta import relativedelta
 from werkzeug.exceptions import Forbidden, NotFound
 
 from odoo import fields
-from odoo.addons.website.controllers.main import QueryURL
 from odoo.http import Controller, Response, request
 from odoo.http import route as o_route
 from odoo.osv import expression
+
+from odoo.addons.website.controllers.main import QueryURL
 
 _logger = logging.getLogger(__name__)
 
@@ -752,11 +754,49 @@ class Runbot(Controller):
             for batch in batches:
                 builds_by_batch_id[batch.id] = build_error.build_ids.filtered_domain([('id', 'child_of', batch.slot_ids.build_id.ids)])
 
+        build_error = build_error if build_error else self.env['runbot.build.error']
+        diff_versions_filter = build_error.version_ids
+        diff_repos_filter = build_error.trigger_ids.dependency_ids
+        commit_link_details_url = f'/runbot/commit_link/details/{",".join(map(str, batches.commit_link_ids.ids))}'
+
         return request.render("runbot.batches_by_date", {
             'batches_date': batches_date,
             'batches': batches,
             'next_date_url': next_date_url,
             'previous_date_url': previous_date_url,
+            'commit_link_details_url': commit_link_details_url,
             'builds_by_batch_id': builds_by_batch_id,
             'category': request.env['runbot.category'].browse(category_id),
+            'diff_versions_filter': diff_versions_filter,
+            'diff_repos_filter': diff_repos_filter,
+        })
+
+    @route([
+        "/runbot/commit_link/details/<string:commit_link_ids>",
+        ], type="http", auth="user", website=True, sitemap=False)
+    def commit_links_diffs(self, commit_link_ids=None, versions_filter_ids=None, repos_filter_ids=None, **kwargs):
+        commit_links = request.env['runbot.commit.link'].browse([int(id) for id in commit_link_ids.split(',')])
+        if versions_filter_ids:
+            vids = [int(v) for v in versions_filter_ids.split(',')]
+            commit_links = commit_links.filtered_domain([('branch_id.bundle_id.version_id.id', 'in', vids)])
+        if repos_filter_ids:
+            rids = [int(r) for r in repos_filter_ids.split(',')]
+            commit_links = commit_links.filtered_domain([('branch_id.repo_id.id', 'in', rids)])
+        diff_by_commit_link_ids = {}
+        popot_filter = ":!*.po :!*.pot"
+        git_show_filter = ["--", "."] + popot_filter.split()
+        selected_commit_links = request.env['runbot.commit.link']
+        for commit_link in commit_links:
+            if commit_link.merge_base_commit_id:
+                git_show_argument = f"{commit_link.merge_base_commit_id.name}..{commit_link.commit_id.name}"
+                try:
+                    diff = commit_link.commit_id.repo_id.sudo()._git(['show', git_show_argument] + git_show_filter, errors='ignore').removeprefix('commit ')
+                except CalledProcessError as e:
+                    diff = f'Error with command git command:\n{e.cmd}\n{e.stdout}'
+                diff_by_commit_link_ids[commit_link.id] = diff
+                selected_commit_links |= commit_link
+
+        return request.render("runbot.commit_link_details", {
+            'commit_links': selected_commit_links,
+            'diff_by_commit_link_ids': diff_by_commit_link_ids,
         })

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -37,26 +37,29 @@ def draw_svg(daily_version_freq, y_labels=None, max_value: int = 10, error_id: i
     x_keys = sorted(daily_version_freq.keys())
     height = 40
     for idx, (x_key) in enumerate(x_keys):
-        batch_date = x_key.strftime('%Y-%m-%d')
+        batch_date = x_key.strftime("%Y-%m-%d")
         for idy, (y_key, y_label) in enumerate(y_labels.items()):
             value = daily_version_freq[x_key].get(y_key, 0)
             if not value:
-                continue
-            if value > max_value:
-                value = max_value
-            cell_opacity = ((max_value * 0.3 + value) / (max_value * 0.3 + max_value))
-            cell_color = get_color(value, cell_opacity)
+                cell_color = "white"
+                cell_opacity = 0
+            else:
+                value = min(value, max_value)
+                cell_opacity = ((max_value * 0.3 + value) / (max_value * 0.3 + max_value))
+                cell_color = get_color(value, cell_opacity)
+            href = f'/runbot/batches/{project_id}/{category_id}/{batch_date}/{error_id or ""}'
             pos_y = idy * 10 + 0.5
             pos_x = idx * 10 + 0.5
             rects.append(
-                f''''
-                <a href="/runbot/batches/{project_id}/{category_id}/{batch_date}/{error_id if error_id else ""}">
+                f'''
+                <a href="{href}">
                 <title>{batch_date} {y_label} ({value})</title>
                 <rect fill="{cell_color}" width="9" height="9" x="{pos_x}" y="{pos_y}"/>
-                </a>'''
+                </a>''',
             )
     rects = ''.join(rects)
     return f'<div style="height: {height}px"><svg xmlns="https://www.w3.org/2000/svg" viewbox="0 0 {len(x_keys) * 10} {len(y_labels) * 10}" style="border: 1px solid black; height: 100%; width: 100%;" preserveAspectRatio="none" shape-rendering="cripsEdges">{rects}</svg></div>'
+
 
 class BuildErrorLink(models.Model):
     _name = 'runbot.build.error.link'

--- a/runbot/templates/batches_by_date.xml
+++ b/runbot/templates/batches_by_date.xml
@@ -10,11 +10,26 @@
                             <div class="btn-group" role="group">
                                 <a t-att-href="previous_date_url" class="btn btn-sm text-start" title="Previous date"><i class="fa fa-chevron-left"/></a>
                                 <a t-att-href="next_date_url" class="btn btn-sm text-start" title="Next date"><i class="fa fa-chevron-right"/></a>
+                                <t t-set="repo_url_separator" t-value="'?'"/>
+                                <t t-if="diff_versions_filter">
+                                    <t t-set="commit_link_details_url" t-value="commit_link_details_url + '?versions_filter_ids=' + ','.join(map(str, diff_versions_filter.ids))"/>
+                                    <t t-set="repo_url_separator" t-value="'&amp;'"/>
+                                </t>
+                                <t t-if="diff_repos_filter">
+                                    <t t-set="commit_link_details_url" t-value="commit_link_details_url + repo_url_separator + 'repos_filter_ids=' + ','.join(map(str, diff_repos_filter.ids))"/>
+                                </t>
+                                <a t-att-href="commit_link_details_url" class="btn btn-sm text-start" title="Compare all batches with their bases" groups="runbot.group_runbot_advanced_user">
+                                    <i class="fa fa-arrows-v"/>
+                                </a>
                             </div>
                         </h5>
                         <t t-foreach="batches" t-as="batch">
                             <div class="col-md-1">
                                 <t t-esc="batch.bundle_id.name" />
+                                <t t-set="batch_diff_url" t-value="'/runbot/commit_link/details/' + ','.join(map(str, batch.commit_link_ids.ids))"/>
+                                <a t-att-href="batch_diff_url" class="btn btn-sm text-start" title="Compare batch with its base" groups="runbot.group_runbot_advanced_user">
+                                    <i class="fa fa-arrows-v"/>
+                                </a>
                             </div>
                             <div class="col-md-11">
                                 <div class="batch_row" >

--- a/runbot/templates/commit_link_details.xml
+++ b/runbot/templates/commit_link_details.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="runbot.commit_link_details">
+            <t t-call="runbot.layout" groups="base.group_user">
+                <t t-foreach="commit_links" t-as="commit_link">
+                    <t t-set="commit" t-value="commit_link.commit_id"/>
+                    <t t-set="collapse" t-value="'collapse' + str(commit_link.id)"/>
+                    <t t-set="href" t-value="'#' + collapse"/>
+                    <div class="container sticky-top bg-white" style="margin-left: 50%;">
+                        <p>
+                            <span type="button" data-bs-toggle="collapse" t-att-data-bs-target="href" role="button" aria-expanded="true" t-att-aria-controls="collapse"><i class="fa fa-toggle-up"/></span>
+                                <a t-attf-href="/runbot/commit/#{commit.id}">
+                                    <span class="label" t-esc="commit.dname"/>
+                                    <span t-esc="'+%s' % commit_link.diff_add" class="text-success"/>
+                                    <span t-esc="'-%s' % commit_link.diff_remove" class="text-danger"/>
+                                    <span class="text-info">
+                                        (
+                                        <span t-esc="commit_link.file_changed"/>
+                                        <i class="fa fa-file"/>
+                                        )
+                                        <span io="behind">(
+                                            <span t-esc="'%s ahead' % commit_link.base_ahead" class="text-success"/>
+                                            ,
+                                            <span t-esc="'%s behind' % commit_link.base_behind" class="text-danger"/>
+                                        )</span>
+                                    </span>
+                                </a>
+                                <br/>
+                                Branch: <span t-esc="commit_link.branch_id.name"/><br/>
+                                Version: <span t-esc="commit_link.branch_id.bundle_id.version_id.name"/><br/>
+                                Base head:<span t-esc="commit_link.base_commit_id.name"/><br/>
+                                Merge base:<span t-esc="commit_link.merge_base_commit_id.name"/><br/>
+                        </p>
+                    </div>
+                    <div t-att-id="collapse" class="collapsed show" style="background-color:#223;color:CCC;padding:10px;">
+                        <t t-set="diff_command" t-value="str(commit_link.merge_base_commit_id.name) +'..'+commit.name"/>
+                        <i> &gt; git -C <t t-esc="commit.repo_id.name"/> show <t t-esc="diff_command"/> </i>
+                        <t t-set="diff" t-value="diff_by_commit_link_ids.get(int(commit_link.id),'')"/>
+                        <t t-set="commits" t-value="diff.split('\ncommit ')"/>
+                        <div>
+                        <t t-foreach="commits" t-as="commit_desc">
+                            <t t-set="commit_name" t-value="commit_desc.split('\n', 1)[0]"/>
+                            <t t-set="commit_desc" t-value="'commit ' + commit_desc"/>
+                            <!--t t-set="pr" t-value="commit_desc.split(commit.repo_id.main_remote_id.short_name+'#')[1].split('\n')[0] if commit.repo_id.main_remote_id.short_name+'#' in commit_desc else None"/-->
+                            <t t-set="url" t-value="'https://github.com/%s/commit/%s' % (commit.repo_id.main_remote_id.short_name, commit_name)"/>
+                            <a t-att-href="url" t-att-title="commit_name" target="_blank">
+                            <div style="border-bottom:25px solid #ccc;">
+                                <t t-foreach="commit_desc.split('\n')" t-as="line">
+                                    <t t-set="color" t-value="'#DDD'"/>
+                                    <t t-set="color" t-value="'#faa'" t-if="line.startswith('-')"/>
+                                    <t t-set="color" t-value="'#afa'" t-if="line.startswith('+')"/>
+                                    <t t-if="line_first">
+                                        <div t-esc="line" class="sticky-top bg-dark" t-attf-style="margin-right: 50%; font-family:SFMono-Regular, Menlo, Monaco, Consolas,monospace;white-space-collapse: preserve;color:{{color}}"/>
+                                    </t>
+                                    <t t-else="">
+                                        <div t-esc="line" t-attf-style="font-family:SFMono-Regular, Menlo, Monaco, Consolas,monospace;white-space-collapse: preserve;color:{{color}}"/>
+                                    </t>
+                                </t>
+                            </div>
+                            </a>
+                        </t>
+                        </div>
+                    </div>
+                </t>
+            </t>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
A new frontend page and route is added to show details of commit_links. The datails includes the diff with the base commit for the commit links specified in the url.

Also, the commit links can be filtered by version and repository. Version ids and repository ids have to be given in URL params as comma separated ids.

The build error frequency graph is also improved. Each cell is now clickable and links to the batches of the day. On that `batch by date` page, a link is added to the commit details page, filtered by the versions and repositories where the build error was seen.

The original diff page was a custom page made by @Xavier-Do

Further improvements have to be made:
- add a form on the batches by date page to customize the details filters
- improve the UI of the diff page