### PR TITLE
[FIX] runbot: fix custom trigger wizard

### DIFF
--- a/runbot/views/custom_trigger_wizard_views.xml
+++ b/runbot/views/custom_trigger_wizard_views.xml
@@ -26,7 +26,7 @@
                     </group>
                     <group colspan="4">
                         <field name="child_extra_params"/>
-                        <field name="config_data"  widget="runbotjsonb" readonly="1"/>
+                        <field name="config_data"  widget="runbotjsonb"/>
                     </group>
                 </group>
                 <footer>


### PR DESCRIPTION
Passing the widget in readonly was a stupid idea.