### PR TITLE
[FIX] runbot: fix stats for dynamic steps

### DIFF
--- a/runbot/documentation/dynamic_config.md
+++ b/runbot/documentation/dynamic_config.md
@@ -70,6 +70,7 @@ The config steps are mainly defined by their `job_type`. The `name` key is also 
     'demo_mode': OPTIONAL(IN(['default', 'with_demo', 'without_demo'])),
     'enable_auto_tags': OPTIONAL(BOOL),
     'cpu_limit': OPTIONAL(INT),
+    'make_stats': OPTIONAL(BOOL),
 }
 ```
 The `db_name` is optionnal, usually set to all as a convention on runbot for databases that contains *almost* all modules. If not defined the sanitized version of the name will be used.
@@ -231,6 +232,7 @@ A `trigger_id` can be provided to restore from the build created by a specific t
     'cpu_limit': OPTIONAL(INT),
     'install_requirements': OPTIONAL(BOOL),
     'export_database': OPTIONAL(BOOL),
+    'make_stats': OPTIONAL(BOOL),
 }
 ```
 

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -231,6 +231,7 @@ class Config(models.Model):
             'enable_auto_tags': OPTIONAL(BOOL),
             'cpu_limit': OPTIONAL(INT),
             'export_database': OPTIONAL(BOOL),
+            'make_stats': OPTIONAL(BOOL),
         }
         valid_steps['create_build'] = {
             'name': REQUIRED(NAME),
@@ -257,6 +258,7 @@ class Config(models.Model):
             'export_database': OPTIONAL(BOOL),
             'check_logs': OPTIONAL(LIST(STR)),
             'expected_logs': OPTIONAL(LIST(STR)),
+            'make_stats': OPTIONAL(BOOL),
         }
         validate(config_schema, config, 'config')
 
@@ -1504,7 +1506,11 @@ class ConfigStep(models.Model):
             build.local_result = self._get_checkers_result(build, checkers)
 
     def _make_stats(self, build):
-        if not self.make_stats:  # TODO garbage collect non sticky stat
+        make_stats = self.make_stats
+        current_dynamic_step = self._get_dynamic_step(build) or {}
+        if current_dynamic_step and 'make_stats' in current_dynamic_step:
+            make_stats = current_dynamic_step['make_stats']
+        if not make_stats:  # TODO garbage collect non sticky stat
             return
         build._log('make_stats', 'Getting stats from log file')
         log_path = build._path('logs', '%s.txt' % self.sanitized_name(build))
@@ -1520,6 +1526,7 @@ class ConfigStep(models.Model):
                 build_stats = [
                     {
                         'config_step_id': self.id,
+                        'dynamic_step_name': current_dynamic_step.get('name', ''),
                         'build_id': build.id,
                         'category': category,
                         'values': values,
@@ -1566,25 +1573,33 @@ class ConfigStep(models.Model):
                 modified_files[commit_link] = files
         return modified_files
 
+    def _get_dynamic_step(self, build):
+        if self.job_type != 'dynamic':
+            return None
+        dynamic_config = build.dynamic_config
+        if not dynamic_config:
+            return None
+        steps = dynamic_config.get("steps", [])
+        if not steps:
+            return None
+        if len(steps) <= build.dynamic_active_step_index:
+            _logger.error('Invalid dynamic_active_step_index %s, only %s steps defined', build.dynamic_active_step_index, len(steps))
+            return None
+        current_step = steps[build.dynamic_active_step_index]
+        return current_step
+
     def _run_dynamic(self, build):
         if len(build.ancestors) > 6:
             raise RunbotException('Too many ancestors builds, possible cyclic dynamic build creation')
         if build.parent_id and build.dynamic_config == build.parent_id.dynamic_config:
             raise RunbotException('A child build cannot load the same dynamic config if parent, recursion detected')
-
-        dynamic_config = build.dynamic_config
-        dynamic_active_step_index = build.dynamic_active_step_index
-        if not dynamic_config:
-            build._log('', 'No dynamic config found, skipping', level="WARNING")
+        current_step = self._get_dynamic_step(build)
+        if not current_step:
+            build._log('Dynamic Step', 'No dynamic config or steps found, skipping', level="WARNING")
             return
-        steps = dynamic_config.get("steps", [])
-        if not steps:
-            build._log('', 'Dynamic config has no steps, skipping', level="WARNING")
-            return
-        current_step = steps[dynamic_active_step_index]
         if current_step['job_type'] == 'create_build':
             for_each_vars_list = current_step.get('for_each_vars', [{}])
-            parent_vars = {**dynamic_config.get('vars', {}), **build.params_id.config_data.get('dynamic_vars', {})}
+            parent_vars = {**build.dynamic_config.get('vars', {}), **build.params_id.config_data.get('dynamic_vars', {})}
             child_data_list = []
             for child_index, child in enumerate(current_step.get('children', [])):
                 child_vars = child.get('vars', {})

--- a/runbot/models/build_stat.py
+++ b/runbot/models/build_stat.py
@@ -12,13 +12,14 @@ class BuildStat(models.Model):
     _log_access = False
 
     _build_config_key_unique = models.Constraint(
-        'unique (build_id, config_step_id, category)',
+        'unique (build_id, config_step_id, category, dynamic_step_name)',
         "Build stats must be unique for the same build step",
     )
 
     build_id = fields.Many2one("runbot.build", "Build", index=True, ondelete="cascade")
     config_step_id = fields.Many2one(
-        "runbot.build.config.step", "Step", ondelete="cascade"
+        "runbot.build.config.step", "Step", ondelete="cascade",
     )
+    dynamic_step_name = fields.Char("Dynamic Step Name")
     category = fields.Char("Category", index=True)
     values = JsonDictField("Value")

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -93,7 +93,7 @@ class Trigger(models.Model):
         ('no_pending', 'No pending'),
         ('errors', 'Only errors'),
     ], string="CI startegy", default='all', help="Strategy to use when sending CI status to github")
-    has_stats = fields.Boolean('Has a make_stats config step', compute="_compute_has_stats", store=True)
+    has_stats = fields.Boolean('Has a make_stats config step', compute="_compute_has_stats", store=True, readonly=False)
 
     team_ids = fields.Many2many('runbot.team', string="Runbot Teams", help="Teams responsible of this trigger, mainly usefull for nightly")
     active = fields.Boolean("Active", default=True)

--- a/runbot/tests/test_build_stat.py
+++ b/runbot/tests/test_build_stat.py
@@ -72,12 +72,12 @@ nothing to see here
             with mute_logger("odoo.sql_db"):
                 with self.cr.savepoint():  # needed to continue tests
                     self.env["runbot.build.stat"].create({
-                        'build_id': self.build.id, 
+                        'build_id': self.build.id,
+                        'dynamic_step_name': '',
                         'config_step_id': self.config_step.id,
                         'category': 'query_count',
                         'values': {'website_event.tests.test_ui': 2435},
                         }
-
                     )
 
     def test_build_stat_regex_generic(self):

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -20,6 +20,7 @@
                   <field name="network_enabled"/>
                   <field name="config_data" widget="runbotjsonb"/>
                   <field name="report_view_id"/>
+                  <field name="has_stats"/>
                 </group>
                 <group>
                   <field name="description"/>


### PR DESCRIPTION
Since dynamic steps are a thing, it is possible to have the same step multiple time in a build breaking the stats constraint.

Note that the step could be removed as it is not mandatory but having doubled stats without a way to distinguish them is not ideal, adding the dynamic step name for now.