### PR TITLE
[IMP] runbot: add a button to disable regular triggers

### DIFF
--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -329,6 +329,28 @@ class Bundle(models.Model):
         }
         return self._generate_custom_trigger_action(context)
 
+    def action_disable_all_triggers(self):
+        triggers_to_disable = (
+            self.env["runbot.trigger"]
+            .search([
+                ("id", "not in", self.trigger_custom_ids.trigger_id.ids),
+                ("project_id", "=", self.project_id.id),
+                ("manual", "=", False),
+                ("category_id", "=", 1),
+            ])
+            .filtered(
+                lambda rec: not rec.version_domain or self.version_id.filtered_domain(rec._get_version_domain()),
+            )
+        )
+        vals = []
+        for trigger in triggers_to_disable:
+            vals.append({
+                'bundle_id': self.id,
+                'trigger_id': trigger.id,
+                'start_mode': 'disabled',
+            })
+        self.env['runbot.bundle.trigger.custom'].create(vals)
+
 
 class BundleTag(models.Model):
 

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -43,6 +43,7 @@
                 <header>
                     <button name="action_generate_custom_trigger_multi_action" string="New custom multi" type="object" class="oe_highlight"/>
                     <button name="action_generate_custom_trigger_restore_action" string="New custom restore" type="object" class="oe_highlight"/>
+                    <button name="action_disable_all_triggers" string="Disable regular triggers" type="object" class="oe_highlight"/>
                 </header>
                 <sheet>
                     <group>

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -83,7 +83,7 @@
                                 <list editable="bottom">
                                     <field name="start_mode"/>
                                     <field name="use_base_commits"/>
-                                    <field name="trigger_id" domain="[('project_id', '=', parent.project_id)]"/>
+                                    <field name="trigger_id" domain="[('project_id', '=', parent.project_id), ('category_id.name', '=', 'Default')]"/>
                                     <field name="config_id"/>
                                     <field name="extra_params"/>
                                     <field name="config_data" widget="runbotjsonb"/>


### PR DESCRIPTION
[IMP] runbot: add a button to disable regular triggers

It's sometimes useful to disable regular triggers on a bundle to only
starts manual or custom triggers.

With this commit, a button is added on the bundle page to disable
regular triggers by creating disabled custom triggers.
