### PR TITLE
[FIX] runbot: CodeEditor crash with 'json' mode

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -69,6 +69,7 @@
             'runbot/static/src/libs/diff_match_patch/diff_match_patch.js',
             'runbot/static/src/js/views/**/*',
             'runbot/static/src/js/fields/*',
+            'runbot/static/src/js/components/*',
         ],
         'runbot.assets_frontend': [
             '/web/static/lib/bootstrap/dist/css/bootstrap.css',

--- a/runbot/static/src/js/components/code_editor.js
+++ b/runbot/static/src/js/components/code_editor.js
@@ -1,0 +1,6 @@
+import { patch } from "@web/core/utils/patch";
+import { CodeEditor } from "@web/core/code_editor/code_editor";
+
+patch(CodeEditor, {
+    MODES: [...new Set(CodeEditor.MODES).add("json")],
+});


### PR DESCRIPTION
While Odoo provides ACE editor with json mode, for some reason (?) this mode isn't activated for the CodeEditor component.

As it isn't used anywhere in the Odoo codebase (? bis), this commit only activate it for the runbot.

Steps to reproduce:
- Open any config form view in debug => crash with unsupported mode