### PR TITLE
[IMP] runbot: don't open in new tab

### DIFF
--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -321,7 +321,7 @@
                       <!--a groups="runbot.group_user" t-attf-href="/web#id={{error_content.id}}&amp;view_type=form&amp;model=runbot.build.error.content&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="_blank">
                         <i t-attf-class="fa fa-search"/>
                       </a-->
-                      <a groups="runbot.group_user" t-attf-href="/web#id={{error.id}}&amp;view_type=form&amp;model=runbot.build.error&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend" target="_blank">
+                      <a groups="runbot.group_user" t-attf-href="/web#id={{error.id}}&amp;view_type=form&amp;model=runbot.build.error&amp;menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" title="View in Backend">
                         <i t-attf-class="fa fa-list"/>
                       </a>
                       <span t-if="error.responsible and (env.user.has_group('runbot.group_runbot_error_manager') or error.responsible.id == uid)">(<i t-out="error.responsible.name"/>)</span>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -12,7 +12,7 @@
                                     <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
                                     <div class="btn-group" role="group">
                                         <a groups="runbot.group_runbot_advanced_user"
-                                            t-attf-href="/odoo/runbot.bundle/{{bundle.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" class="btn btn-default" target="_blank" title="View in Backend">
+                                            t-attf-href="/odoo/runbot.bundle/{{bundle.id}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" class="btn btn-default" title="View in Backend">
                                           <i class="fa fa-list"/>
                                         </a>
                                         <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Force A New Batch">

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -388,7 +388,7 @@
                         Find similar builds
                     </a>
                     <a class="dropdown-item"
-                        t-attf-href="/odoo/runbot.build/{{bu['id']}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}" target="_blank">
+                        t-attf-href="/odoo/runbot.build/{{bu['id']}}?menu_id={{env['ir.model.data']._xmlid_to_res_id('runbot.runbot_menu_root')}}">
                         <i class="fa fa-list"/>
                         View in backend
                     </a>


### PR DESCRIPTION
In some case we would like to be able to open a record in backend without keeping the active tab open.

Moreover, target="_blank" will also open in the app when installed, which is not the expected behavior.