### PR TITLE
[FIX] runbot: forward X-Accel-Buffering header for streaming responses

### DIFF
--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -91,7 +91,10 @@ server {
     listen 8080;
     server_name ~^<t t-out="re_escape(build.dest)"/>(-[a-z0-9_-]+)?\.<t t-out="re_escape(build.host)"/>$;
     <t id="build_anchor"/>
-    location / { proxy_pass http://127.0.0.1:<t t-out="build.port"/>; }
+    location / {
+      proxy_pass_header "X-Accel-Buffering";
+      proxy_pass http://127.0.0.1:<t t-out="build.port"/>;
+    }
     location /longpolling { proxy_pass http://127.0.0.1:<t t-out="build.port + 1"/>; }
     location /websocket {
       proxy_pass http://127.0.0.1:<t t-out="build.port + 1"/>;


### PR DESCRIPTION
Because of multi-layered use of nginx, responses with "X-Accel-Buffering: no" is still buffered because the special header is absorbed by layer just above the odoo app. As a result, it's impossible to test in runbot endpoints that stream responses. To ensure that header is respected thoughout the stack, we propose in this commit to pass the "X-Accel-Buffering" header.