### PR TITLE
[FIX] runbot: undefined ids in frontend url links

### DIFF
--- a/runbot/static/src/js/fields/fields.js
+++ b/runbot/static/src/js/fields/fields.js
@@ -106,7 +106,7 @@ export class FrontendUrl extends Component {
 
     _route(fieldName) {
         const model = this.props.record.fields[fieldName].relation || "runbot.unknown";
-        const id = this.props.record.data[fieldName][0];
+        const { id } = this.props.record.data[fieldName];
         if (model.startsWith('runbot.')){
             return '/runbot/' + model.split('.')[1] + '/' + id;
         } else {


### PR DESCRIPTION
This commit fixes the id retrieval from the record's data in the "frontend_url" field.

Steps to reproduce:
- Open Errors
- Open one of them
- In the Error Content list view, click on one of date in the {First,Last} seen date column => 404 not found error due to "undefined" id used in the URL.