### PR TITLE
[IMP] runbot: speedup history graph rendering

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -728,25 +728,34 @@ class Runbot(Controller):
         })
 
     @route([
+        '/runbot/batches/ids/<string:batch_ids>',
+        '/runbot/batches/ids/<string:batch_ids>/<model("runbot.build.error"):build_error>',
         '/runbot/batches/<int:project_id>/<int:category_id>/<batches_date>',
         '/runbot/batches/<int:project_id>/<int:category_id>/<batches_date>/<model("runbot.build.error"):build_error>',
         ], type='http', auth="public", website=True, sitemap=False)
-    def batches_by_date(self, project_id=None, category_id=None, batches_date=None, build_error=None, **kwargs):
+    def batches_by_date(self, batch_ids=None, project_id=None, category_id=None, batches_date=None, build_error=None, title=None, **kwargs):
         limit = int(kwargs.get('limit', 25)) if int(kwargs.get('limit', 25)) < 100 else 25
         try:
             start_date = fields.Date.from_string(batches_date)
         except ValueError:
             raise NotFound
-
-        end_date = start_date + relativedelta(days=1)
-        next_date_url = f'/runbot/batches/{project_id}/{category_id}/{end_date}/{build_error.id if build_error else ""}'
-        previous_date_url = f'/runbot/batches/{project_id}/{category_id}/{start_date - relativedelta(days=1)}/{build_error.id if build_error else ""}'
-        batches = request.env["runbot.batch"].search([
-            ("category_id", "=", category_id),
-            ("bundle_id.project_id", "=", project_id),
-            ("create_date", ">=", start_date),
-            ("create_date", "<", end_date),
-        ], limit=limit)
+        if batch_ids:
+            batch_ids = [int(bid) for bid in batch_ids.split(',')]
+            batches = request.env['runbot.batch'].browse(batch_ids).exists().sorted(lambda b: b.bundle_id.version_id.number, reverse=True)
+            if not batches:
+                raise NotFound
+            next_date_url = None
+            previous_date_url = None
+        else:
+            end_date = start_date + relativedelta(days=1)
+            next_date_url = f'/runbot/batches/{project_id}/{category_id}/{end_date}/{build_error.id if build_error else ""}'
+            previous_date_url = f'/runbot/batches/{project_id}/{category_id}/{start_date - relativedelta(days=1)}/{build_error.id if build_error else ""}'
+            batches = request.env["runbot.batch"].search([
+                ("category_id", "=", category_id),
+                ("bundle_id.project_id", "=", project_id),
+                ("create_date", ">=", start_date),
+                ("create_date", "<", end_date),
+            ], limit=limit)
 
         builds_by_batch_id = None
         if build_error:
@@ -754,12 +763,14 @@ class Runbot(Controller):
             for batch in batches:
                 builds_by_batch_id[batch.id] = build_error.build_ids.filtered_domain([('id', 'child_of', batch.slot_ids.build_id.ids)])
 
-        build_error = build_error if build_error else self.env['runbot.build.error']
+        build_error = build_error if build_error else request.env['runbot.build.error']
         diff_versions_filter = build_error.version_ids
         diff_repos_filter = build_error.trigger_ids.dependency_ids
         commit_link_details_url = f'/runbot/commit_link/details/{",".join(map(str, batches.commit_link_ids.ids))}'
 
         return request.render("runbot.batches_by_date", {
+            'build_error': build_error,
+            'title': title,
             'batches_date': batches_date,
             'batches': batches,
             'next_date_url': next_date_url,

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -14,7 +14,7 @@ from werkzeug.urls import url_join
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import SQL, lazy
+from odoo.tools import SQL, lazy, ormcache
 from odoo.osv import expression
 
 from ..fields import JsonDictField
@@ -32,7 +32,6 @@ def get_color(value: int, opacity='1'):
 
 
 def draw_svg(daily_version_freq, y_labels=None, max_value: int = 10, error_id: int = 0, category_id=1, project_id=1):
-
     rects = []
     x_keys = sorted(daily_version_freq.keys())
     height = 40
@@ -90,10 +89,10 @@ class BuildErrorSeenMixin(models.AbstractModel):
     last_seen_date = fields.Datetime(string='Last Seen Date', compute='_compute_seen', store=True)
     build_count = fields.Integer(string='Nb Seen', compute='_compute_seen', store=True)
     seen_hash = fields.Char(string='Seen hash', compute='_compute_seen_hash', store=True)
+    first_seen_batch_ids = fields.Many2many('runbot.batch', compute='_compute_seen_batch', string='First Seen Batches')
+    last_seen_batch_ids = fields.Many2many('runbot.batch', compute='_compute_seen_batch', string='Last Seen Batches')
 
-    graph_history = fields.Html('30 days history', compute='_compute_graph', sanitize=False)
-    graph_day_of_week_recurence = fields.Html('Weekly recurence', compute='_compute_graph', sanitize=False)
-    graph_day_of_month_recurence = fields.Html('Monthly recurence', compute='_compute_graph', sanitize=False)
+    history_data = fields.Json('30 days history', compute='_compute_graph')
 
     @api.depends('build_error_link_ids')
     def _compute_seen(self):
@@ -101,7 +100,7 @@ class BuildErrorSeenMixin(models.AbstractModel):
             record.first_seen_date = False
             record.last_seen_date = False
             record.build_count = 0
-            error_link_ids = record.build_error_link_ids.sorted('log_date')
+            error_link_ids = record.build_error_link_ids.sorted(lambda bel: bel.build_id.top_parent.create_batch_id.id)
             if error_link_ids:
                 first_error_link = error_link_ids[0]
                 last_error_link = error_link_ids[-1]
@@ -110,6 +109,32 @@ class BuildErrorSeenMixin(models.AbstractModel):
                 record.first_seen_build_id = first_error_link.build_id
                 record.last_seen_build_id = last_error_link.build_id
                 record.build_count = len(error_link_ids.build_id)
+
+    @api.depends('build_error_link_ids')
+    def _compute_seen_batch(self):
+        from_clause, content_table = self.get_log_dates_from_clause()
+        query = f"""
+            SELECT record.id, bundle.version_id, MIN(batch.id) AS first_batch_id, MAX(batch.id) AS last_batch_id
+            {from_clause}
+            JOIN runbot_build_error_link AS link ON link.error_content_id = {content_table}.id
+            JOIN runbot_build AS build ON link.build_id = build.id
+            JOIN runbot_build_params AS params ON params.id = build.params_id
+            JOIN runbot_batch AS batch ON build.create_batch_id = batch.id
+            JOIN runbot_bundle AS bundle ON bundle.id = batch.bundle_id
+            WHERE record.id IN %s
+            GROUP BY record.id, bundle.version_id
+        """
+        self.env.cr.execute(query, (tuple(self.ids),))
+        first_batch_ids_by_record_id = {}
+        last_batch_ids_by_record_id = {}
+        res = self.env.cr.fetchall()
+        for row in res:
+            record_id, _version_id, first_batch_id, last_batch_id = row
+            first_batch_ids_by_record_id.setdefault(record_id, []).append(first_batch_id)
+            last_batch_ids_by_record_id.setdefault(record_id, []).append(last_batch_id)
+        for record in self:
+            record.first_seen_batch_ids = self.env['runbot.batch'].browse(sorted(first_batch_ids_by_record_id.get(record.id, [])))
+            record.last_seen_batch_ids = self.env['runbot.batch'].browse(sorted(last_batch_ids_by_record_id.get(record.id, [])))
 
     @api.depends('build_error_link_ids')
     def _compute_seen_hash(self):
@@ -128,26 +153,37 @@ class BuildErrorSeenMixin(models.AbstractModel):
             dates = log_date_per_error[error]
             versions = self.env['runbot.bundle'].search([('project_id', '=', project_id), ('sticky', '=', True)]).version_id.sorted(lambda v: (v.sequence, v.number), reverse=True)
             versions_ids = versions.ids
-            y_labels = {version.id: version.number for version in versions}
-            daily_version_freq = dict.fromkeys([date.date() for date in rrule.rrule(rrule.DAILY, dtstart=start_date, until=end_date)])
-            for date in daily_version_freq:
-                daily_version_freq[date] = {version: 0 for version in versions_ids}
+            x_labels = [date.strftime("%Y-%m-%d") for date in rrule.rrule(rrule.DAILY, dtstart=start_date, until=end_date)]
+            y_labels = [version.number for version in versions]
+            x_indexes = {date: idx for idx, date in enumerate(x_labels)}
+            y_indexes = {version_id: idx for idx, version_id in enumerate(versions_ids)}
+            daily_version_freq = []
+            for date in x_labels:
+                daily_version_freq.append([0] * len(y_labels))
             max_count = 0
-            for (date, version), count in dates.items():
-                d = date.date()
-                if d in daily_version_freq and version in daily_version_freq[d]:
-                    c = daily_version_freq[d][version] + count
-                    daily_version_freq[d][version] = c
+            for (date, version_id), count in dates.items():
+                date_str = date.date().strftime("%Y-%m-%d")
+                x_index = x_indexes.get(date_str)
+                y_index = y_indexes.get(version_id)
+                if x_index and y_index:
+                    c = daily_version_freq[x_index][y_index] + count
+                    daily_version_freq[x_index][y_index] = c
                     max_count = max(max_count, c)
 
-            error.graph_history = draw_svg(
-                daily_version_freq, y_labels=y_labels, max_value=max_count, error_id=error.id,
-                category_id=error.first_seen_build_id.create_batch_id.category_id.id if error.first_seen_build_id else 1,
-                project_id=project_id if error.first_seen_build_id else 1,
-            )
-            error.graph_day_of_week_recurence = False
-            error.graph_day_of_month_recurence = False
+            error.history_data = {
+                'versions_ids': versions_ids,
+                'x_labels': x_labels,
+                'y_labels': y_labels,
+                'start_date': start_date.strftime("%Y-%m-%d"),
+                'end_date': end_date.strftime("%Y-%m-%d"),
+                'daily_version_freq': daily_version_freq,
+                'max_count': max_count,
+                'error_id': error.id,
+                'category_id': error.first_seen_build_id.top_parent.params_id.create_batch_id.category_id.id if error.first_seen_build_id else 1,
+                'project_id': project_id if error.first_seen_build_id else 1,
+            }
 
+    @ormcache('tuple(self.ids)', 'start_date', 'end_date')  # not sure that this is a good idea. Could be a stored field recomputed after scanning the errors?
     def _get_log_dates(self, start_date: datetime.datetime, end_date: datetime.datetime):
         """
         Returns an count of build_error per hour for the last 30 days.
@@ -157,11 +193,11 @@ class BuildErrorSeenMixin(models.AbstractModel):
         result = defaultdict(dict)
         if not self._origin.ids:
             return result
-        from_clause, content_field = self.get_log_dates_from_clause()
+        from_clause, content_table = self.get_log_dates_from_clause()
         self.env.cr.execute(f"""
             SELECT record.id as record_id, date_trunc('day', batch.create_date) as time, build.version_id as version_id, count(*) as count
               {from_clause}
-              JOIN runbot_build_error_link AS link ON link.error_content_id = {content_field}.id
+              JOIN runbot_build_error_link AS link ON link.error_content_id = {content_table}.id
               JOIN runbot_build AS build ON link.build_id = build.id
               JOIN runbot_batch AS batch ON build.create_batch_id = batch.id
              WHERE record.id IN %s AND batch.create_date BETWEEN %s AND %s
@@ -241,8 +277,9 @@ class BuildError(models.Model):
     version_ids = fields.Many2many('runbot.version', string='Versions', compute=_compute_related_error_content_ids('version_ids'), search=_search_related_error_content_ids('version_ids'))
     trigger_ids = fields.Many2many('runbot.trigger', string='Triggers', compute=_compute_related_error_content_ids('trigger_ids'), store=True)
     tag_ids = fields.Many2many('runbot.build.error.tag', string='Tags', compute=_compute_related_error_content_ids('tag_ids'), search=_search_related_error_content_ids('tag_ids'))
-
     random = fields.Boolean('Random', compute="_compute_random", store=True)
+
+    disappearing_batch_ids = fields.Many2many('runbot.batch', compute='_compute_disappearing_batch_ids', string='Fixing batches')
 
     @api.constrains('tags_min_version_id', 'tags_max_version_id')
     def _check_min_max_version(self):
@@ -288,6 +325,44 @@ class BuildError(models.Model):
             record.description = record.name
             if record.error_content_ids:
                 record.description = record.error_content_ids[0].content
+
+    def _compute_disappearing_batch_ids(self):
+        # this is really inefficient but should only be used in form view
+        # One search per version where it appeared
+        # an alternative solution could be to do it using a table, fetching all batches after the minimal
+        # last_seen_batches, but it could scale verry bad on old errors
+        for record in self:
+            disappearing_batches_ids = []
+            last_seen_batches = record.last_seen_batch_ids
+            for batch in last_seen_batches:
+                disappearing_batch = self.env['runbot.batch'].search([
+                    ('bundle_id', '=', batch.bundle_id.id),
+                    ('id', '>', batch.id),
+                    ('category_id', '=', batch.category_id.id),
+                    ('state', '=', 'done')], order='id', limit=1)
+                if disappearing_batch:
+                    disappearing_batches_ids.append(disappearing_batch.id)
+            record.disappearing_batch_ids = self.env['runbot.batch'].browse(disappearing_batches_ids)
+
+    def action_appearing_batches(self):
+        self.ensure_one()
+        if not self.first_seen_batch_ids:
+            return
+        ids = ','.join(str(i) for i in self.first_seen_batch_ids.ids)
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/runbot/batches/ids/{ids}/{self.id}?title=First%20seen%20batches'
+            }
+
+    def action_disappearing_batches(self):
+        self.ensure_one()
+        if not self.disappearing_batch_ids:
+            return
+        ids = ','.join(str(i) for i in self.disappearing_batch_ids.ids)
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/runbot/batches/ids/{ids}/{self.id}?title=Disappearing%20batches',
+        }
 
     def _compute_content(self):
         for record in self:

--- a/runbot/static/src/js/fields/fields.js
+++ b/runbot/static/src/js/fields/fields.js
@@ -10,7 +10,7 @@ import { useDynamicPlaceholder } from "@web/views/fields/dynamic_placeholder_hoo
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useInputField } from "@web/views/fields/input_field_hook";
 
-import { useRef, xml, Component, markup } from "@odoo/owl";
+import { useRef, xml, Component, markup, useEffect } from "@odoo/owl";
 import { useAutoresize } from "@web/core/utils/autoresize";
 import { getFormattedValue } from "@web/views/utils";
 
@@ -110,7 +110,7 @@ export class FrontendUrl extends Component {
     _route(fieldName) {
         const model = this.props.record.fields[fieldName].relation || "runbot.unknown";
         const id = this.props.record.data[fieldName][0];
-        if (model.startsWith('runbot.') ) {
+        if (model.startsWith('runbot.')){
             return '/runbot/' + model.split('.')[1] + '/' + id;
         } else {
             return false;
@@ -142,7 +142,7 @@ export class FieldCharFrontendUrl extends Component {
     get route() {
         const model = this.props.record.resModel;
         const id = this.props.record.resId;
-        if (model.startsWith('runbot.') ) {
+        if (model.startsWith('runbot.')) {
             return '/runbot/' + model.split('.')[1] + '/' + id;
         } else {
             return false;
@@ -164,7 +164,7 @@ class PullRequestUrlField extends UrlField {
     `;
     static components = { UrlField }
     get fieldProps() {
-        const props = {...this.props};
+        const props = {...this.props };
         const parts = pullRequestRegex.exec(this.props.record.data[props.name])
         if (parts) {
             props.text = `${parts[1]}#${parts[2]}`;
@@ -180,12 +180,3 @@ registry.category("fields").add("pull_request_url", {
     supportedTypes: ["char"],
     component: PullRequestUrlField,
 });
-
-
-//export class GithubTeamWidget extends CharField {
-
-//this.value.split(',').forEach((value) => {
-//    const href = 'https://github.com/orgs/' + organisation + '/teams/' + value.trim() + '/members';
-//}
-//
-//registry.category("fields").add("github_team", GithubTeamWidget);

--- a/runbot/static/src/js/fields/history_graph.js
+++ b/runbot/static/src/js/fields/history_graph.js
@@ -1,0 +1,153 @@
+/** @odoo-module **/
+import { _lt } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useRef, xml, Component, useEffect } from "@odoo/owl";
+
+export class HistoryGraph extends Component {
+    static template = xml`
+        <div class="w-100">
+            <canvas t-ref="canvas"/>
+        </div>
+    `;
+    setup() {
+        this.canvasRef = useRef("canvas");
+        this.data = this.props.record.data[this.props.name] || {};
+        this.errorId = this.data.error_id;
+        this.projectId = this.data.project_id;
+        this.categoryId = this.data.category_id;
+        useEffect(() => this.renderErrorGraph());
+    }
+
+    renderErrorGraph(activeCell) {
+        const canvas = this.canvasRef.el
+        const ctx = canvas.getContext("2d");
+        const maxValue = this.data.max_count;
+        const canvasBorder = 1;
+        const cellBorder = 0.5;
+        const cellSize = this.props.cellSize;
+        const mouseActions = this.props.mouseActions;
+        const cellWidth = cellSize - cellBorder * 2;
+        const cellHeight = cellSize - cellBorder * 2;
+        const canvasWidth = this.data.x_labels.length * cellSize + canvasBorder * 2;
+        const canvasHeight = this.data.y_labels.length * cellSize + canvasBorder * 2;
+        canvas.width = canvasWidth;
+        canvas.height = canvasHeight;
+
+
+        function getColor(value, opacity) {
+            if (value >= 10) {
+                return `rgba(255, 0, 0, ${opacity})`; // red
+            } else if (value >= 5) {
+                return `rgba(255, 165, 0, ${opacity})`; // orange
+            }
+            return `rgba(0, 170, 0, ${opacity})` // green
+        }
+
+        ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+        ctx.fillStyle = "#EEE";
+        ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+        ctx.strokeStyle = "#333";
+        ctx.lineWidth = canvasBorder * 2; // * 2 to account for each side, not only inner width 
+        ctx.strokeRect(0, 0, canvasWidth, canvasHeight,);
+
+        this.data.x_labels.forEach((xLabel, idx) => {
+            this.data.y_labels.forEach((yLabel, idy) => {
+                let value = this.data.daily_version_freq[idx][idy] || 0;
+                let cellColor = "white";
+                let cellOpacity = 0;
+                if (value) {
+                    value = Math.min(value, maxValue);
+                    cellOpacity = ((maxValue * 0.3 + value) / (maxValue * 0.3 + maxValue));
+                    cellColor = getColor(value, cellOpacity);
+                }
+                const posX = idx * cellSize + canvasBorder + cellBorder;
+                const posY = idy * cellSize + canvasBorder + cellBorder;
+
+                ctx.fillStyle = cellColor;
+                ctx.fillRect(posX, posY, cellWidth, cellHeight);
+                if (activeCell && activeCell.col === idx && activeCell.row === idy) {
+                    ctx.strokeStyle = "black";
+                    ctx.lineWidth = 2;
+                    ctx.strokeRect(posX, posY, cellWidth, cellHeight);
+                }
+            });
+        });
+        console.log(mouseActions)
+        if (mouseActions) {
+            canvas.onmousemove = (event) => {
+                let tooltip = canvas.parentElement.querySelector('.history-graph-tooltip');
+                if (tooltip) {
+                    tooltip.remove();
+                }
+
+                const { col, row, value, xLabel, yLabel } = this.getCellFromEvent(event);
+
+                if ( col >= 0 && row >= 0) {
+                    tooltip = document.createElement('div');
+                    tooltip.className = 'history-graph-tooltip';
+                    tooltip.style.position = 'absolute';
+                    tooltip.style.left = `${canvas.offsetLeft}px`;
+                    tooltip.style.top = `${canvas.offsetTop + canvas.height}px`;
+                    tooltip.style.background = '#fff';
+                    tooltip.style.border = '1px solid #333';
+                    tooltip.style.padding = '4px 8px';
+                    tooltip.style.fontSize = '12px';
+                    tooltip.style.pointerEvents = 'none';
+                    tooltip.style.zIndex = 1000;
+                    tooltip.innerHTML = `
+                        Date: ${xLabel}
+                        Version: ${yLabel}
+                        Value: ${value}
+                    `;
+                    canvas.parentElement.appendChild(tooltip);
+                    this.renderErrorGraph({ col, row }); // Re-render to highlight the active cell
+                } else {
+                    this.renderErrorGraph();
+                }
+            };
+
+            canvas.onmouseleave = () => {
+                const tooltip = canvas.parentElement.querySelector('.history-graph-tooltip');
+                if (tooltip) {
+                    tooltip.remove();
+                    this.renderErrorGraph()
+                }
+            };
+
+            canvas.onclick = (event) => {
+                const { col, row, value, xLabel, yLabel } = this.getCellFromEvent(event);
+                if (col >= 0 && row >= 0) {
+                    const url = `/runbot/batches/${this.projectId}/${this.categoryId}/${xLabel}/${this.errorId}`;
+                    window.open(url, '_blank');
+                }
+            }
+        }
+
+    }
+    getCellFromEvent(event) {
+        const rect = this.canvasRef.el.getBoundingClientRect();
+        const x = event.clientX - rect.left - 1; // Adjust for canvas border
+        const y = event.clientY - rect.top - 1; // Adjust for canvas border
+        const col = Math.floor(x / this.props.cellSize);
+        const row = Math.floor(y / this.props.cellSize);
+         if ( col >= 0 && col < this.data.x_labels.length && row >= 0 && row < this.data.y_labels.length) {
+            const value = this.data.daily_version_freq[col][row] || 0;
+            const xLabel = this.data.x_labels[col];
+            const yLabel = this.data.y_labels[row];
+            return { col, row, value, xLabel, yLabel };
+        } else {
+            return { col: -1, row: -1, value: 0, xLabel: '', yLabel: '' };
+        }
+    }
+}
+
+registry.category("fields").add("history_graph", {
+    supportedTypes: ["jsonb"],
+    component: HistoryGraph,
+    extractProps({ attrs, options }, dynamicInfo) {
+        return {
+            cellSize: options.cell_size || 5, // Default cell size if not specified
+            mouseActions: options.mouse_actions || false, // Default to false if not specified
+        };
+    },
+});

--- a/runbot/templates/batches_by_date.xml
+++ b/runbot/templates/batches_by_date.xml
@@ -6,23 +6,31 @@
                 <div class="container-fluid">
                     <div class="row">
                         <h5>
-                            <t t-esc="category.name"/> batches on <t t-esc="batches_date"/>
-                            <div class="btn-group" role="group">
-                                <a t-att-href="previous_date_url" class="btn btn-sm text-start" title="Previous date"><i class="fa fa-chevron-left"/></a>
-                                <a t-att-href="next_date_url" class="btn btn-sm text-start" title="Next date"><i class="fa fa-chevron-right"/></a>
-                                <t t-set="repo_url_separator" t-value="'?'"/>
-                                <t t-if="diff_versions_filter">
-                                    <t t-set="commit_link_details_url" t-value="commit_link_details_url + '?versions_filter_ids=' + ','.join(map(str, diff_versions_filter.ids))"/>
-                                    <t t-set="repo_url_separator" t-value="'&amp;'"/>
-                                </t>
-                                <t t-if="diff_repos_filter">
-                                    <t t-set="commit_link_details_url" t-value="commit_link_details_url + repo_url_separator + 'repos_filter_ids=' + ','.join(map(str, diff_repos_filter.ids))"/>
-                                </t>
-                                <a t-att-href="commit_link_details_url" class="btn btn-sm text-start" title="Compare all batches with their bases" groups="runbot.group_runbot_advanced_user">
-                                    <i class="fa fa-arrows-v"/>
-                                </a>
-                            </div>
+                            <t t-if="batches_date">
+                                <t t-esc="category.name"/>Batches on <t t-esc="batches_date"/>
+                            </t>
+                            <t t-if="title">
+                                <t t-esc="title"/>
+                            </t>
+                            <t t-if="build_error">
+                                <em>Error <a t-attf-href="/odoo/error/{build_error.id}" t-esc="build_error.id"/></em>
+                            </t>
                         </h5>
+                        <div>
+                            <a t-if="previous_date_url" t-att-href="previous_date_url" class="btn btn-sm text-start" title="Previous date"><i class="fa fa-chevron-left"/></a>
+                            <a t-if="next_date_url" t-att-href="next_date_url" class="btn btn-sm text-start" title="Next date"><i class="fa fa-chevron-right"/></a>
+                            <t t-set="repo_url_separator" t-value="'?'"/>
+                            <t t-if="diff_versions_filter">
+                                <t t-set="commit_link_details_url" t-value="commit_link_details_url + '?versions_filter_ids=' + ','.join(map(str, diff_versions_filter.ids))"/>
+                                <t t-set="repo_url_separator" t-value="'&amp;'"/>
+                            </t>
+                            <t t-if="diff_repos_filter">
+                                <t t-set="commit_link_details_url" t-value="commit_link_details_url + repo_url_separator + 'repos_filter_ids=' + ','.join(map(str, diff_repos_filter.ids))"/>
+                            </t>
+                            <a t-att-href="commit_link_details_url" title="Compare all batches with their bases" groups="runbot.group_runbot_advanced_user">
+                                See diffs <i class="fa fa-arrows-v"/>
+                            </a>
+                        </div>
                         <t t-foreach="batches" t-as="batch">
                             <div class="col-md-1">
                                 <t t-esc="batch.bundle_id.name" />

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -34,8 +34,6 @@
               </group>
               <group>
                 <group name="fixer_info" string="Fixing" col="2">
-                  <field name="breaking_pr_id"/>
-                  <field name="breaking_pr_url"  widget="pull_request_url" invisible="not breaking_pr_id"/>
                   <field name="breaking_bundle_url" invisible="not breaking_pr_id"/>
                   <field name="responsible"/>
                   <field name="customer"/>
@@ -50,11 +48,15 @@
                   <field name="trigger_ids" widget="many2many_tags"/>
                   <field name="tag_ids" widget="many2many_tags"/>
                   <field name="random"/>
+                  <field name="breaking_pr_id"/>
+                  <field name="breaking_pr_url"  widget="pull_request_url" invisible="not breaking_pr_id"/>
                   <field name="first_seen_date" widget="frontend_url" options="{'link_field': 'first_seen_build_id'}"/>
                   <field name="last_seen_date" widget="frontend_url" options="{'link_field': 'last_seen_build_id'}"/>
-                  <field name="graph_history"/>
                   <field name="first_seen_build_id" invisible="True"/>
                   <field name="last_seen_build_id" invisible="True"/>
+                  <field name="history_data" widget="history_graph" options="{'cell_size': 13, 'mouse_actions': True}"/>
+                  <button name="action_appearing_batches" string="Appearing Batches" type="object" class="btn btn-primary" invisible="not first_seen_batch_ids"/>
+                  <button name="action_disappearing_batches" string="Disappearing Batches" type="object" class="btn btn-primary" invisible="not disappearing_batch_ids"/>
                 </group>
               </group>
               <group name="test_tags_group" string="Disabling">
@@ -254,7 +256,7 @@
               <field name="fixing_pr_id" optional="hide"/>
               <field name="fixing_pr_alive" optional="hide"/>
               <field name="fixing_pr_url" widget="pull_request_url" text="view PR" readonly="1" invisible="not fixing_pr_url"/>
-              <field name="graph_history" optional="show" width="210px"/>
+              <field name="history_data" widget="history_graph" optional="show" width="210px"/>
           </list>
       </field>
   </record>
@@ -290,7 +292,7 @@
                 <field name="fixing_pr_alive" optional="hide"/>
                 <field name="fixing_pr_url" widget="url" text="view PR" readonly="1" invisible="not fixing_pr_url"/>
                 <field name="fingerprint" optional="hide"/>
-                <field name="graph_history" optional="show" width="210px"/>
+                <field name="history_data" widget="history_graph" optional="show" width="210px"/>
                 <field name="seen_hash" optional="hide"/>
             </list>
         </field>


### PR DESCRIPTION
Since #1189 the rendering of the page is slower, mainly because of the number of element in the svg. This commit replaces the svg with a canvas element, which is much faster to render.

This also allow to customize the rendering.

While on it, adding a possibility to get all first batch, and all last batch