### PR TITLE
[IMP] runbot: allow to archive config and steps

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -67,12 +67,14 @@ def prepend_string(modules, build, dynamic_vars, element):
 def append_string(modules, build, element):
     return ','.join([f'{module}{element}' for module in modules.split(',')])
 
+
 class Config(models.Model):
     _name = 'runbot.build.config'
     _description = "Build config"
     _inherit = "mail.thread"
 
     name = fields.Char('Config name', required=True, tracking=True, help="Unique name for config please use trigram as postfix for custom configs")
+    active = fields.Boolean('Active', default=True, tracking=True)
 
     description = fields.Char('Config description')
     step_order_ids = fields.One2many('runbot.build.config.step.order', 'config_id', copy=True)
@@ -343,6 +345,7 @@ class ConfigStep(models.Model):
 
     # general info
     name = fields.Char('Step name', required=True, tracking=True, help="Unique name for step please use trigram as postfix for custom step_ids")
+    active = fields.Boolean('Active', default=True, tracking=True)
     domain_filter = fields.Char('Domain filter', tracking=True)
     description = fields.Char('Config step description')
 

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <form string="Build config">
                 <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" invisible="active"/>
                     <div class="alert alert-warning" role="alert" invisible="not protected">
                         This record is protected and can only be edited by config administrator.
                     </div>
@@ -35,6 +36,7 @@
         <field name="arch" type="xml">
             <form string="Build config step">
                 <sheet>
+                    <widget name="web_ribbon" title="Archived" bg_color="bg-danger" invisible="active"/>
                     <div class="alert alert-warning" role="alert" invisible="not protected">
                         This record is protected and can only be edited by config administrator.
                     </div>
@@ -166,6 +168,7 @@
         <search string="Search config">
           <field name="name"/>
           <field name="group_name"/>
+          <filter string="Archived" name='is_archived' domain="[('active', '=', False)]"/>
           <filter string="Is in a group" name='is_in_group' domain="[(['group', '!=', False])]"/>
           <filter string="No step's defined" name="no_step" domain="[(['step_order_ids', '=', False])]"/>
         </search>
@@ -185,6 +188,7 @@
               ('python_result_code', 'ilike', self),
           ]">
         </field>
+          <filter string="Archived" name='is_archived' domain="[('active', '=', False)]"/>
           <filter string="Install job" name='install_job' domain="[(['job_type', '=', 'install_odoo'])]"/>
           <filter string="Run job" name='run_job' domain="[(['job_type', '=', 'run_odoo'])]"/>
           <filter string="Python job" name='python_job' domain="[(['job_type', '=', 'python'])]"/>


### PR DESCRIPTION
A lots of config and steps are unused but deleting them is tricky in case of rebuids, or just because the config is referenced somewhere and we son't want to loose the information or risk expensive foreign key checks

This pr allows to archive those records