### PR TITLE
[FIX] runbot: pagination padding in Standard mode

### DIFF
--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -426,9 +426,3 @@ code {
 .hide-success tr.bg-success-subtle {
     display: none;
 }
-
-/* .pagination */
-.page-link:has(.oi:only-child) {
-	--bs-pagination-padding-x: 0.625rem;
-	--bs-pagination-padding-y: 0.625rem;
-}


### PR DESCRIPTION
Since commit [^1], the addition of the HTML5 doctype made the browser's rendering switch from "Quirks mode" to "Standard mode". This applies a lot of subtle adjustments to the layout's handling and, in this case, made the pagination's padding adjustment useless and even broken.

This commit removes the (now faulty) padding's override.

[^1]: odoo/runbot@dc6ffbda