### PR TITLE
[FIX] runbot: fix bundle foreign repo logic

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -302,7 +302,7 @@ class Batch(models.Model):
                 if batches:
                     self.base_reference_batch_id = batches[0]
 
-            if missing_repos and bundle.always_use_foreign and foreign_projects:
+            if missing_repos and (bundle.always_use_foreign or project.always_use_foreign) and foreign_projects:
                 self._log('Starting by filling foreign repo')
                 foreign_bundles = bundle.search([('name', '=', bundle.name), ('project_id', 'in', foreign_projects.ids)])
                 used_branches = _fill_missing({branch: branch.head for branch in foreign_bundles.mapped('branch_ids').sorted('is_pr', reverse=True)}, 'head')

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -21,7 +21,7 @@ class Bundle(models.Model):
     no_build = fields.Boolean('No build')
     no_auto_run = fields.Boolean('No run')
     build_all = fields.Boolean('Force all triggers')
-    always_use_foreign = fields.Boolean('Use foreign bundle', help='By default, check for the same bundle name in another project to fill missing commits.', default=lambda self: self.project_id.always_use_foreign)
+    always_use_foreign = fields.Boolean('Use foreign bundle', help='By default, check for the same bundle name in another project to fill missing commits.')
     modules = fields.Char("Modules to install", help="Comma-separated list of modules to install and test.")
 
     batch_ids = fields.One2many('runbot.batch', 'bundle_id')


### PR DESCRIPTION
The current logic was not working because the project is not set when the default is evaluated.