### PR TITLE
[IMP] runbot: allow to create one build per module

### DIFF
--- a/runbot/documentation/dynamic_config.md
+++ b/runbot/documentation/dynamic_config.md
@@ -109,6 +109,8 @@ test_tags is also a dynamic value and can use variables, as well as [filter](#fi
     'job_type': 'create_build',
     'children': REQUIRED(LIST(CONFIG)),
     'for_each_vars': OPTIONAL(LIST(VARS)),
+    'for_each_module': OPTIONAL(DYNAMIC_VALUE),
+    'max_builds': OPTIONAL(INT),
 }
 ```
 
@@ -198,6 +200,24 @@ This is how the runbot post install builds are created, using [filters](#filters
     }]
 }
 ```
+
+`for_each_module` allow to create one child per selected module (comma separated list, can be a dynamic value)
+
+```json
+ {
+    "job_type": "create_build",
+    "for_each_module": "base,web,mail"
+}
+```
+``` json
+{
+    "job_type": "create_build",
+    "for_each_module": "{{*|filter_all_modules|modified_modules}}",
+    "max_builds": 20,
+}
+```
+
+
 
 ### Restore steps
 
@@ -322,7 +342,7 @@ Note that using `web` instead of `web->web` would include web, but also all modu
 
 Filters are a way to transform dynamic values before using them. They are defined by appending `|filter_name` to the dynamic value.
 
-Filters are currently only used to transform module filters into test tags.
+For example, to transform a module filter into test tags:
 
 ```json
     {"test_tags": "-at_install,{{test_module_filter|filter_all_modules|make_module_test_tags}}",
@@ -333,3 +353,12 @@ In this example, the `filter_all_modules` filters will first transform the `test
 Note that `filter_all_modules` is actually equivalent to `filter_default_modules`, but prepending a `*` at the begining of the filter.
 
 `*,mail -> !web|filter_default_modules` is the same as `mail -> !web|filter_all_modules`
+
+In some case we also want to combine the test-tags module with another tag or test method, this can be done using prepend and append
+
+`"{{-*,web*|filter_all_modules|make_module_test_tags|append('.test_method')}}`
+`{{-*,web*|filter_all_modules|make_module_test_tags|prepend('custom_tag')}}`
+
+
+It is also possible to filter modules based on the one modified in the current bundle.
+`{{*|filter_all_modules|modified_modules}}"`

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1194,6 +1194,27 @@ class BuildResult(models.Model):
                 if os.path.isdir(commit._source_path(addons_path)):
                     yield os.sep.join([repo_folder, addons_path]).strip(os.sep)
 
+    def _modified_files(self, commit_link_links=None):
+        modified_files = {}
+        if commit_link_links is None:
+            commit_link_links = self.params_id.commit_link_ids
+        for commit_link in commit_link_links:
+            commit = commit_link.commit_id
+            modified = commit.repo_id._git(['diff', '--name-only', '%s..%s' % (commit_link.merge_base_commit_id.name, commit.name)])
+            if modified:
+                files = [os.sep.join([self._docker_source_folder(commit), file]) for file in modified.split('\n') if file]
+                modified_files[commit_link] = files
+        return modified_files
+
+    def _modified_modules(self, commit_link_links=None):
+        modified_files = self._modified_files(commit_link_links)
+        modified_modules = set()
+        for commit_link, files in modified_files.items():
+            commit = commit_link.commit_id
+            for file in files:
+                modified_modules.add(commit.repo_id._get_module(file))
+        return modified_modules
+
     def _get_upgrade_path(self):
         for commit in (self.env.context.get('defined_commit_ids') or self.params_id.commit_ids):
             if not commit.repo_id.upgrade_paths:

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -52,6 +52,22 @@ def filter_default_modules(selector, build, dynamic_vars):
     return ','.join(modules)
 
 
+def keep_modified_modules(modules, build, dynamic_vars):
+    if build.params_id.config_data.get('skip_modified_modules_filter', False):
+        return modules
+    modified_modules = build._modified_modules()
+    modules = modules.split(',')
+    filtered_modules = [module for module in modules if module in modified_modules]
+    return ','.join(filtered_modules)
+
+
+def keep_modified_modules_or_base(modules, build, dynamic_vars):
+    bundle = build.params_id.create_batch_id.bundle_id
+    if bundle.is_base or bundle.is_staging:
+        return modules
+    return keep_modified_modules(modules, build, dynamic_vars)
+
+
 def make_module_test_tags(modules, build, dynamic_vars):
     return ','.join([f'/{module}' for module in modules.split(',')])
 
@@ -64,7 +80,11 @@ def prepend_string(modules, build, dynamic_vars, element):
     return ','.join([f'{element}{module}' for module in modules.split(',')])
 
 
-def append_string(modules, build, element):
+def append_string(modules, build, dynamic_vars, element):
+    if re.match(r'^[\'"].*[\'"]$', element):
+        element = element[1:-1]
+    else:
+        element = dynamic_vars.get(element, element)
     return ','.join([f'{module}{element}' for module in modules.split(',')])
 
 
@@ -240,6 +260,8 @@ class Config(models.Model):
             'job_type': 'create_build',
             'children': REQUIRED(LIST(CONFIG)),
             'for_each_vars': OPTIONAL(LIST(VARS)),
+            'for_each_module': OPTIONAL(DYNAMIC_VALUE),
+            'max_builds': OPTIONAL(INT),
         }
         valid_steps['restore'] = {
             'name': REQUIRED(NAME),
@@ -533,7 +555,7 @@ class ConfigStep(models.Model):
             return build._docker_run(self, **docker_params)
         return True
 
-    def _run_create_build(self, build, config_data=None):
+    def _run_create_build(self, build, config_data=None, max_build=200):
         if config_data:
             config_data = {**config_data, **build.params_id.config_data}
         else:
@@ -552,9 +574,10 @@ class ConfigStep(models.Model):
                 child_data_values = {'config_data': {}, **child_data, 'config_id': create_config}
                 for _ in range(config_data.get('number_build', self.number_builds)):
                     count += 1
-                    if count > 200:
+                    if count > max_build:
                         build._logger('Too much build created')
-                        break
+                        build._log('create_build', f'More than {max_build} build created, stopping', level='WARNING')
+                        return
                     config_name = config_name or create_config.name
                     child = build._add_child(child_data_values, orphan=self.make_orphan, description=description or config_name)
                     build._log('create_build', 'created with config %s' % config_name, log_type='subbuild', path=str(child.id))
@@ -1565,16 +1588,7 @@ class ConfigStep(models.Model):
         return success
 
     def _modified_files(self, build, commit_link_links=None):
-        modified_files = {}
-        if commit_link_links is None:
-            commit_link_links = build.params_id.commit_link_ids
-        for commit_link in commit_link_links:
-            commit = commit_link.commit_id
-            modified = commit.repo_id._git(['diff', '--name-only', '%s..%s' % (commit_link.merge_base_commit_id.name, commit.name)])
-            if modified:
-                files = [os.sep.join([build._docker_source_folder(commit), file]) for file in modified.split('\n') if file]
-                modified_files[commit_link] = files
-        return modified_files
+        return build._modified_files(commit_link_links=commit_link_links)
 
     def _get_dynamic_step(self, build):
         if self.job_type != 'dynamic':
@@ -1602,6 +1616,15 @@ class ConfigStep(models.Model):
             return
         if current_step['job_type'] == 'create_build':
             for_each_vars_list = current_step.get('for_each_vars', [{}])
+            if 'for_each_module' in current_step:
+                modules_vars = []
+                for for_each_vars in for_each_vars_list:
+                    modules_entry = self._parse_dynamic_entry(current_step['for_each_module'], build, additional_dynamic_vars=for_each_vars)
+                    modules = [m.strip() for m in modules_entry.split(',') if m.strip()]
+                    for module in modules:
+                        module_vars = {**for_each_vars, 'module': module}
+                        modules_vars.append(module_vars)
+                for_each_vars_list = modules_vars
             parent_vars = {**build.dynamic_config.get('vars', {}), **build.params_id.config_data.get('dynamic_vars', {})}
             child_data_list = []
             for child_index, child in enumerate(current_step.get('children', [])):
@@ -1623,7 +1646,11 @@ class ConfigStep(models.Model):
                         'description': description,
                     }
                     child_data_list.append(child_data)
-            return self._run_create_build(build, {'child_data': child_data_list, 'number_build': current_step.get('number_builds', 1)})
+            return self._run_create_build(
+                build,
+                {'child_data': child_data_list, 'number_build': current_step.get('number_builds', 1)},
+                max_build=min(current_step.get('max_builds', 20), 200),
+            )
 
         if current_step['job_type'] == 'restore':
             config_data = {
@@ -1701,6 +1728,8 @@ class ConfigStep(models.Model):
             'make_module_test_tags': make_module_test_tags,
             'prepend': prepend_string,
             'append': append_string,
+            'modified_modules': keep_modified_modules,
+            'modified_modules_or_base': keep_modified_modules_or_base,
         }
         dynamic_vars = {**dynamic_config.get('vars', {}), **build.params_id.config_data.get('dynamic_vars', {}), **(additional_dynamic_vars or {})}
 
@@ -1718,8 +1747,8 @@ class ConfigStep(models.Model):
                 if match := re.match(r'(\w+)\((.+)\)', processor):
                     processor = match.group(1)
                     args = match.group(2).split(',')
-                expression_filter = expression_filters.get(processor, *args)
-                if not processor:
+                expression_filter = expression_filters.get(processor)
+                if not expression_filter:
                     build._log('Dynamic Config', f'Unknown processor {processor} in dynamic config entry {entry}', level="ERROR")
                     return expression
                 value = expression_filter(value, build, dynamic_vars, *args)

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -134,7 +134,7 @@ class Trigger(models.Model):
             return safe_eval(self.version_domain)
         return []
 
-    def _filter_modules_to_test(self, modules, module_patterns=None):
+    def _filter_modules_to_test(self, modules_per_repo, module_patterns=None):
         if module_patterns == '-*':
             return []
         repo_module_patterns = {}
@@ -154,34 +154,48 @@ class Trigger(models.Model):
                 exclude.append(e2)
             return lambda mod: ((not e1 or mod >= e1) and (not e2 or mod <= e2) and mod not in exclude)
 
-        def _filter_patterns(patterns_list, default, all):
+        def _filter_patterns(patterns_list, default, all_modules):
             current = set(default)
             for pat in patterns_list:
                 pat = pat.replace(' ', '')
                 if not pat:
                     continue
-                if pat == '-*':
-                    current = set()
-                elif pat == '*':
-                    current = set(all)
-                elif '->' in pat:
+
+                if '->' in pat:
                     mod_filter = _parse_filter(pat)
                     current = {mod for mod in current if mod_filter(mod)}
-                elif pat.startswith(('-', '!')):
+                    continue
+
+                negate = False
+                repo = None
+                if pat.startswith(('-', '!')) and '->' not in pat:
+                    negate = True
                     pat = pat[1:]
-                    current -= {mod for mod in current if fnmatch.fnmatch(mod, pat)}
-                elif pat:
-                    current |= {mod for mod in all if fnmatch.fnmatch(mod, pat)}
+                available_modules = all_modules
+                if '/' in pat:
+                    repo, pat = pat.split('/', 1)
+                    available_modules = {mod: r for mod, r in all_modules.items() if r.name == repo}
+
+                if pat == '*' and not repo:  # optimisation when matchin all
+                    if negate:
+                        current = set()
+                    else:
+                        current = set(available_modules)
+                else:
+                    selection = {mod for mod in available_modules if fnmatch.fnmatch(mod, pat)}
+                    if negate:
+                        current -= selection
+                    else:
+                        current |= selection
             return current
 
-        available_modules = []
+        available_modules = {}
         modules_to_install = set()
-        for repo, repo_available_modules in modules.items():
-            available_modules += repo_available_modules
 
-        # repo specific filters
-        for repo, repo_available_modules in modules.items():
-            repo_modules = set(repo_available_modules)
+        for repo, repo_modules in modules_per_repo.items():
+            repo_available_modules = {module: repo for module in repo_modules}
+            available_modules.update(repo_available_modules)
+            repo_modules = set(repo_available_modules.keys())
             if repo.modules:
                 repo_modules = _filter_patterns(repo.modules.split(','), repo_modules, repo_available_modules)
             module_pattern = repo_module_patterns.get(repo)

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -38,7 +38,7 @@ class RunbotCase(TransactionCase):
         commiter_email = '%s@somewhere.com' % committer.lower().replace(' ', '_')
         author = author or committer
         author_email = '%s@somewhere.com' % author.lower().replace(' ', '_')
-        self.commit_list[self.repo_server.id] = [(
+        self.commit_list[self.repo_odoo.id] = [(
             'refs/%s/heads/%s' % (remote.remote_name, branch_name),
             sha or 'd0d0caca',
             str(tstamp or int(time.time())),
@@ -66,20 +66,20 @@ class RunbotCase(TransactionCase):
         self.Commit = self.env['runbot.commit']
         self.Runbot = self.env['runbot.runbot']
         self.project = self.env['runbot.project'].create({'name': 'Tests', 'process_delay': 0})
-        self.repo_server = self.Repo.create({
-            'name': 'server',
+        self.repo_odoo = self.Repo.create({
+            'name': 'odoo',
             'project_id': self.project.id,
             'server_files': 'server.py',
             'addons_paths': 'addons,core/addons',
             'modules': '-hw_*',
         })
-        self.repo_addons = self.Repo.create({
-            'name': 'addons',
+        self.repo_enterprise = self.Repo.create({
+            'name': 'enterprise',
             'project_id': self.project.id,
             'modules': '-l10n_*',
         })
         self.addons_per_repo = {
-            self.repo_server: [
+            self.repo_odoo: [
                 ('odoo/addons', 'base', '__manifest__.py'),
                 ('odoo/addons', 'test_lint', '__manifest__.py'),
                 ('addons', 'mail', '__manifest__.py'),
@@ -90,7 +90,7 @@ class RunbotCase(TransactionCase):
                 ('addons', 'test_l10n', '__manifest__.py'),
 
             ],
-            self.repo_addons: [
+            self.repo_enterprise: [
                 ('', 'documents', '__manifest__.py'),
                 ('', 'web_enterprise', '__manifest__.py'),
                 ('', 'l10n_be', '__manifest__.py'),
@@ -98,24 +98,24 @@ class RunbotCase(TransactionCase):
             ],
         }
 
-        self.remote_server = self.Remote.create({
-            'name': 'bla@example.com:base/server',
-            'repo_id': self.repo_server.id,
+        self.remote_odoo = self.Remote.create({
+            'name': 'bla@example.com:base/odoo',
+            'repo_id': self.repo_odoo.id,
             'token': '123',
         })
-        self.remote_server_dev = self.Remote.create({
-            'name': 'bla@example.com:dev/server',
-            'repo_id': self.repo_server.id,
+        self.remote_odoo_dev = self.Remote.create({
+            'name': 'bla@example.com:dev/odoo',
+            'repo_id': self.repo_odoo.id,
             'token': '123',
         })
-        self.remote_addons = self.Remote.create({
-            'name': 'bla@example.com:base/addons',
-            'repo_id': self.repo_addons.id,
+        self.remote_enterprise = self.Remote.create({
+            'name': 'bla@example.com:base/enterprise',
+            'repo_id': self.repo_enterprise.id,
             'token': '123',
         })
-        self.remote_addons_dev = self.Remote.create({
-            'name': 'bla@example.com:dev/addons',
-            'repo_id': self.repo_addons.id,
+        self.remote_enterprise_dev = self.Remote.create({
+            'name': 'bla@example.com:dev/enterprise',
+            'repo_id': self.repo_enterprise.id,
             'token': '123',
         })
 
@@ -125,7 +125,7 @@ class RunbotCase(TransactionCase):
         self.initial_server_commit = self.Commit.create({
             'name': 'aaaaaaa',
             'tree_hash': '0aaaaaaa',
-            'repo_id': self.repo_server.id,
+            'repo_id': self.repo_odoo.id,
             'date': '2006-12-07',
             'subject': 'New trunk',
             'author': 'purply',
@@ -133,13 +133,13 @@ class RunbotCase(TransactionCase):
         })
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_is_base_regex', r'^((master)|(saas-)?\d+\.\d+)$')
 
-        self.branch_server = self.Branch.create({
+        self.branch_odoo = self.Branch.create({
             'name': 'master',
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
             'is_pr': False,
             'head': self.initial_server_commit.id,
         })
-        self.master_bundle = self.branch_server.bundle_id # compute
+        self.master_bundle = self.branch_odoo.bundle_id  # compute
         self.dev_bundle = self.Bundle.create({
             'name': 'master-dev-tri',
             'project_id': self.project.id
@@ -148,17 +148,17 @@ class RunbotCase(TransactionCase):
             'name': 'master-dev-tri',
             'bundle_id': self.dev_bundle.id,
             'is_pr': False,
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
         })
         with patch('odoo.addons.runbot.models.branch.Branch._update_branch_infos', return_value=None):
             self.dev_pr = self.Branch.create({
                 'name': '1234',
                 'is_pr': True,
                 'alive': True,
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'target_branch_name': self.dev_bundle.base_id.name,
-                'pull_head_remote_id': self.remote_server.id,
-                'pull_head_name': f'{self.remote_server.owner}:{self.dev_branch.name}',
+                'pull_head_remote_id': self.remote_odoo.id,
+                'pull_head_name': f'{self.remote_odoo.owner}:{self.dev_branch.name}',
             })
         self.assertEqual(self.dev_pr.bundle_id.id, self.dev_bundle.id)
 
@@ -175,15 +175,15 @@ class RunbotCase(TransactionCase):
 
         self.trigger_server = self.Trigger.create({
             'name': 'Server trigger',
-            'repo_ids': [(4, self.repo_server.id)],
+            'repo_ids': [(4, self.repo_odoo.id)],
             'config_id': self.default_config.id,
             'project_id': self.project.id,
         })
 
         self.trigger_addons = self.Trigger.create({
             'name': 'Addons trigger',
-            'repo_ids': [(4, self.repo_addons.id)],
-            'dependency_ids': [(4, self.repo_server.id)],
+            'repo_ids': [(4, self.repo_enterprise.id)],
+            'dependency_ids': [(4, self.repo_odoo.id)],
             'config_id': self.default_config.id,
             'project_id': self.project.id,
         })
@@ -268,11 +268,11 @@ class RunbotCase(TransactionCase):
 
     def additionnal_setup(self):
         """Helper that setup a the repos with base branches and heads"""
-        self.branch_server.bundle_id.is_base = True
+        self.branch_odoo.bundle_id.is_base = True
         initial_addons_commit = self.Commit.create({
             'name': 'cccccc',
             'tree_hash': '0cccccc',
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
             'date': '2015-03-12',
             'subject': 'Initial commit',
             'author': 'someone',
@@ -281,14 +281,14 @@ class RunbotCase(TransactionCase):
 
         self.branch_addons = self.Branch.create({
             'name': 'master',
-            'remote_id': self.remote_addons.id,
+            'remote_id': self.remote_enterprise.id,
             'is_pr': False,
             'head': initial_addons_commit.id,
         })
-        self.assertEqual(self.branch_addons.bundle_id, self.branch_server.bundle_id)
-        triggers = self.env['runbot.trigger'].search([('repo_ids', 'in', [self.repo_addons.id, self.repo_server.id])])
+        self.assertEqual(self.branch_addons.bundle_id, self.branch_odoo.bundle_id)
+        triggers = self.env['runbot.trigger'].search([('repo_ids', 'in', [self.repo_enterprise.id, self.repo_odoo.id])])
 
-        self.assertEqual(triggers.repo_ids + triggers.dependency_ids, self.remote_addons.repo_id + self.remote_server.repo_id)
+        self.assertEqual(triggers.repo_ids + triggers.dependency_ids, self.remote_enterprise.repo_id + self.remote_odoo.repo_id)
 
         batch = self.branch_addons.bundle_id._force()
         batch._process()

--- a/runbot/tests/test_batch.py
+++ b/runbot/tests/test_batch.py
@@ -22,7 +22,7 @@ class TestBatch(RunbotCase):
         self.trigger_server.ci_context = "test"
 
         def get_build_commit(sha, tree_hash, branch):
-            commit = self.Commit._get(sha, self.repo_server.id, {
+            commit = self.Commit._get(sha, self.repo_odoo.id, {
                 'tree_hash': tree_hash,
             })
             branch.head = commit
@@ -36,10 +36,10 @@ class TestBatch(RunbotCase):
             self.assertEqual(batch.commit_link_ids.commit_id, commit)
             return batch, batch.slot_ids.build_id, commit
 
-        batch_1, build_1, commit_1 = get_build_commit('aaaaaaa', '0aaaaaa', self.branch_server)
+        batch_1, build_1, commit_1 = get_build_commit('aaaaaaa', '0aaaaaa', self.branch_odoo)
         self.assertEqual(build_1.slot_ids.mapped('batch_id'), batch_1)
 
-        batch_2, build_2, commit_2 = get_build_commit('bbbbbbb', '0bbbbbb', self.branch_server)
+        batch_2, build_2, commit_2 = get_build_commit('bbbbbbb', '0bbbbbb', self.branch_odoo)
         self.assertNotEqual(build_1, build_2)
         self.assertNotEqual(commit_1, commit_2)
         self.assertNotEqual(batch_1, batch_2)

--- a/runbot/tests/test_branch.py
+++ b/runbot/tests/test_branch.py
@@ -7,7 +7,7 @@ from .common import RunbotCase, RunbotCaseMinimalSetup
 class TestBranch(RunbotCase):
 
     def test_base_fields(self):
-        self.assertEqual(self.branch_server.branch_url, 'https://example.com/base/server/tree/master')
+        self.assertEqual(self.branch_odoo.branch_url, 'https://example.com/base/odoo/tree/master')
 
     def test_pull_request(self):
         mock_github = self.patchers['github_patcher']
@@ -21,24 +21,24 @@ class TestBranch(RunbotCase):
             },
         }
         pr = self.Branch.create({
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
             'name': '12345',
             'is_pr': True,
         })
         self.assertEqual(pr.name, '12345')
-        self.assertEqual(pr.branch_url, 'https://example.com/base/server/pull/12345')
+        self.assertEqual(pr.branch_url, 'https://example.com/base/odoo/pull/12345')
         self.assertEqual(pr.target_branch_name, 'master')
         self.assertEqual(pr.pull_head_name, 'foo-dev:bar_branch')
 
     def test_branch_dname_search(self):
         # Basic branch
         self.assertEqual(
-            self.branch_server,
-            self.Branch.search([('dname', '=', self.branch_server.dname)]),
+            self.branch_odoo,
+            self.Branch.search([('dname', '=', self.branch_odoo.dname)]),
         )
         self.assertEqual(
-            self.branch_server,
-            self.Branch.search([('dname', '=', self.branch_server.dname.replace(':', '#'))]),
+            self.branch_odoo,
+            self.Branch.search([('dname', '=', self.branch_odoo.dname.replace(':', '#'))]),
         )
         # Basic pr
         self.assertEqual(
@@ -58,7 +58,7 @@ class TestBranch(RunbotCase):
         # Branch with a . inside of it
         branch = self.Branch.create({
             'name': '18.0-test',
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
             'is_pr': False,
         })
         self.assertEqual(
@@ -73,13 +73,13 @@ class TestBranchRelations(RunbotCase):
 
         def create_base(name):
             branch = self.Branch.create({
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'name': name,
                 'is_pr': False,
             })
             branch.bundle_id.is_base = True
             return branch
-        self.master = self.branch_server
+        self.master = self.branch_odoo
         create_base('11.0')
         create_base('saas-11.1')
         create_base('12.0')
@@ -92,7 +92,7 @@ class TestBranchRelations(RunbotCase):
 
     def test_relations_master_dev(self):
         b = self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': 'master-test-tri',
                 'is_pr': False,
             })
@@ -108,7 +108,7 @@ class TestBranchRelations(RunbotCase):
 
     def test_relations_no_intermediate(self):
         b = self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': 'saas-13.1-test-tri',
                 'is_pr': False,
             })
@@ -118,7 +118,7 @@ class TestBranchRelations(RunbotCase):
 
     def test_relations_old_branch(self):
         b = self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': '11.0-test-tri',
                 'is_pr': False,
             })
@@ -128,7 +128,7 @@ class TestBranchRelations(RunbotCase):
 
     def test_relations_closest_forced(self):
         b = self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': 'master-test-tri',
                 'is_pr': False,
             })
@@ -144,7 +144,7 @@ class TestBranchRelations(RunbotCase):
 
     def test_relations_no_match(self):
         b = self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': 'icantnamemybranches',
                 'is_pr': False,
             })
@@ -153,14 +153,14 @@ class TestBranchRelations(RunbotCase):
 
     def test_relations_pr(self):
         self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': 'master-test-tri',
                 'is_pr': False,
             })
 
         self.patchers['github_patcher'].return_value = {
             'base': {'ref': 'master-test-tri'},
-            'head': {'label': 'dev:master-test-tri-imp', 'repo': {'full_name': 'dev/server'}},
+            'head': {'label': 'dev:master-test-tri-imp', 'repo': {'full_name': 'dev/odoo'}},
             'title': '[IMP] Title',
             'body': 'Body',
             'user': {
@@ -168,7 +168,7 @@ class TestBranchRelations(RunbotCase):
             },
         }
         b = self.Branch.create({
-                'remote_id': self.remote_server_dev.id,
+                'remote_id': self.remote_odoo_dev.id,
                 'name': '100',
                 'is_pr': True,
             })
@@ -183,11 +183,11 @@ class TestBranchForbidden(RunbotCase):
     """Test that a branch matching the repo forbidden regex, goes to dummy bundle"""
 
     def test_forbidden(self):
-        dummy_bundle = self.remote_server_dev.repo_id.project_id.dummy_bundle_id
-        self.remote_server_dev.repo_id.forbidden_regex = '^bad_name.+'
+        dummy_bundle = self.remote_odoo_dev.repo_id.project_id.dummy_bundle_id
+        self.remote_odoo_dev.repo_id.forbidden_regex = '^bad_name.+'
         with mute_logger("odoo.addons.runbot.models.branch"):
             branch = self.Branch.create({
-                    'remote_id': self.remote_server_dev.id,
+                    'remote_id': self.remote_odoo_dev.id,
                     'name': 'bad_name-evil',
                     'is_pr': False,
                 })
@@ -203,7 +203,7 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
 
     def test_is_base_regex_on_main_remote(self):
         branch = self.Branch.create({
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'name': 'saas-13.4',
                 'is_pr': False,
             })
@@ -211,7 +211,7 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
         self.assertTrue(branch.bundle_id.sticky, "A branch matching the is_base_regex parameter should create sticky bundle")
 
         staging = self.Branch.create({
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
             'name': 'staging.saas-13.4',
             'is_pr': False,
         })
@@ -222,19 +222,19 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
         r12 = self.env['runbot.host'].create({'name': 'runbot12.odoo.com', 'assigned_only': True})
 
         branch = self.Branch.create({
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'name': 'saas-13.4-runbotinexist-test',
                 'is_pr': False,
             })
         self.assertFalse(branch.bundle_id.host_id)
         branch = self.Branch.create({
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'name': 'saas-13.4-runbot10-test',
                 'is_pr': False,
         })
         self.assertEqual(branch.bundle_id.host_id, r10)
         branch = self.Branch.create({
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'name': 'saas-13.4-runbot_x-test',
                 'is_pr': False,
         })
@@ -243,13 +243,13 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
     @mute_logger("odoo.addons.runbot.models.branch")
     def test_is_base_regex_on_dev_remote(self):
         """Test that a branch matching the is_base regex on a secondary remote goes to the dummy bundles."""
-        dummy_bundle = self.repo_addons.project_id.dummy_bundle_id
+        dummy_bundle = self.repo_enterprise.project_id.dummy_bundle_id
 
         # master branch on dev remote
         initial_addons_dev_commit = self.Commit.create({
             'name': 'dddddd',
             'tree_hash': '0dddddd',
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
             'date': '2015-09-30',
             'subject': 'Please use the right repo',
             'author': 'oxo',
@@ -258,7 +258,7 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
 
         branch_addons_dev = self.Branch.create({
             'name': 'master',
-            'remote_id': self.remote_addons_dev.id,
+            'remote_id': self.remote_enterprise_dev.id,
             'is_pr': False,
             'head': initial_addons_dev_commit.id
         })
@@ -268,26 +268,26 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
         initial_server_dev_commit = self.Commit.create({
             'name': 'bbbbbb',
             'tree_hash': '0bbbbbb',
-            'repo_id': self.repo_server.id,
+            'repo_id': self.repo_odoo.id,
             'date': '2014-05-26',
             'subject': 'Please use the right repo',
             'author': 'oxo',
             'author_email': 'oxo@somewhere.com'
         })
 
-        branch_server_dev = self.Branch.create({
+        branch_odoo_dev = self.Branch.create({
             'name': 'saas-12.3',
-            'remote_id': self.remote_server_dev.id,
+            'remote_id': self.remote_odoo_dev.id,
             'is_pr': False,
             'head': initial_server_dev_commit.id
         })
-        self.assertEqual(branch_server_dev.bundle_id, dummy_bundle, "A branch matching the is_base_regex should on a secondary repo should goes in dummy bundle")
+        self.assertEqual(branch_odoo_dev.bundle_id, dummy_bundle, "A branch matching the is_base_regex should on a secondary repo should goes in dummy bundle")
 
         # 12.0 branch on dev remote
         mistaken_commit = self.Commit.create({
             'name': 'eeeeee',
             'tree_hash': '0eeeeee',
-            'repo_id': self.repo_server.id,
+            'repo_id': self.repo_odoo.id,
             'date': '2015-06-27',
             'subject': 'dummy commit',
             'author': 'brol',
@@ -296,7 +296,7 @@ class TestBranchIsBase(RunbotCaseMinimalSetup):
 
         branch_mistake_dev = self.Branch.create({
             'name': '12.0',
-            'remote_id': self.remote_server_dev.id,
+            'remote_id': self.remote_odoo_dev.id,
             'is_pr': False,
             'head': mistaken_commit.id
         })
@@ -319,7 +319,7 @@ class TestBundleTeam(RunbotCase):
         team.user_ids += test_user
 
         branch = self.Branch.create({
-            'remote_id': self.remote_server_dev.id,
+            'remote_id': self.remote_odoo_dev.id,
             'name': 'saas-19.1-test-tru',
             'is_pr': False,
         })

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -31,7 +31,7 @@ class TestBuildParams(RunbotCaseMinimalSetup):
         server_commit = self.Commit.create({
             'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
             'tree_hash': '0dfdfcfcf0000fffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
 
         params = self.BuildParameters.create({
@@ -66,7 +66,7 @@ class TestBuildParams(RunbotCaseMinimalSetup):
         other_commit = self.Commit.create({
             'name': 'deadbeef0000ffffffffffffffffffffffffffff',
             'tree_hash': '0',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
 
         copied_params = params.copy({
@@ -85,10 +85,10 @@ class TestBuildParams(RunbotCaseMinimalSetup):
 
         # A commit is found on the dev remote
         branch_a_name = 'master-test-something'
-        self.push_commit(self.remote_server_dev, branch_a_name, 'nice subject', sha='d0d0caca')
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'nice subject', sha='d0d0caca')
 
         # batch preparation
-        self.repo_server._update_batches()
+        self.repo_odoo._update_batches()
 
         # prepare last_batch
         bundle = self.env['runbot.bundle'].search([('name', '=', branch_a_name), ('project_id', '=', self.project.id)])
@@ -104,10 +104,10 @@ class TestBuildParams(RunbotCaseMinimalSetup):
 
         # A commit is found on the dev remote
         branch_a_name = 'master-test-something'
-        self.push_commit(self.remote_server_dev, branch_a_name, 'nice subject', sha='d0d0caca')
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'nice subject', sha='d0d0caca')
         # batch preparation
-        self.repo_server.project_id.process_delay = 10
-        self.repo_server._update_batches()
+        self.repo_odoo.project_id.process_delay = 10
+        self.repo_odoo._update_batches()
 
         # create a custom config and a new trigger
         custom_config = self.env['runbot.build.config'].create({'name': 'A Custom Config'})
@@ -122,29 +122,29 @@ class TestBuildParams(RunbotCaseMinimalSetup):
             'config_id': custom_config.id
         })
 
-        self.repo_server.project_id.process_delay = 0
+        self.repo_odoo.project_id.process_delay = 0
         bundle.last_batch._process()
         build_slot = bundle.last_batch.slot_ids.filtered(lambda rec: rec.trigger_id == self.trigger_server)
         self.assertEqual(build_slot.build_id.params_id.config_id, custom_config)
 
         # Test custom trigger if targetting non base bundle
         branch_b_name = 'master-test-something-other-thing'
-        self.push_commit(self.remote_server_dev, branch_b_name, 'Subject', sha='d0d0abab')
-        self.repo_server.project_id.process_delay = 10
-        self.repo_server._update_batches()
+        self.push_commit(self.remote_odoo_dev, branch_b_name, 'Subject', sha='d0d0abab')
+        self.repo_odoo.project_id.process_delay = 10
+        self.repo_odoo._update_batches()
         bundle_b = self.Bundle.search([('name', '=', branch_b_name), ('project_id', '=', self.project.id)])
         bundle_b.write({
             'branch_ids': [(0, 0, {
                 'name': '1',
                 'is_pr': True,
-                'pull_head_remote_id': self.remote_server.id,
+                'pull_head_remote_id': self.remote_odoo.id,
                 'pull_head_name': f'remote:{branch_b_name}',
                 'target_branch_name': bundle.name,
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
             })]
         })
         self.assertEqual(bundle.all_trigger_custom_ids, bundle_b.all_trigger_custom_ids)
-        self.repo_server.project_id.process_delay = 0
+        self.repo_odoo.project_id.process_delay = 0
         bundle_b.last_batch._process()
         build_slot = bundle_b.last_batch.slot_ids.filtered(lambda rec: rec.trigger_id == self.trigger_server)
         self.assertEqual(build_slot.build_id.params_id.config_id, custom_config)
@@ -159,7 +159,7 @@ class TestBuildParams(RunbotCaseMinimalSetup):
         trigger_minimal_check = self.Trigger.create({
             'sequence': 0,
             'name': 'minimal_check',
-            'repo_ids': [(4, self.repo_addons.id), (4, self.repo_server.id)],
+            'repo_ids': [(4, self.repo_enterprise.id), (4, self.repo_odoo.id)],
             'config_id': minimal_config.id,
             'project_id': self.project.id,
             'starts_before_ids': other_triggers.ids,
@@ -168,8 +168,8 @@ class TestBuildParams(RunbotCaseMinimalSetup):
         self.assertEqual(self.trigger_addons.starts_after_ids, trigger_minimal_check)
 
         branch_a_name = 'master-test-something'
-        self.push_commit(self.remote_server_dev, branch_a_name, 'nice subject', sha='d0d0caca')
-        self.repo_server._update_batches()
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'nice subject', sha='d0d0caca')
+        self.repo_odoo._update_batches()
         bundle = self.Bundle.search([('name', '=', branch_a_name), ('project_id', '=', self.project.id)])
         batch = bundle.last_batch
         batch._process()
@@ -212,10 +212,10 @@ class TestBuildParams(RunbotCaseMinimalSetup):
 
         # A commit is found on the dev remote
         branch_a_name = 'master-test-something'
-        self.push_commit(self.remote_server_dev, branch_a_name, 'nice subject', sha='d0d0caca')
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'nice subject', sha='d0d0caca')
         # batch preparation
-        self.repo_server.project_id.process_delay = 10
-        self.repo_server._update_batches()
+        self.repo_odoo.project_id.process_delay = 10
+        self.repo_odoo._update_batches()
 
         # set config data on the trigger
         self.trigger_server.config_data = {'moc_var': 'bar'}
@@ -223,7 +223,7 @@ class TestBuildParams(RunbotCaseMinimalSetup):
         # create a custom trigger for the bundle
         bundle = self.Bundle.search([('name', '=', branch_a_name), ('project_id', '=', self.project.id)])
 
-        self.repo_server.project_id.process_delay = 0
+        self.repo_odoo.project_id.process_delay = 0
         bundle.last_batch._process()
         build_slot = bundle.last_batch.slot_ids.filtered(lambda rec: rec.trigger_id == self.trigger_server)
         self.assertIn(
@@ -238,10 +238,10 @@ class TestBuildParams(RunbotCaseMinimalSetup):
 
         # A commit is found on the dev remote
         branch_a_name = 'master-test-something'
-        self.push_commit(self.remote_server_dev, branch_a_name, 'nice subject', sha='d0d0caca')
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'nice subject', sha='d0d0caca')
         # batch preparation
-        self.repo_server.project_id.process_delay = 10
-        self.repo_server._update_batches()
+        self.repo_odoo.project_id.process_delay = 10
+        self.repo_odoo._update_batches()
 
         # set config data on the trigger
         self.trigger_server.config_data = {'moc_var': 'bar'}
@@ -256,7 +256,7 @@ class TestBuildParams(RunbotCaseMinimalSetup):
             'config_data': {'moc_var': 'foo'},
         })
 
-        self.repo_server.project_id.process_delay = 0
+        self.repo_odoo.project_id.process_delay = 0
         bundle.last_batch._process()
         build_slot = bundle.last_batch.slot_ids.filtered(lambda rec: rec.trigger_id == self.trigger_server)
         self.assertIn(
@@ -272,13 +272,13 @@ class TestBuildResult(RunbotCase):
         self.server_commit = self.Commit.create({
             'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
             'tree_hash': '0dfdfcfcf0000fffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
 
         self.addons_commit = self.Commit.create({
             'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
             'tree_hash': '0d0d0caca0000fffffffffffffffffffffffffff',
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
         })
 
         self.server_params = self.base_params.copy({'commit_link_ids': [
@@ -338,18 +338,18 @@ class TestBuildResult(RunbotCase):
         })
 
         mock_get_available_modules.return_value = {
-            self.repo_server: ['good_module', 'bad_module', 'other_good', 'l10n_be', 'hw_foo', 'hwgood', 'hw_explicit'],
-            self.repo_addons: ['other_mod_1', 'other_mod_2'],
+            self.repo_odoo: ['good_module', 'bad_module', 'other_good', 'l10n_be', 'hw_foo', 'hwgood', 'hw_explicit'],
+            self.repo_enterprise: ['other_mod_1', 'other_mod_2'],
         }
 
-        self.repo_server.modules = '-bad_module,-hw_*,hw_explicit,-l10n_*'
+        self.repo_odoo.modules = '-bad_module,-hw_*,hw_explicit,-l10n_*'
 
-        self.repo_addons.modules = False  # no filter, should not crash
+        self.repo_enterprise.modules = False  # no filter, should not crash
 
         modules_to_test = build._get_modules_to_test(modules_patterns='')
         self.assertEqual(modules_to_test, sorted(['good_module', 'hwgood', 'other_good', 'hw_explicit', 'other_mod_1', 'other_mod_2']))
 
-        self.repo_addons.modules = '-*'
+        self.repo_enterprise.modules = '-*'
 
         modules_to_test = build._get_modules_to_test(modules_patterns='')
         self.assertEqual(modules_to_test, sorted(['good_module', 'hwgood', 'other_good', 'hw_explicit']))
@@ -364,15 +364,15 @@ class TestBuildResult(RunbotCase):
 
         self.env['runbot.module.filter'].create([{
             'trigger_id': self.trigger_addons.id,
-            'repo_id': self.repo_server.id,
+            'repo_id': self.repo_odoo.id,
             'modules': '-*',
         }, {
             'trigger_id': self.trigger_addons.id,
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
             'modules': '*',
         }, {
             'trigger_id': self.trigger_addons.id,
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
             'modules': '-other_mod_1',
         }])
         modules_to_test = build._get_modules_to_test(modules_patterns='')
@@ -401,7 +401,7 @@ class TestBuildResult(RunbotCase):
             'params_id': self.server_params.id,
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('python3 -m pip install --progress-bar off -r server/requirements.txt'.split(), cmd.pres)
+        self.assertIn(['python3', '-m', 'pip', 'install', '--progress-bar', 'off', '-r', 'odoo/requirements.txt'], cmd.pres)
         self.assertIn(custom_pre, cmd.pres)
         self.assertIn(custom_post, cmd.posts)
 
@@ -413,7 +413,7 @@ class TestBuildResult(RunbotCase):
         })
         cmd = build._cmd(py_version=3)
         self.assertEqual('python3', cmd[0])
-        self.assertEqual('server/server.py', cmd[1])
+        self.assertEqual('odoo/server.py', cmd[1])
         self.assertIn('--addons-path', cmd)
         # TODO fix the _get_addons_path and/or _docker_source_folder
         # addons_path_pos = cmd.index('--addons-path') + 1
@@ -424,19 +424,19 @@ class TestBuildResult(RunbotCase):
 
         def is_file(file):
             self.assertIn(file, [
-                self.env['runbot.runbot']._path('sources/addons/0d0d0caca0000fffffffffffffffffffffffffff/requirements.txt'),
-                self.env['runbot.runbot']._path('sources/server/0dfdfcfcf0000fffffffffffffffffffffffffff/requirements.txt'),
-                self.env['runbot.runbot']._path('sources/server/0dfdfcfcf0000fffffffffffffffffffffffffff/server.py'),
-                self.env['runbot.runbot']._path('sources/server/0dfdfcfcf0000fffffffffffffffffffffffffff/odoo/tools/config.py'),
-                self.env['runbot.runbot']._path('sources/server/0dfdfcfcf0000fffffffffffffffffffffffffff/odoo/sql_db.py')
+                self.env['runbot.runbot']._path('sources/enterprise/0d0d0caca0000fffffffffffffffffffffffffff/requirements.txt'),
+                self.env['runbot.runbot']._path('sources/odoo/0dfdfcfcf0000fffffffffffffffffffffffffff/requirements.txt'),
+                self.env['runbot.runbot']._path('sources/odoo/0dfdfcfcf0000fffffffffffffffffffffffffff/server.py'),
+                self.env['runbot.runbot']._path('sources/odoo/0dfdfcfcf0000fffffffffffffffffffffffffff/odoo/tools/config.py'),
+                self.env['runbot.runbot']._path('sources/odoo/0dfdfcfcf0000fffffffffffffffffffffffffff/odoo/sql_db.py'),
             ])
-            return file != self.env['runbot.runbot']._path('static/sources/addons/0d0d0caca0000fffffffffffffffffffffffffff/requirements.txt')
+            return file != self.env['runbot.runbot']._path('static/sources/enterprise/0d0d0caca0000fffffffffffffffffffffffffff/requirements.txt')
 
         def is_dir(file):
             paths = [
-                'sources/server/0dfdfcfcf0000fffffffffffffffffffffffffff/addons',
-                'sources/server/0dfdfcfcf0000fffffffffffffffffffffffffff/core/addons',
-                'sources/addons/0d0d0caca0000fffffffffffffffffffffffffff'
+                'sources/odoo/0dfdfcfcf0000fffffffffffffffffffffffffff/addons',
+                'sources/odoo/0dfdfcfcf0000fffffffffffffffffffffffffff/core/addons',
+                'sources/enterprise/0d0d0caca0000fffffffffffffffffffffffffff'
             ]
             self.assertTrue(any([path in file for path in paths]))  # checking that addons path existence check looks ok
             return True
@@ -451,8 +451,8 @@ class TestBuildResult(RunbotCase):
         cmd = build._cmd(py_version=3)
         self.assertIn('--addons-path', cmd)
         addons_path_pos = cmd.index('--addons-path') + 1
-        self.assertEqual(cmd[addons_path_pos], 'server/addons,server/core/addons,addons')
-        self.assertEqual('server/server.py', cmd[1])
+        self.assertEqual(cmd[addons_path_pos], 'odoo/addons,odoo/core/addons,enterprise')
+        self.assertEqual('odoo/server.py', cmd[1])
         self.assertEqual('python3', cmd[0])
 
     def test_build_gc_date(self):
@@ -465,7 +465,7 @@ class TestBuildResult(RunbotCase):
         child_build = self.Build.create({
             'params_id': self.server_params.id,
             'parent_id': build.id,
-            'local_state': 'done'
+            'local_state': 'done',
         })
 
         # verify that the gc_day is set 30 days later (29 days since we should be a few microseconds later)
@@ -691,19 +691,19 @@ class TestBuildResult(RunbotCase):
             'params_id': self.server_params.id,
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('faketime "2024-02-04 02:42 UTC" python3 server/server.py', str(cmd))
+        self.assertIn('faketime "2024-02-04 02:42 UTC" python3 odoo/server.py', str(cmd))
 
         # let's ensure that a time offset is added to a child build
         build.build_start = datetime.datetime(2025, 1, 1, 12, 00)
         child_build = build._add_child({})
         child_build.create_date = datetime.datetime(2025, 1, 1, 13, 00)
         child_cmd = child_build._cmd(py_version=3)
-        self.assertIn('faketime "2024-02-04 03:42 UTC" python3 server/server.py', str(child_cmd))
+        self.assertIn('faketime "2024-02-04 03:42 UTC" python3 odoo/server.py', str(child_cmd))
 
         build.build_end = datetime.datetime(2025, 1, 1, 14, 00)
         second_child = build._add_child({})
         second_child_cmd = second_child._cmd(py_version=3)
-        self.assertIn('faketime "2024-02-04 04:42 UTC" python3 server/server.py', str(second_child_cmd))
+        self.assertIn('faketime "2024-02-04 04:42 UTC" python3 odoo/server.py', str(second_child_cmd))
 
 class TestGc(RunbotCaseMinimalSetup):
 
@@ -721,10 +721,10 @@ class TestGc(RunbotCaseMinimalSetup):
 
         # A commit is found on the dev remote
         branch_a_name = 'master-test-something'
-        self.push_commit(self.remote_server_dev, branch_a_name, 'nice subject', sha='d0d0caca')
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'nice subject', sha='d0d0caca')
 
         # batch preparation
-        self.repo_server._update_batches()
+        self.repo_odoo._update_batches()
 
         # prepare last_batch
         bundle_a = self.env['runbot.bundle'].search([('name', '=', branch_a_name)])
@@ -739,8 +739,8 @@ class TestGc(RunbotCaseMinimalSetup):
 
         # now another commit is found in another branch
         branch_b_name = 'master-test-other-thing'
-        self.push_commit(self.remote_server_dev, branch_b_name, 'other subject', sha='cacad0d0')
-        self.repo_server._update_batches()
+        self.push_commit(self.remote_odoo_dev, branch_b_name, 'other subject', sha='cacad0d0')
+        self.repo_odoo._update_batches()
         bundle_b = self.env['runbot.bundle'].search([('name', '=', branch_b_name)])
         bundle_b.last_batch._process()
 
@@ -758,8 +758,8 @@ class TestGc(RunbotCaseMinimalSetup):
         self.assertFalse(build_b.requested_action)
 
         # a new commit is pushed on branch_a
-        self.push_commit(self.remote_server_dev, branch_a_name, 'new subject', sha='d0cad0ca')
-        self.repo_server._update_batches()
+        self.push_commit(self.remote_odoo_dev, branch_a_name, 'new subject', sha='d0cad0ca')
+        self.repo_odoo._update_batches()
         bundle_a = self.env['runbot.bundle'].search([('name', '=', branch_a_name)])
         bundle_a.last_batch._process()
         build_a_last = bundle_a.last_batch.slot_ids[0].build_id

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -22,7 +22,7 @@ class TestBuildConfigStepCommon(RunbotCase):
         self.server_commit = self.Commit.create({
             'name': 'dfdfcfcf',
             'tree_hash': '0dfdfcfcf',
-            'repo_id': self.repo_server.id,
+            'repo_id': self.repo_odoo.id,
         })
         self.parent_build = self.Build.create({
             'params_id': self.base_params.copy({'commit_link_ids': [(0, 0, {'commit_id': self.server_commit.id})]}).id,
@@ -98,35 +98,34 @@ class TestCodeowner(TestBuildConfigStepCommon):
         second_pr = self.Branch.create({
             'name': '1235',
             'is_pr': True,
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
             'target_branch_name': self.dev_bundle.base_id.name,
-            'pull_head_remote_id': self.remote_server.id,
-            'pull_head_name': f'{self.remote_server.owner}:{self.dev_branch.name}',
+            'pull_head_remote_id': self.remote_odoo.id,
+            'pull_head_name': f'{self.remote_odoo.owner}:{self.dev_branch.name}',
         })
         self.assertEqual(second_pr.bundle_id.id, self.dev_bundle.id)
         self.config_step._run_codeowner(self.parent_build)
         self.assertEqual(self.parent_build.log_ids.mapped('message'), [
-            "More than one open pr in this bundle for server: ['1234', '1235']"
+            "More than one open pr in this bundle for odoo: ['1234', '1235']"
         ])
         self.assertEqual(self.parent_build.local_result, 'ko')
 
     def test_get_module(self):
-        self.assertEqual(self.repo_server.addons_paths, 'addons,core/addons')
-        self.assertEqual('module1', self.repo_server._get_module('server/core/addons/module1/some/file.py'))
-        self.assertEqual('module1', self.repo_server._get_module('server/addons/module1/some/file.py'))
-        self.assertEqual('module_addons', self.repo_addons._get_module('addons/module_addons/some/file.py'))
-        self.assertEqual(None, self.repo_server._get_module('server/core/module1/some/file.py'))
-        self.assertEqual(None, self.repo_server._get_module('server/core/module/some/file.py'))
-
+        self.assertEqual(self.repo_odoo.addons_paths, 'addons,core/addons')
+        self.assertEqual('module1', self.repo_odoo._get_module('odoo/core/addons/module1/some/file.py'))
+        self.assertEqual('module1', self.repo_odoo._get_module('odoo/addons/module1/some/file.py'))
+        self.assertEqual('module_addons', self.repo_enterprise._get_module('enterprise/module_addons/some/file.py'))
+        self.assertEqual(None, self.repo_odoo._get_module('odoo/core/module1/some/file.py'))
+        self.assertEqual(None, self.repo_odoo._get_module('odoo/core/module/some/file.py'))
     def test_codeowner_regex_multiple(self):
         self.diff = 'file.js\nfile.py\nfile.xml'
         self.config_step._run_codeowner(self.parent_build)
         messages = self.parent_build.log_ids.mapped('message')
         self.assertEqual(messages[1], 'Checking 2 codeowner regexed on 3 files')
-        self.assertEqual(markdown_unescape(messages[2]), 'Adding team_js to reviewers for file [server/file.js](https://False/blob/dfdfcfcf/file.js)')
-        self.assertEqual(markdown_unescape(messages[3]), 'Adding team_py to reviewers for file [server/file.py](https://False/blob/dfdfcfcf/file.py)')
-        self.assertEqual(markdown_unescape(messages[4]), 'Adding codeowner-team to reviewers for file [server/file.xml](https://False/blob/dfdfcfcf/file.xml)')
-        self.assertEqual(markdown_unescape(messages[5]), 'Requesting review for pull request [base/server:1234](https://example.com/base/server/pull/1234): codeowner-team, team_js, team_py')
+        self.assertEqual(markdown_unescape(messages[2]), 'Adding team_js to reviewers for file [odoo/file.js](https://False/blob/dfdfcfcf/file.js)')
+        self.assertEqual(markdown_unescape(messages[3]), 'Adding team_py to reviewers for file [odoo/file.py](https://False/blob/dfdfcfcf/file.py)')
+        self.assertEqual(markdown_unescape(messages[4]), 'Adding codeowner-team to reviewers for file [odoo/file.xml](https://False/blob/dfdfcfcf/file.xml)')
+        self.assertEqual(markdown_unescape(messages[5]), 'Requesting review for pull request [base/odoo:1234](https://example.com/base/odoo/pull/1234): codeowner-team, team_js, team_py')
         self.assertEqual(self.dev_pr.reviewers, 'codeowner-team,team_js,team_py')
 
     def test_codeowner_regex_some_already_on(self):
@@ -134,14 +133,14 @@ class TestCodeowner(TestBuildConfigStepCommon):
         self.dev_pr.reviewers = 'codeowner-team,team_js'
         self.config_step._run_codeowner(self.parent_build)
         messages = self.parent_build.log_ids.mapped('message')
-        self.assertEqual(markdown_unescape(messages[5]), 'Requesting review for pull request [base/server:1234](https://example.com/base/server/pull/1234): team_py')
+        self.assertEqual(markdown_unescape(messages[5]), 'Requesting review for pull request [base/odoo:1234](https://example.com/base/odoo/pull/1234): team_py')
 
     def test_codeowner_regex_all_already_on(self):
         self.diff = 'file.js\nfile.py\nfile.xml'
         self.dev_pr.reviewers = 'codeowner-team,team_js,team_py'
         self.config_step._run_codeowner(self.parent_build)
         messages = self.parent_build.log_ids.mapped('message')
-        self.assertEqual(messages[5], 'All reviewers are already on pull request [base/server:1234](https://example.com/base/server/pull/1234)')
+        self.assertEqual(messages[5], 'All reviewers are already on pull request [base/odoo:1234](https://example.com/base/odoo/pull/1234)')
 
     def test_codeowner_author_in_team(self):
         self.diff = 'file.js\nfile.py\nfile.xml'
@@ -152,7 +151,7 @@ class TestCodeowner(TestBuildConfigStepCommon):
         self.config_step._run_codeowner(self.parent_build)
         messages = self.parent_build.log_ids.mapped('message')
         self.assertEqual(markdown_unescape(messages[5]), "Skipping teams ['team_py'] since author is part of the team members")
-        self.assertEqual(markdown_unescape(messages[6]), 'Requesting review for pull request [base/server:1234](https://example.com/base/server/pull/1234): codeowner-team, team_js')
+        self.assertEqual(markdown_unescape(messages[6]), 'Requesting review for pull request [base/odoo:1234](https://example.com/base/odoo/pull/1234): codeowner-team, team_js')
         self.assertEqual(self.dev_pr.reviewers, 'codeowner-team,team_js,team_py')
 
     def test_codeowner_ownership_base(self):
@@ -165,7 +164,7 @@ class TestCodeowner(TestBuildConfigStepCommon):
         messages = self.parent_build.log_ids.mapped('message')
         self.assertEqual(
             markdown_unescape(messages[2]), 
-            'Adding team_01, team_py to reviewers for file [server/core/addons/module1/some/file.py](https://False/blob/dfdfcfcf/core/addons/module1/some/file.py)'
+            'Adding team_01, team_py to reviewers for file [odoo/core/addons/module1/some/file.py](https://False/blob/dfdfcfcf/core/addons/module1/some/file.py)'
         )
 
     def test_codeowner_ownership_fallback(self):
@@ -178,7 +177,7 @@ class TestCodeowner(TestBuildConfigStepCommon):
         messages = self.parent_build.log_ids.mapped('message')
         self.assertEqual(
             markdown_unescape(messages[2]), 
-            'Adding team_py to reviewers for file [server/core/addons/module1/some/file.py](https://False/blob/dfdfcfcf/core/addons/module1/some/file.py)'
+            'Adding team_py to reviewers for file [odoo/core/addons/module1/some/file.py](https://False/blob/dfdfcfcf/core/addons/module1/some/file.py)'
         )
 
     def test_codeowner_ownership(self):
@@ -195,13 +194,13 @@ class TestCodeowner(TestBuildConfigStepCommon):
         self.config_step._run_codeowner(self.parent_build)
         messages = [markdown_unescape(message) for message in self.parent_build.log_ids.mapped('message')]
         self.assertEqual(messages, [
-            'PR [base/server:1234](https://example.com/base/server/pull/1234) found for repo **server**',
+            'PR [base/odoo:1234](https://example.com/base/odoo/pull/1234) found for repo **odoo**',
             'Checking 2 codeowner regexed on 4 files',
-            'Adding team_01, team_py to reviewers for file [server/core/addons/module1/some/file.py](https://False/blob/dfdfcfcf/core/addons/module1/some/file.py)',
-            'Adding team_02 to reviewers for file [server/core/addons/module2/some/file.ext](https://False/blob/dfdfcfcf/core/addons/module2/some/file.ext)',
-            'Adding team_js to reviewers for file [server/core/addons/module3/some/file.js](https://False/blob/dfdfcfcf/core/addons/module3/some/file.js)',
-            'Adding codeowner-team to reviewers for file [server/core/addons/module4/some/file.txt](https://False/blob/dfdfcfcf/core/addons/module4/some/file.txt)',
-            'Requesting review for pull request [base/server:1234](https://example.com/base/server/pull/1234): codeowner-team, team_01, team_02, team_js, team_py'
+            'Adding team_01, team_py to reviewers for file [odoo/core/addons/module1/some/file.py](https://False/blob/dfdfcfcf/core/addons/module1/some/file.py)',
+            'Adding team_02 to reviewers for file [odoo/core/addons/module2/some/file.ext](https://False/blob/dfdfcfcf/core/addons/module2/some/file.ext)',
+            'Adding team_js to reviewers for file [odoo/core/addons/module3/some/file.js](https://False/blob/dfdfcfcf/core/addons/module3/some/file.js)',
+            'Adding codeowner-team to reviewers for file [odoo/core/addons/module4/some/file.txt](https://False/blob/dfdfcfcf/core/addons/module4/some/file.txt)',
+            'Requesting review for pull request [base/odoo:1234](https://example.com/base/odoo/pull/1234): codeowner-team, team_01, team_02, team_js, team_py'
         ])
 
     def test_codeowner___init__log(self):
@@ -215,7 +214,7 @@ class TestCodeowner(TestBuildConfigStepCommon):
 
         self.assertEqual(
             logs[2]._markdown(),
-            'Adding team_01, team_py to reviewers for file <a href="https://False/blob/dfdfcfcf/core/addons/module1/some/__init__.py">server/core/addons/module1/some/__init__.py</a>',
+            'Adding team_01, team_py to reviewers for file <a href="https://False/blob/dfdfcfcf/core/addons/module1/some/__init__.py">odoo/core/addons/module1/some/__init__.py</a>',
             '__init__.py should not be replaced by <ins>init</ins>.py'
         )
 
@@ -392,12 +391,12 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         self.commit_server = self.Commit.create({
             'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
             'tree_hash': '0dfdfcfcf0000fffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id,
+            'repo_id': self.repo_odoo.id,
         })
         self.commit_addons = self.Commit.create({
             'name': 'dfdfcfcf0011ffffffffffffffffffffffffffff',
             'tree_hash': '0dfdfcfcf0011fffffffffffffffffffffffffff',
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
         })
 
         with open(__file__[:-25] + 'test_build_config_step_dynamic.json') as f:
@@ -427,9 +426,9 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         })
 
     def mock_git_helper(self, repo, cmd):
-        if repo == self.repo_server and cmd == ['show', 'dfdfcfcf0000ffffffffffffffffffffffffffff:odoo/tests/.runbot/parallel_testing.json']:
+        if repo == self.repo_odoo and cmd == ['show', 'dfdfcfcf0000ffffffffffffffffffffffffffff:odoo/tests/.runbot/parallel_testing.json']:
             return self.config_file
-        elif repo == self.repo_server and cmd == ['show', 'dfdfcfcf0000ffffffffffffffffffffffffffff:odoo/tests/.runbot/l10n_standalone_testing.json']:
+        elif repo == self.repo_odoo and cmd == ['show', 'dfdfcfcf0000ffffffffffffffffffffffffffff:odoo/tests/.runbot/l10n_standalone_testing.json']:
             return self.l10n_standalone_testing_file
         elif 'show' in cmd:
             raise subprocess.CalledProcessError(cmd, 128)
@@ -442,6 +441,11 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         self.assertEqual(self.build._get_modules_to_test('!web ->'), ['web_enterprise'])
         self.assertEqual(self.build._get_modules_to_test('-> !mail, -crm'), ['base', 'documents'])
         self.assertEqual(self.build._get_modules_to_test('mail -> !web, !project'), ['mail', 'test_l10n', 'test_lint'])
+        self.assertEqual(self.build._get_modules_to_test('-*,odoo/*'), ['base', 'crm', 'hw_drivers', 'mail', 'project', 'test_l10n', 'test_lint', 'web'])
+        self.assertEqual(self.build._get_modules_to_test('-*,odoo/test_*'), ['test_l10n', 'test_lint'])
+        self.assertEqual(self.build._get_modules_to_test('-*,enterprise/*'), ['documents', 'l10n_be', 'l10n_in', 'web_enterprise'])
+        self.assertEqual(self.build._get_modules_to_test('-*,web*'), ['web', 'web_enterprise'])
+        self.assertEqual(self.build._get_modules_to_test('-*,web*,-enterprise/web*'), ['web'])
 
     def test_config_extension(self):
         self.assertEqual(self.build.dynamic_config['steps'][1]['cpu_limit'], 6500)
@@ -449,7 +453,7 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         self.assertEqual(self.build.dynamic_config['vars']['module_filter'], '*,-hw_*,-l10n_*')
 
     def check_server_cmd(self, cmd, install, test_enable, test_tags, db=None):
-        self.assertIn('server/server.py', cmd)
+        self.assertIn('odoo/server.py', cmd)
         if install:
             self.assertIn('-i', cmd)
             cmd_install = cmd[cmd.index('-i') + 1].split(',')
@@ -596,7 +600,7 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
                 self.assertEqual(post_install.description, f'Post install tests for **{test_module_filter}**')
 
     def test_dynamic_step_l10n_standalone(self):
-        self.addons_per_repo[self.repo_addons] += [
+        self.addons_per_repo[self.repo_enterprise] += [
             ('', 'l10n_edi_be', '__manifest__.py'),
             ('', 'l10n_edi_in', '__manifest__.py'),
             ('', 'l10n_reports_be', '__manifest__.py'),
@@ -647,7 +651,7 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         build._schedule()()
         self.assertEqual(len(self.docker_run_calls), 1, "One docker run should have been called for install_all step")
         cmd = self.docker_run_calls[0][0]
-        self.assertEqual(cmd.build(), f'odoo/odoo/tests/test_module_operations.py -d {build.dest}-l10n --data-dir /data/build/datadir/ --addons-path server/addons,server/core/addons,addons --standalone all_l10n')
+        self.assertEqual(cmd.build(), f'odoo/odoo/tests/test_module_operations.py -d {build.dest}-l10n --data-dir /data/build/datadir/ --addons-path odoo/addons,odoo/core/addons,enterprise --standalone all_l10n')
 
         # 0.3. create post install builds
         build._schedule()
@@ -696,6 +700,83 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
                 test_module_filter = post_install.params_id.config_data['dynamic_vars']['test_module_filter']
                 self.assertEqual(post_install.description, f'Post install tests for **{test_module_filter}**')
 
+    def test_foreach_module(self):
+        dynamic_config = '''{
+            "name": "Foreach module testing",
+            "steps": [{
+                "name": "Create module builds",
+                "job_type": "create_build",
+                "for_each_module": "{{-test_*|filter_default_modules}}",
+                "children": [{
+                    "name": "Test single module",
+                    "description": "Post install tests for **{{module}}**",
+                    "steps": [{
+                        "name": "Start single module test",
+                        "job_type": "odoo",
+                        "install_modules": "{{module}}",
+                        "test_tags": "{{module|make_module_test_tags}}"
+                    }]
+                }]
+            }]
+        }'''
+        self.config.default_dynamic_config = dynamic_config
+        self.config.step_ids[0]._run_dynamic(self.build)
+        self.assertEqual(self.build.children_ids.mapped('description'),
+            [
+                'Post install tests for **base**',
+                'Post install tests for **crm**',
+                'Post install tests for **documents**',
+                'Post install tests for **mail**',
+                'Post install tests for **project**',
+                'Post install tests for **web**',
+                'Post install tests for **web_enterprise**',
+        ])
+
+    def test_foreach_modified_module(self):
+        dynamic_config = '''{
+            "name": "Foreach module testing",
+            "steps": [{
+                "name": "Create module builds",
+                "job_type": "create_build",
+                "for_each_module": "{{-test_*|filter_default_modules|modified_modules}}",
+                "children": [{
+                    "name": "Test single module",
+                    "description": "Post install tests for **{{module}}**",
+                    "steps": [{
+                        "name": "Start single module test",
+                        "job_type": "odoo",
+                        "install_modules": "{{module}}",
+                        "test_tags": "{{module|make_module_test_tags}}"
+                    }]
+                }]
+            }]
+        }'''
+
+        self.patch(type(self.build), '_modified_modules', lambda cl: {'crm'})
+        self.config.default_dynamic_config = dynamic_config
+        self.config.step_ids[0]._run_dynamic(self.build)
+        self.assertEqual(self.build.children_ids.mapped('description'),
+            [
+                'Post install tests for **crm**',
+        ])
+
+    def test_parse_dynamic_entry(self):
+        Step = self.env['runbot.build.config.step']
+
+        def check_parse(entry, expected):
+            res = Step._parse_dynamic_entry(entry, self.build, {'key': 'value', 'test_method': '.test_method'})
+            self.assertEqual(res, expected)
+        check_parse('{{-test_*|filter_all_modules}}', 'base,crm,documents,hw_drivers,l10n_be,l10n_in,mail,project,web,web_enterprise')
+        check_parse('{{-*,web*|filter_all_modules}}', 'web,web_enterprise')
+        check_parse('{{-*,web*|filter_all_modules|make_module_test_tags}}', '/web,/web_enterprise')
+        check_parse('{{-*,web*|filter_all_modules|make_module_test_tags|prepend("some_tag")}}', 'some_tag/web,some_tag/web_enterprise')
+        check_parse('{{-*,web*|filter_all_modules|make_module_test_tags|prepend(key)}}', 'value/web,value/web_enterprise')
+        check_parse('{{-*,web*|filter_all_modules|make_module_test_tags|append(".test_method")}}', '/web.test_method,/web_enterprise.test_method')
+        check_parse('{{-*,web*|filter_all_modules|make_module_test_tags|append(test_method)}}', '/web.test_method,/web_enterprise.test_method')
+
+        self.patch(type(self.build), '_modified_modules', lambda cl: {'crm'})
+
+        check_parse('{{*|filter_all_modules|modified_modules}}', 'crm')
 
 
 class TestBuildConfigStep(TestBuildConfigStepCommon):
@@ -771,7 +852,7 @@ class TestBuildConfigStep(TestBuildConfigStepCommon):
         })
 
         cmd = config_step._run_install_odoo(self.parent_build)['cmd']
-        self.assertEqual(cmd.cmd[:10], ['python3', '-m', 'coverage', 'run', '--branch', '--source', '/data/build', '--omit', '*__manifest__.py,server/addons/hw_drivers/*', 'server/server.py'])
+        self.assertEqual(cmd.cmd[:10], ['python3', '-m', 'coverage', 'run', '--branch', '--source', '/data/build', '--omit', '*__manifest__.py,odoo/addons/hw_drivers/*', 'odoo/server.py'])
         self.assertIn(['python3', '-m', 'coverage', 'html', '-d', '/data/build/coverage', '--ignore-errors'], cmd.finals)
         self.assertIn(['python3', '-m', 'coverage', 'xml', '-o', '/data/build/logs/coverage.xml', '--ignore-errors'], cmd.finals)
 
@@ -786,20 +867,20 @@ class TestBuildConfigStep(TestBuildConfigStepCommon):
         dest = self.parent_build.dest
 
         cmd = config_step._run_install_odoo(self.parent_build)['cmd']
-        self.assertEqual(cmd.cmd[:2], ['python3', 'server/server.py'])
+        self.assertEqual(cmd.cmd[:2], ['python3', 'odoo/server.py'])
         self.assertEqual(cmd.finals[0], ['pg_dump', '%s-all' % dest, '>', '/data/build/logs/%s-all//dump.sql' % dest])
         self.assertEqual(cmd.finals[1], ['cp', '-r', '/data/build/datadir/filestore/%s-all' % dest, '/data/build/logs/%s-all//filestore/' % dest])
         self.assertEqual(cmd.finals[2], ['cd', '/data/build/logs/%s-all/' % dest, '&&', 'zip', '-rmq9', '/data/build/logs/%s-all.zip' % dest, '*'])
 
     def get_test_tags(self, params):
         cmds = params['cmd'].build().split(' && ')
-        self.assertEqual(cmds[1].split(' server/server.py')[0], 'python3')
+        self.assertEqual(cmds[1].split(' odoo/server.py')[0], 'python3')
         return cmds[1].split('--test-tags ')[1].split(' --')[0]
 
     def get_odoo_cmd(self, params):
         cmds = params['cmd'].build().split(' && ')
-        self.assertTrue(any('server/server.py' in cmd for cmd in cmds), 'did not find start command')
-        return next(iter(cmd for cmd in cmds if 'server/server.py' in cmd))
+        self.assertTrue(any('odoo/server.py' in cmd for cmd in cmds), 'did not find start command')
+        return next(iter(cmd for cmd in cmds if 'odoo/server.py' in cmd))
 
     @patch('odoo.addons.runbot.models.build.BuildResult._parse_config')
     @patch('odoo.addons.runbot.models.build.BuildResult._checkout')
@@ -912,7 +993,7 @@ docker_params = dict(cmd=cmd)
 
         config_step._run_step(self.parent_build)()
 
-        self.assertEqual(self.docker_run_calls[0][0].build(), Like('python3 -m pip install ... && python3 server/server.py...-d test_database...'))
+        self.assertEqual(self.docker_run_calls[0][0].build(), Like('python3 -m pip install ... && python3 odoo/server.py...-d test_database...'))
         db = self.env['runbot.database'].search([('name', '=', 'test_database')])
         self.assertEqual(db.build_id, self.parent_build)
 
@@ -940,7 +1021,7 @@ def run():
         })
         config_step._run_step(self.parent_build)()
         self.assertEqual(len(self.docker_run_calls), 1)
-        self.assertEqual(self.docker_run_calls[0][0].build(), Like('python3 -m pip install ... && python3 server/server.py subcommand ...'))
+        self.assertEqual(self.docker_run_calls[0][0].build(), Like('python3 -m pip install ... && python3 odoo/server.py subcommand ...'))
 
 
     @patch('odoo.addons.runbot.models.build.BuildResult._parse_config')

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -66,7 +66,7 @@ class TestBuildErrorCommon(RunbotCase):
             'level': 'ERROR',
             'type': 'server',
             'name': 'test-build-error-name',
-            'path': '/data/build/server/addons/web_studio/tests/test_ui.py',
+            'path': '/data/build/odoo/addons/web_studio/tests/test_ui.py',
             'func': 'test-build-error-func',
             'line': 1,
         }
@@ -354,7 +354,7 @@ class TestBuildError(TestBuildErrorCommon):
         self.assertEqual(error_link.log_date, fields.Datetime.from_string('2023-08-29 00:46:21'))
         self.assertIn(ko_build, error_content.build_ids, 'The parsed build should be added to the runbot.build.error')
         self.assertFalse(self.BuildErrorLink.search([('build_id', '=', ok_build.id)]), 'A successful build should not be associated to a runbot.build.error')
-        self.assertEqual(error_content.file_path, '/data/build/server/addons/web_studio/tests/test_ui.py')
+        self.assertEqual(error_content.file_path, '/data/build/odoo/addons/web_studio/tests/test_ui.py')
         self.assertEqual(build_error.team_id, error_team)
 
         # Test that build with same error is added to the errors
@@ -550,11 +550,11 @@ class TestBuildError(TestBuildErrorCommon):
     def test_build_error_test_tags_fixing_pr(self):
         fix_commit = self.env['runbot.commit'].create({
             'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
         branch_pr = self.Branch.create({
             'name': '1337',
-            'remote_id': self.remote_server.id,
+            'remote_id': self.remote_odoo.id,
             'is_pr': True,
             'head': fix_commit.id,
         })
@@ -660,8 +660,8 @@ class TestBuildError(TestBuildErrorCommon):
         self.env['runbot.module.ownership'].create({'module_id': module_sale.id, 'team_id': sale_team.id, 'is_fallback': False})
         self.env['runbot.module.ownership'].create({'module_id': module_sale.id, 'team_id': website_team.id, 'is_fallback': True})
 
-        self.repo_server.name = 'odoo'
-        self.repo_addons.name = 'enterprise'
+        self.repo_odoo.name = 'odoo'
+        self.repo_enterprise.name = 'enterprise'
         teams = self.env['runbot.team'].search(['|', ('path_glob', '!=', False), ('module_ownership_ids', '!=', False)])
         self.assertFalse(teams._get_team('/data/build/odoo/addons/web_studio/tests/test_ui.py'))
         self.assertEqual(website_team, teams._get_team('/data/build/odoo/addons/website_crm/tests/test_website_crm'))

--- a/runbot/tests/test_commit.py
+++ b/runbot/tests/test_commit.py
@@ -14,7 +14,7 @@ class TestCommitDate(RunbotCaseMinimalSetup):
         commit = self.Commit.create({
             'name': 'caca00caca00ffffffffffffffffffffffffffff',
             'tree_hash': '0caca00caca00fffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
 
         self.assertNotEqual(commit.date, False, "A commit should always have a date")
@@ -25,7 +25,7 @@ class TestCommitStatus(HttpCase):
     def setUp(self):
         super(TestCommitStatus, self).setUp()
         self.project = self.env['runbot.project'].create({'name': 'Tests'})
-        self.repo_server = self.env['runbot.repo'].create({
+        self.repo_odoo = self.env['runbot.repo'].create({
             'name': 'server',
             'project_id': self.project.id,
             'server_files': 'server.py',
@@ -34,7 +34,7 @@ class TestCommitStatus(HttpCase):
 
         self.server_commit = self.env['runbot.commit'].create({
             'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
 
         create_context = {'no_reset_password': True, 'mail_create_nolog': True, 'mail_create_nosubscribe': True, 'mail_notrack': True}

--- a/runbot/tests/test_cron.py
+++ b/runbot/tests/test_cron.py
@@ -24,7 +24,7 @@ class TestCron(RunbotCase):
         """ test that cron_fetch_and_schedule do its work """
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_update_frequency', 1)
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_do_fetch', True)
-        self.env['runbot.repo'].search([('id', '!=', self.repo_server.id)]).write({'mode': 'disabled'})  # disable all other existing repo than repo_server
+        self.env['runbot.repo'].search([('id', '!=', self.repo_odoo.id)]).write({'mode': 'disabled'})  # disable all other existing repo than repo_odoo
         try:
             self.Runbot._cron()
         except SleepException:
@@ -41,7 +41,7 @@ class TestCron(RunbotCase):
         self.patchers['hostname_patcher'].return_value = hostname
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_update_frequency', 1)
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_do_schedule', True)
-        self.env['runbot.repo'].search([('id', '!=', self.repo_server.id)]).write({'mode': 'disabled'})  # disable all other existing repo than repo_server
+        self.env['runbot.repo'].search([('id', '!=', self.repo_odoo.id)]).write({'mode': 'disabled'})  # disable all other existing repo than repo_odoo
 
         try:
             self.Runbot._cron()

--- a/runbot/tests/test_host.py
+++ b/runbot/tests/test_host.py
@@ -36,13 +36,13 @@ class TestHost(RunbotCase):
         self.server_commit = self.Commit.create({
             'name': 'dfdfcfcf0000ffffffffffffffffffffffffffff',
             'tree_hash': '0dfdfcfcf0000fffffffffffffffffffffffffff',
-            'repo_id': self.repo_server.id
+            'repo_id': self.repo_odoo.id
         })
 
         self.addons_commit = self.Commit.create({
             'name': 'd0d0caca0000ffffffffffffffffffffffffffff',
             'tree_hash': '0d0d0caca0000fffffffffffffffffffffffffff',
-            'repo_id': self.repo_addons.id,
+            'repo_id': self.repo_enterprise.id,
         })
 
         self.server_params = self.base_params.copy({'commit_link_ids': [

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -24,20 +24,20 @@ class TestRepo(RunbotCaseMinimalSetup):
         self.commit_list = {}
 
     def test_base_fields(self):
-        repo = self.repo_server
-        remote = self.remote_server
-        # name = 'bla@example.com:base/server'
-        self.assertTrue(repo.path.endswith('static/repo/server'))
-        self.assertEqual(remote.base_url, 'example.com/base/server')
-        self.assertEqual(remote.short_name, 'base/server')
+        repo = self.repo_odoo
+        remote = self.remote_odoo
+        # name = 'bla@example.com:base/odoo'
+        self.assertTrue(repo.path.endswith('static/repo/odoo'))
+        self.assertEqual(remote.base_url, 'example.com/base/odoo')
+        self.assertEqual(remote.short_name, 'base/odoo')
         self.assertEqual(remote.owner, 'base')
-        self.assertEqual(remote.repo_name, 'server')
+        self.assertEqual(remote.repo_name, 'odoo')
 
         # HTTPS
-        remote.name = 'https://bla@example.com/base/server.git'
-        self.assertEqual(remote.short_name, 'base/server')
+        remote.name = 'https://bla@example.com/base/odoo.git'
+        self.assertEqual(remote.short_name, 'base/odoo')
         self.assertEqual(remote.owner, 'base')
-        self.assertEqual(remote.repo_name, 'server')
+        self.assertEqual(remote.repo_name, 'odoo')
 
         # LOCAL
         remote.name = '/path/somewhere/bar.git'
@@ -49,8 +49,8 @@ class TestRepo(RunbotCaseMinimalSetup):
         """ Test that when finding new refs in a repo, the missing branches
         are created and new builds are created in pending state
         """
-        self.repo_addons = self.repo_addons  # lazy repo_addons fails on union
-        self.repo_server = self.repo_server  # lazy repo_addons fails on union
+        self.repo_enterprise = self.repo_enterprise  # lazy repo_enterprise fails on union
+        self.repo_odoo = self.repo_odoo  # lazy repo_enterprise fails on union
         self.additionnal_setup()
         self.start_patchers()
         max_bundle_id = self.env['runbot.bundle'].search([], order='id desc', limit=1).id or 0
@@ -62,7 +62,7 @@ class TestRepo(RunbotCaseMinimalSetup):
             self.assertEqual(url, '/repos/:owner/:repo/pulls/123')
             return {
                 'base': {'ref': 'master'},
-                'head': {'label': 'dev:%s' % branch_name, 'repo': {'full_name': 'dev/server'}},
+                'head': {'label': 'dev:%s' % branch_name, 'repo': {'full_name': 'dev/odoo'}},
                 'title': '[IMP] Title',
                 'body': 'Body',
                 'user': {
@@ -70,10 +70,10 @@ class TestRepo(RunbotCaseMinimalSetup):
                 },
             }
 
-        repos = self.repo_addons | self.repo_server
+        repos = self.repo_enterprise | self.repo_odoo
 
         first_commit = [(
-            'refs/%s/heads/%s' % (self.remote_server_dev.remote_name, branch_name),
+            'refs/%s/heads/%s' % (self.remote_odoo_dev.remote_name, branch_name),
             'd0d0caca',
             str(int(time.time())),
             'Marc Bidule',
@@ -83,13 +83,13 @@ class TestRepo(RunbotCaseMinimalSetup):
             '<marc.bidule@somewhere.com>',
             't0d0caca')]
 
-        self.commit_list[self.repo_server.id] = first_commit
+        self.commit_list[self.repo_odoo.id] = first_commit
 
         self.patchers['github_patcher'].side_effect = github
-        self.repo_server.project_id.process_delay = 10
+        self.repo_odoo.project_id.process_delay = 10
         repos._update_batches()
 
-        dev_branch = self.env['runbot.branch'].search([('remote_id', '=', self.remote_server_dev.id)])
+        dev_branch = self.env['runbot.branch'].search([('remote_id', '=', self.remote_odoo_dev.id)])
 
         bundle = dev_branch.bundle_id
         self.assertEqual(dev_branch.name, branch_name, 'A new branch should have been created')
@@ -103,7 +103,7 @@ class TestRepo(RunbotCaseMinimalSetup):
         last_batch = batch
 
         # create a addons branch in the same bundle
-        self.commit_list[self.repo_addons.id] = [('refs/%s/heads/%s' % (self.remote_addons_dev.remote_name, branch_name),
+        self.commit_list[self.repo_enterprise.id] = [('refs/%s/heads/%s' % (self.remote_enterprise_dev.remote_name, branch_name),
                                                   'deadbeef',
                                                    str(int(time.time())),
                                                   'Marc Bidule',
@@ -115,14 +115,14 @@ class TestRepo(RunbotCaseMinimalSetup):
 
         repos._update_batches()
 
-        addons_dev_branch = self.env['runbot.branch'].search([('remote_id', '=', self.remote_addons_dev.id)])
+        addons_dev_branch = self.env['runbot.branch'].search([('remote_id', '=', self.remote_enterprise_dev.id)])
 
         self.assertEqual(addons_dev_branch.bundle_id, bundle)
 
         self.assertEqual(dev_branch.head_name, 'd0d0caca', "Dev branch head name shoudn't have change")
         self.assertEqual(addons_dev_branch.head_name, 'deadbeef')
 
-        branch_count = self.env['runbot.branch'].search_count([('remote_id', '=', self.remote_server_dev.id)])
+        branch_count = self.env['runbot.branch'].search_count([('remote_id', '=', self.remote_odoo_dev.id)])
         self.assertEqual(branch_count, 1, 'No new branch should have been created')
 
         batch = self.env['runbot.batch'].search([('bundle_id', '=', bundle.id)])
@@ -131,8 +131,8 @@ class TestRepo(RunbotCaseMinimalSetup):
         self.assertEqual(batch.commit_link_ids.commit_id.mapped('subject'), ['Server subject', 'Addons subject'])
 
         # create a server pr in the same bundle with the same hash
-        self.commit_list[self.repo_server.id] += [
-            ('refs/%s/pull/123' % self.remote_server.remote_name,
+        self.commit_list[self.repo_odoo.id] += [
+            ('refs/%s/pull/123' % self.remote_odoo.remote_name,
              'd0d0caca',
              str(int(time.time())),
              'Marc Bidule',
@@ -146,15 +146,15 @@ class TestRepo(RunbotCaseMinimalSetup):
         # Create Batches
         repos._update_batches()
 
-        pull_request = self.env['runbot.branch'].search([('remote_id', '=', self.remote_server.id), ('name', '=', '123')])
+        pull_request = self.env['runbot.branch'].search([('remote_id', '=', self.remote_odoo.id), ('name', '=', '123')])
         self.assertEqual(pull_request.bundle_id, bundle)
 
         self.assertEqual(dev_branch.head_name, 'd0d0caca')
         self.assertEqual(pull_request.head_name, 'd0d0caca')
         self.assertEqual(addons_dev_branch.head_name, 'deadbeef')
 
-        self.assertEqual(dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_server_dev.id)]))
-        self.assertEqual(addons_dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_addons_dev.id)]))
+        self.assertEqual(dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_odoo_dev.id)]))
+        self.assertEqual(addons_dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_enterprise_dev.id)]))
 
         batch = self.env['runbot.batch'].search([('bundle_id', '=', bundle.id)])
         self.assertEqual(last_batch, batch, "No new batch should have been created")
@@ -162,9 +162,9 @@ class TestRepo(RunbotCaseMinimalSetup):
         self.assertEqual(batch.commit_link_ids.commit_id.mapped('subject'), ['Server subject', 'Addons subject'])
 
         # A new commit is found in the server repo
-        self.commit_list[self.repo_server.id] = [
+        self.commit_list[self.repo_odoo.id] = [
             (
-                'refs/%s/heads/%s' % (self.remote_server_dev.remote_name, branch_name),
+                'refs/%s/heads/%s' % (self.remote_odoo_dev.remote_name, branch_name),
                 'b00b',
                 str(int(time.time())),
                 'Marc Bidule',
@@ -175,7 +175,7 @@ class TestRepo(RunbotCaseMinimalSetup):
                 't00b',
             ),
             (
-                'refs/%s/pull/123' % self.remote_server.remote_name,
+                'refs/%s/pull/123' % self.remote_odoo.remote_name,
                 'b00b',
                 str(int(time.time())),
                 'Marc Bidule',
@@ -189,9 +189,9 @@ class TestRepo(RunbotCaseMinimalSetup):
         # Create Batches
         repos._update_batches()
 
-        self.assertEqual(dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_server_dev.id)]))
-        #self.assertEqual(pull_request + self.branch_server, self.env['runbot.branch'].search([('remote_id', '=', self.remote_server.id)]))
-        self.assertEqual(addons_dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_addons_dev.id)]))
+        self.assertEqual(dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_odoo_dev.id)]))
+        # self.assertEqual(pull_request + self.branch_odoo, self.env['runbot.branch'].search([('remote_id', '=', self.remote_odoo.id)]))
+        self.assertEqual(addons_dev_branch, self.env['runbot.branch'].search([('remote_id', '=', self.remote_enterprise_dev.id)]))
 
         batch = self.env['runbot.batch'].search([('bundle_id', '=', bundle.id)])
         self.assertEqual(bundle.last_batch, batch)
@@ -215,8 +215,8 @@ class TestRepo(RunbotCaseMinimalSetup):
         batch = self.env['runbot.batch'].search([('bundle_id', '=', bundle.id)])
         self.assertEqual(len(batch), 1, 'No new batch created, no head change')
 
-        self.commit_list[self.repo_server.id] = [
-            ('refs/%s/heads/%s' % (self.remote_server_dev.remote_name, branch_name),
+        self.commit_list[self.repo_odoo.id] = [
+            ('refs/%s/heads/%s' % (self.remote_odoo_dev.remote_name, branch_name),
              'dead1234',
              str(int(time.time())),
              'Marc Bidule',
@@ -236,7 +236,7 @@ class TestRepo(RunbotCaseMinimalSetup):
         self.assertEqual(bundle.last_batch.state, 'preparing')
         self.assertEqual(bundle.last_batch.commit_link_ids.commit_id.subject, 'A last subject')
 
-        self.commit_list[self.repo_server.id] = first_commit  # branch reset hard to an old commit (and pr closed)
+        self.commit_list[self.repo_odoo.id] = first_commit  # branch reset hard to an old commit (and pr closed)
 
         repos._update_batches()
 
@@ -254,7 +254,7 @@ class TestRepo(RunbotCaseMinimalSetup):
 
         self.patchers['github_patcher'].side_effect = github2
 
-        self.repo_server.project_id.process_delay = 0
+        self.repo_odoo.project_id.process_delay = 0
         bundle.last_batch._process()
         self.assertEqual(last_batch.commit_link_ids.commit_id.mapped('subject'), ['Server subject', 'Addons subject'])
 
@@ -267,14 +267,14 @@ class TestRepo(RunbotCaseMinimalSetup):
     def test_repo_perf_find_new_commits(self):
         repo = self.env['runbot.repo'].search([('name', '=', 'blabla')])
 
-        self.commit_list[self.repo_server.id] = []
+        self.commit_list[self.repo_odoo.id] = []
 
         # create 20000 branches and refs
         start_time = time.time()
         self.env['runbot.build'].search([], limit=5).write({'name': 'jflsdjflj'})
 
         for i in range(20005):
-            self.commit_list[self.repo_server.id].append(['refs/heads/bidon-%05d' % i,
+            self.commit_list[self.repo_odoo.id].append(['refs/heads/bidon-%05d' % i,
                                                           'd0d0caca %s' % i,
                                                           str(int(time.time())),
                                                           'Marc Bidule',
@@ -293,8 +293,8 @@ class TestRepo(RunbotCaseMinimalSetup):
     @common.warmup
     def test_times(self):
         def _test_times(model, setter, field_name):
-            repo1 = self.repo_server
-            repo2 = self.repo_addons
+            repo1 = self.repo_odoo
+            repo2 = self.repo_enterprise
 
             with self.assertQueryCount(1):
                 getattr(repo1, setter)(1.1)
@@ -330,28 +330,28 @@ class TestGithub(TransactionCase):
         """ Test different github responses or failures"""
 
         project = self.env['runbot.project'].create({'name': 'Tests'})
-        repo_server = self.env['runbot.repo'].create({
-            'name': 'server',
+        repo_odoo = self.env['runbot.repo'].create({
+            'name': 'odoo',
             'project_id': project.id,
         })
-        remote_server = self.env['runbot.remote'].create({
-            'name': 'bla@example.com:base/server',
-            'repo_id': repo_server.id,
+        remote_odoo = self.env['runbot.remote'].create({
+            'name': 'bla@example.com:base/odoo',
+            'repo_id': repo_odoo.id,
         })
 
-        #  self.assertEqual(remote_server._github('/repos/:owner/:repo/statuses/abcdef', dict(), ignore_errors=True), None, 'A repo without token should return None')
-        remote_server.token = 'abc'
+        #  self.assertEqual(remote_odoo._github('/repos/:owner/:repo/statuses/abcdef', dict(), ignore_errors=True), None, 'A repo without token should return None')
+        remote_odoo.token = 'abc'
 
         import requests
         with patch('odoo.addons.runbot.models.repo.requests.Session') as mock_session, patch('time.sleep') as mock_sleep:
             mock_sleep.return_value = None
             with self.assertRaises(Exception, msg='should raise an exception with ignore_errors=False'):
                 mock_session.return_value.post.side_effect = requests.HTTPError('301: Bad gateway')
-                remote_server._github('/repos/:owner/:repo/statuses/abcdef', {'foo': 'bar'}, ignore_errors=False)
+                remote_odoo._github('/repos/:owner/:repo/statuses/abcdef', {'foo': 'bar'}, ignore_errors=False)
 
             mock_session.return_value.post.reset_mock()
             with self.assertLogs(logger='odoo.addons.runbot.models.repo') as assert_log:
-                remote_server._github('/repos/:owner/:repo/statuses/abcdef', {'foo': 'bar'}, ignore_errors=True)
+                remote_odoo._github('/repos/:owner/:repo/statuses/abcdef', {'foo': 'bar'}, ignore_errors=True)
                 self.assertIn('Ignored github error', assert_log.output[0])
 
             self.assertEqual(2, mock_session.return_value.post.call_count, "_github method should try two times by default")
@@ -359,7 +359,7 @@ class TestGithub(TransactionCase):
             mock_session.return_value.post.reset_mock()
             mock_session.return_value.post.side_effect = [requests.HTTPError('301: Bad gateway'), Mock()]
             with self.assertLogs(logger='odoo.addons.runbot.models.repo') as assert_log:
-                remote_server._github('/repos/:owner/:repo/statuses/abcdef', {'foo': 'bar'}, ignore_errors=True)
+                remote_odoo._github('/repos/:owner/:repo/statuses/abcdef', {'foo': 'bar'}, ignore_errors=True)
                 self.assertIn('Success after 2 tries', assert_log.output[0])
 
             self.assertEqual(2, mock_session.return_value.post.call_count, "_github method should try two times by default")
@@ -389,7 +389,7 @@ class TestFetch(RunbotCase):
         self.assertFalse(host.assigned_only)
         # Ensure that Host is not disabled if fetch succeeds after 3 tries
         with mute_logger("odoo.addons.runbot.models.repo"):
-            self.repo_server._update_fetch_cmd()
+            self.repo_odoo._update_fetch_cmd()
 
         self.assertFalse(host.assigned_only, "Host should not be disabled when fetch succeeds")
         self.assertEqual(self.fetch_count, 3)
@@ -397,13 +397,13 @@ class TestFetch(RunbotCase):
         self.force_failure = True
 
         with mute_logger("odoo.addons.runbot.models.repo"):
-            self.repo_server._update_fetch_cmd()
+            self.repo_odoo._update_fetch_cmd()
         self.assertFalse(host.assigned_only, "Host should not be disabled when fetch fails by default")
 
         self.fetch_count = 0
         self.env['ir.config_parameter'].sudo().set_param('runbot.runbot_disable_host_on_fetch_failure', True)
         with mute_logger("odoo.addons.runbot.models.repo"):
-            self.repo_server._update_fetch_cmd()
+            self.repo_odoo._update_fetch_cmd()
         self.assertTrue(host.assigned_only, "Host should be disabled when fetch fails and runbot_disable_host_on_fetch_failure is set")
         self.assertEqual(self.fetch_count, 5)
 
@@ -426,10 +426,10 @@ class TestIdentityFile(RunbotCase):
             self.patcher_objects['git_patcher'].stop()
             self.start_patcher('check_output_patcher', 'odoo.addons.runbot.models.repo.subprocess.check_output', new=self.check_output_helper())
 
-            self.repo_server.identity_file = 'fake_identity'
+            self.repo_odoo.identity_file = 'fake_identity'
 
             with mute_logger("odoo.addons.runbot.models.repo"):
-                self.repo_server._update_fetch_cmd()
+                self.repo_odoo._update_fetch_cmd()
 
 
 class TestRepoScheduler(RunbotCase):
@@ -492,7 +492,7 @@ class TestGetRefs(RunbotCase):
     def test_get_refs(self):
         current = time.time()
         commit_time = str(int(current) - 5000)
-        self.remote_server_dev.fetch_pull = True
+        self.remote_odoo_dev.fetch_pull = True
         to_ignore = {'242': current - 100}
         good_ref = (
             'refs/bla-dev/heads/master-test-branch-rbt',
@@ -525,7 +525,7 @@ class TestGetRefs(RunbotCase):
             '<foobarman@somewhere.com>',
         )
         self.test_refs.extend([good_ref, bad_ref, to_ignore_ref])
-        refs = self.repo_server._get_refs(ignore=to_ignore)
+        refs = self.repo_odoo._get_refs(ignore=to_ignore)
         self.assertIn(good_ref, refs, 'A valid branch should appear in refs')
         self.assertNotIn(bad_ref, refs, 'A branch name that is an integer should be filtered out')
         self.assertNotIn(to_ignore_ref, refs, 'An explicitely ignored branch should be filtered out')

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -20,7 +20,7 @@ class TestUpgradeFlow(RunbotCase):
         self.start_patcher('find_patcher', 'odoo.addons.runbot.common.find', 0)
         self.additionnal_setup()
 
-        self.master_bundle = self.branch_server.bundle_id
+        self.master_bundle = self.branch_odoo.bundle_id
         self.config_test = self.env['runbot.build.config'].create({'name': 'Test'})
         #################
         # upgrade branch
@@ -107,7 +107,7 @@ class TestUpgradeFlow(RunbotCase):
         })
         self.trigger_template = self.env['runbot.trigger'].create({
             'name': 'Template',
-            'dependency_ids': [(4, self.repo_server.id), (4, self.repo_addons.id)],
+            'dependency_ids': [(4, self.repo_odoo.id), (4, self.repo_enterprise.id)],
             'config_id': self.config_template.id,
             'project_id': self.project.id,
             'category_id': self.default_category.id,
@@ -134,7 +134,7 @@ class TestUpgradeFlow(RunbotCase):
         })
         self.trigger_upgrade_to_current = self.env['runbot.trigger'].create({
             'name': 'Server upgrade',
-            'repo_ids': [(4, self.repo_upgrade.id), (4, self.repo_server.id), (4, self.repo_addons.id)],
+            'repo_ids': [(4, self.repo_upgrade.id), (4, self.repo_odoo.id), (4, self.repo_enterprise.id)],
             'config_id': self.config_upgrade_to_current.id,
             'project_id': self.project.id,
             'upgrade_dumps_trigger_id': self.trigger_template.id,
@@ -163,7 +163,7 @@ class TestUpgradeFlow(RunbotCase):
         self.trigger_upgrade_stable = self.env['runbot.trigger'].create({
             'name': 'Server upgrade',
             'repo_ids': [(4, self.repo_upgrade.id)],
-            'dependency_ids': [(4, self.repo_server.id), (4, self.repo_addons.id)],
+            'dependency_ids': [(4, self.repo_odoo.id), (4, self.repo_enterprise.id)],
             'config_id': self.config_upgrade_stable.id,
             'project_id': self.project.id,
             'upgrade_dumps_trigger_id': self.trigger_template.id,
@@ -178,7 +178,7 @@ class TestUpgradeFlow(RunbotCase):
         self.config_single_module = self.env['runbot.build.config'].create({'name': 'Single'})
         self.trigger_single_nightly = self.env['runbot.trigger'].create({
             'name': 'Nighly server',
-            'dependency_ids': [(4, self.repo_server.id), (4, self.repo_addons.id)],
+            'dependency_ids': [(4, self.repo_odoo.id), (4, self.repo_enterprise.id)],
             'config_id': self.config_single_module.id,
             'project_id': self.project.id,
             'category_id': self.nightly_category.id,
@@ -228,34 +228,34 @@ class TestUpgradeFlow(RunbotCase):
     def create_version(self, name):
         intname = int(''.join(c for c in name if c.isdigit())) if name != 'master' else 0
         if name != 'master':
-            branch_server = self.Branch.create({
+            branch_odoo = self.Branch.create({
                 'name': name,
-                'remote_id': self.remote_server.id,
+                'remote_id': self.remote_odoo.id,
                 'is_pr': False,
                 'head': self.Commit.create({
                     'name': f'server{intname}',
                     'tree_hash': f'0server{intname}',
-                    'repo_id': self.repo_server.id,
+                    'repo_id': self.repo_odoo.id,
                 }).id,
             })
             branch_addons = self.Branch.create({
                 'name': name,
-                'remote_id': self.remote_addons.id,
+                'remote_id': self.remote_enterprise.id,
                 'is_pr': False,
                 'head': self.Commit.create({
                     'name': f'addons{intname}',
                     'tree_hash': f'0addons{intname}',
-                    'repo_id': self.repo_addons.id,
+                    'repo_id': self.repo_enterprise.id,
                 }).id,
             })
         else:
-            branch_server = self.branch_server
+            branch_odoo = self.branch_odoo
             branch_addons = self.branch_addons
 
         host = self.env['runbot.host']._get_current()
 
-        self.assertEqual(branch_server.bundle_id, branch_addons.bundle_id)
-        bundle = branch_server.bundle_id
+        self.assertEqual(branch_odoo.bundle_id, branch_addons.bundle_id)
+        bundle = branch_odoo.bundle_id
         self.assertEqual(bundle.name, name)
         bundle.is_base = True
         batch = bundle._force()
@@ -292,7 +292,7 @@ class TestUpgradeFlow(RunbotCase):
     @patch('odoo.addons.runbot.models.build.BuildResult._parse_config')
     def test_all(self, *_):
         # Test setup
-        self.assertEqual(self.branch_server.bundle_id, self.branch_upgrade.bundle_id)
+        self.assertEqual(self.branch_odoo.bundle_id, self.branch_upgrade.bundle_id)
         self.assertTrue(self.branch_upgrade.bundle_id.is_base)
         self.assertTrue(self.branch_upgrade.bundle_id.version_id)
         self.assertEqual(self.trigger_upgrade_to_current.upgrade_step_id, self.step_upgrade_to_current)
@@ -326,7 +326,7 @@ class TestUpgradeFlow(RunbotCase):
         assertOk(b_173_master_demo, self.template_per_version['saas-17.3'], master_upgrade_build, 'all')
         assertOk(b_173_master_no_demo, self.template_per_version['saas-17.3'], master_upgrade_build, 'no-demo-all')
 
-        self.assertEqual(b_17_master_demo.params_id.commit_ids.repo_id, self.repo_server | self.repo_upgrade | self.repo_addons)
+        self.assertEqual(b_17_master_demo.params_id.commit_ids.repo_id, self.repo_odoo | self.repo_upgrade | self.repo_enterprise)
 
         # upgrade repos tests
         upgrade_stable_build = master_batch.slot_ids.filtered(lambda slot: slot.trigger_id == self.trigger_upgrade_stable).build_id
@@ -484,16 +484,16 @@ class TestUpgradeFlow(RunbotCase):
                 self.assertTrue(ro_volumes.pop(f'/home/{user}/.odoorc').startswith(self.env['runbot.runbot']._path('build')))
                 self.assertEqual(
                     list(ro_volumes.keys()), [
-                        '/data/build/addons',
-                        '/data/build/server',
+                        '/data/build/enterprise',
+                        '/data/build/odoo',
                         '/data/build/upgrade',
                     ],
                     "other commit should have been added automaticaly"
                 )
                 self.assertEqual(
                     str(cmd),
-                    'python3 server/server.py {addons_path} --no-xmlrpcs --no-netrpc -u all -d {db_name} --stop-after-init --max-cron-threads=0'.format(
-                        addons_path='--addons-path addons,server/addons,server/core/addons',
+                    'python3 odoo/server.py {addons_path} --no-xmlrpcs --no-netrpc -u all -d {db_name} --stop-after-init --max-cron-threads=0'.format(
+                        addons_path='--addons-path enterprise,odoo/addons,odoo/core/addons',
                         db_name=f'{current_build.dest}-{suffix}')
                 )
             current_build._schedule()()


### PR DESCRIPTION
This pr add the ability for dynamic config to create one subbuild per
module, or per modified module.

It also adds the possibility to select modules based on the repo they
originate from.