### PR TITLE
[IMP] runbot: network disabled by default

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -234,7 +234,7 @@ def docker_run(*args, **kwargs):
     return _docker_run(*args, **kwargs)
 
 
-def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, cpu_period=100000, cpus=0, memory=None, preexec_fn=None, ro_volumes=None, env_variables=None, network_enabled=True):
+def _docker_run(cmd=False, log_path=False, build_dir=False, container_name=False, image_tag=False, exposed_ports=None, cpu_limit=None, cpu_period=100000, cpus=0, memory=None, preexec_fn=None, ro_volumes=None, env_variables=None, network_enabled=False):
     """Run tests in a docker container
     :param run_cmd: command string to run in container
     :param log_path: path to the logfile that will contain odoo stdout and stderr

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -892,9 +892,8 @@ class BuildResult(models.Model):
 
         self._log('Preparing', 'Using Dockerfile Tag [%s](/runbot/dockerfile_result/%s/%s)', kwargs['image_tag'], kwargs['image_tag'], image_id, log_type='markdown')
 
-        if not kwargs.get('network_enabled', False):
-            # we don't check config data if we explicitely enable the network (e.g.: restore step)
-            kwargs['network_enabled'] = self.params_id.config_data.get('network_enabled', kwargs.get('network_enabled', True))
+        # network is disabled by default, can be enabled via kwargs['network_enabled'] (run, restore) or config_data['network_enabled'] (external, nightly,...)
+        kwargs['network_enabled'] = kwargs.get('network_enabled') or self.params_id.config_data.get('network_enabled') or False
 
         containers_memory_limit = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_memory', 0)
         if containers_memory_limit and 'memory' not in kwargs:

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -780,35 +780,35 @@ def run():
         self.assertIn('--without-demo', cmd)
 
     @patch('odoo.addons.runbot.models.build.BuildResult._checkout')
-    def test_network_can_be_disabled(self, mock_checkout):
+    def test_network_can_be_enable(self, mock_checkout):
         """ test that network can be disabled with config_data """
         config_step = self.ConfigStep.create({
             'name': 'default',
             'job_type': 'install_odoo',
         })
 
-        # by default, network is enabled (will be changed in a near future)
+        # by default, network is disabled
         def first_docker_run(cmd, log_path, *args, **kwargs):
-            self.assertTrue(kwargs['network_enabled'])
+            self.assertFalse(kwargs['network_enabled'])
 
         self.patchers['docker_run'].side_effect = first_docker_run
         config_step._run_step(self.parent_build)()
 
         def second_docker_run(cmd, log_path, *args, **kwargs):
-            self.assertFalse(kwargs['network_enabled'])
+            self.assertTrue(kwargs['network_enabled'])
 
         self.patchers['docker_run'].side_effect = second_docker_run
 
-        parent_build_params = self.parent_build.params_id.copy({'config_data': {'network_enabled': False}})
+        parent_build_params = self.parent_build.params_id.copy({'config_data': {'network_enabled': True}})
         parent_build = self.parent_build.copy({'params_id': parent_build_params.id})
         config_step._run_step(parent_build)()
 
 
     @patch('odoo.addons.runbot.models.build.BuildResult._checkout')
     def test_run_python_networkcan_be_disabled(self, mock_checkout):
-        """test that docker network can be disabled from python step"""
+        """test that docker network can be enabled from python step"""
         test_code = """cmd = build._cmd()
-docker_params = dict(cmd=cmd, network_enabled=False)
+docker_params = dict(cmd=cmd, network_enabled=True)
         """
         config_step = self.ConfigStep.create({
             'name': 'default',
@@ -817,7 +817,7 @@ docker_params = dict(cmd=cmd, network_enabled=False)
         })
 
         def docker_run(cmd, *args, **kwargs):
-            self.assertFalse(kwargs['network_enabled'])
+            self.assertTrue(kwargs['network_enabled'])
 
         self.patchers['docker_run'].side_effect = docker_run
         config_step._run_step(self.parent_build)()


### PR DESCRIPTION
A first part made the network optionally disabled. This was tested in the nightly builds and now that all related errors were fixed, we can make it the default.

As a side effect, it will also now be impossible to add a requirement without asking for a docker image to test it, which is a good thing. It will also force to have one docker image per version of the requirements, meaning that we won't have an image not coherent with the debian control or requirements.