### PR TITLE
[FIX] runbot: ensure correct batch order in last_batchs compute

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -155,7 +155,7 @@ class Bundle(models.Model):
         if self.ids:
             category_id = self.env.context.get('category_id', self.env['ir.model.data']._xmlid_to_res_id('runbot.default_category'))
             self.env.cr.execute("""
-                SELECT bundle.id, ARRAY_AGG(batch.id)
+                SELECT bundle.id, ARRAY_AGG(batch.id ORDER BY batch.id DESC)
                   FROM runbot_bundle bundle
           JOIN LATERAL (
                         SELECT b.id


### PR DESCRIPTION
**Problem:**
In some environments, the `last_batchs` field was returning batches in a non-deterministic order, even though the backend query was intended to sort them by most recent first. This was due to the use of PostgreSQL's `ARRAY_AGG` function without an explicit `ORDER BY` clause, which does not guarantee the order of elements in the resulting array.

This caused the frontend to display batches in the wrong order, despite the backend shell showing them correctly, leading to confusion and inconsistent UI behavior.

**Solution:**
Explicitly specify the order in the `ARRAY_AGG` function within the SQL query used in `_compute_last_batchs`. By adding `ORDER BY batch.id DESC`, we ensure that the array of batch IDs is always sorted from newest to oldest, matching the intended logic and the backend results.