### PR TITLE
[FIX] runbot: make github login case insensitive in team membership check

### DIFF
--- a/runbot/models/build_config_codeowner.py
+++ b/runbot/models/build_config_codeowner.py
@@ -134,7 +134,7 @@ class ConfigStep(models.Model):
                 pr = pr_by_commit[commit_link]
                 new_reviewers = reviewers - set((pr.reviewers or '').split(','))
                 if new_reviewers:
-                    author_skippable_teams = skippable_teams.filtered(lambda team: team.skip_team_pr and team.github_team in new_reviewers and pr.pr_author in team._get_members_logins())
+                    author_skippable_teams = skippable_teams.filtered(lambda team: team.skip_team_pr and team.github_team in new_reviewers and pr.pr_author and pr.pr_author.lower() in team._get_members_logins())
                     author_skipped_teams = set(author_skippable_teams.mapped('github_team'))
                     if author_skipped_teams:
                         new_reviewers = new_reviewers - author_skipped_teams

--- a/runbot/models/team.py
+++ b/runbot/models/team.py
@@ -94,7 +94,7 @@ class RunbotTeam(models.Model):
         if self.github_logins:
             team_loggins = set(self.github_logins.split(','))
         team_loggins |= set(self.user_ids.filtered(lambda user: user.github_login).mapped('github_login'))
-        return team_loggins
+        return [login.lower() for login in team_loggins]
 
     def _fetch_members(self):
         self.check_access_rights('write')


### PR DESCRIPTION
Github login are not case sensitive, and the case is not always the same depending on where we get them from (github api, user input, etc).

Making the check case insensitive to avoid issues.