### PR TITLE
[IMP] quieter logs

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -27,10 +27,10 @@ dest_reg = re.compile(r'^\d{5,}-.+$')
 def transactioncache(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
-        assert not self.ids
+        assert not self.ids or len(self.ids) == 1, "transactioncache only works on singletons or empty recordsets"
         cache = self.env.cr.cache
         method_key = method
-        params_key = (args, frozenset(kwargs.items()))
+        params_key = (tuple(self.ids), args, frozenset(kwargs.items()))
         # should check id key is serializable
         if method_key not in cache:
             cache[method_key] = {}

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -148,16 +148,18 @@ class BuildParameters(models.Model):
                 extensions = []
                 for commit in build_param.commit_ids.sorted(key=lambda c: (c.repo_id.sequence, c.repo_id.id)):
                     for path in file_path.split(','):
-                        try:
-                            if content := commit._git_show_file(path):
-                                file_dynamic_config = json.loads(content)
-                                if file_dynamic_config.get('extension'):
-                                    extensions.append(file_dynamic_config)
-                                else:
-                                    base_config = file_dynamic_config
-                                break
-                        except Exception as e:
-                            build_param.create_batch_id._log(f'Failed to load dynamic config from {file_path} in commit {commit.repo_id.name}: {e}', level='ERROR')
+                        repo, path = path.split(':', 1) if ':' in path else (None, path)
+                        if not repo or commit.repo_id.name == repo:
+                            try:
+                                if content := commit._git_show_file(path):
+                                    file_dynamic_config = json.loads(content)
+                                    if file_dynamic_config.get('extension'):
+                                        extensions.append(file_dynamic_config)
+                                    else:
+                                        base_config = file_dynamic_config
+                                    break
+                            except Exception as e:
+                                build_param.create_batch_id._log(f'Failed to load dynamic config from {file_path} in commit {commit.repo_id.name}: {e}', level='ERROR')
                 extensions.append(default_config_extension)
                 config = base_config
                 for extension in extensions:

--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -2,7 +2,7 @@
 import datetime
 import subprocess
 
-from ..common import os, RunbotException, make_github_session
+from ..common import os, RunbotException, make_github_session, transactioncache
 import glob
 import shutil
 
@@ -164,6 +164,7 @@ class Commit(models.Model):
         except:
             return False
 
+    @transactioncache
     def _git_show_file(self, file):
         self.ensure_one()
         self.repo_id._fetch(self.name)
@@ -201,7 +202,7 @@ class Commit(models.Model):
             return
 
         if ci_strategy != 'all' and state == 'pending':
-            _logger.info("skipping github pending status for build %s and ci %s", build_id, context)
+            _logger.debug("skipping github pending status for build %s and ci %s", build_id, context)
             return
 
         if ci_strategy == 'errors' and state != 'error' and last_status.state not in ('error', 'failure'):

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -520,9 +520,10 @@ class Repo(models.Model):
         cmd = ['git', '-C', self.path] + config_args + cmd
         return cmd
 
-    def _git(self, cmd, errors='strict'):
+    def _git(self, cmd, errors='strict', quiet=False):
         cmd = self._get_git_command(cmd, errors)
-        _logger.info("git command: %s", shlex.join(cmd))
+        if not quiet:
+            _logger.info("git command: %s", shlex.join(cmd))
         return subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode(errors=errors)
 
     def _fetch(self, sha):
@@ -543,7 +544,7 @@ class Repo(models.Model):
         """ Verify that a commit hash exists in the repo """
         self.ensure_one()
         try:
-            self._git(['cat-file', '-e', commit_hash])
+            self._git(['cat-file', '-e', commit_hash], quiet=True)
         except subprocess.CalledProcessError:
             return False
         return True

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -194,7 +194,7 @@ class RunbotCase(TransactionCase):
         self.docker_run_calls = []
         self.diff = ''
 
-        def mock_git(repo, cmd):
+        def mock_git(repo, cmd, quiet=False):
             return self.mock_git_helper(repo, cmd)
 
         self.start_patcher('git_patcher', 'odoo.addons.runbot.models.repo.Repo._git', new=mock_git)


### PR DESCRIPTION
[FIX] runbot: less spammy logs
Lower level of some messages

[IMP] runbot: better json file selection

Allow to specify a repo for dynamic config path to avoid checking them
all if not needed.

[IMP] runbot: add a cache on git show file

The same file content may be read by multiple triggers using the same
config.

This will avoid spamming the log with git show commands as well as
improve performance when the same file content is requested multiple
times within the same transaction.