### PR TITLE
[IMP] runbot: reduce render blocking ressources

### DIFF
--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -8,7 +8,8 @@
                     <meta charset="utf-8"/>
                     <title t-out="title or 'Runbot'"/>
 
-                    <t t-call-assets="runbot.assets_frontend"/>
+                    <t t-call-assets="runbot.assets_frontend" t-js="False"/>
+                    <t t-call-assets="runbot.assets_frontend" t-css="False" defer_load="True"/>
 
                     <t t-if="refresh">
                         <meta http-equiv="refresh" t-att-content="refresh"/>


### PR DESCRIPTION
CSS is render-blocking by nature. But JavaScript can be deferred to allow a faster first contentful paint.