### PR TITLE
[FIX] runbot: display correct trigger on error

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -865,7 +865,7 @@ class BuildErrorContent(models.Model):
     @api.depends('build_ids')
     def _compute_trigger_ids(self):
         for build_error in self:
-            build_error.trigger_ids = build_error.build_ids.trigger_id
+            build_error.trigger_ids = build_error.build_ids.top_parent.trigger_id
 
     @api.depends('content')
     def _compute_summary(self):


### PR DESCRIPTION
a more and more comon practive is to start all standard triggersin a nightly with some specific params (faketime, profiling, ...)

The trigger displayed on the error should be clearer, as an example, in Enterprise tests fails in the faketime trigger, we want to have the Faketime and not the Enterprise trigger on the error.