### PR TITLE
[IMP] runbot: ignore autoretry tb

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -1439,12 +1439,24 @@ class ConfigStep(models.Model):
             build._log('_make_tests_results', 'Error found in logs:\n%s' % '\n'.join(result), level="ERROR")
             return 'ko'
 
+        if build.local_result == 'warn':
+            return 'warn'  # don't check traceback for build in waning since the traceback could come from a warning message
+
         re_traceback = r'^(?:Traceback \(most recent call last\):)$'
         if result := rfind(log_path, re_traceback):
             # find Traceback, all following indented lines and one last non indented line
-            complete_traceback = rfind(log_path, r'^(?:Traceback \(most recent call last\):(?:\n .*)*(?:\n.*)?)')[:10000]
-            complete_traceback = complete_traceback or result
-            build._log('_make_tests_results', 'Traceback found in logs:\n%s' % '\n'.join(complete_traceback), level="ERROR")
+            complete_traceback = rfind(log_path, r'^(?:.+\n)?(?:Traceback \(most recent call last\):(?:\n .*)*(?:\n.*)?)')
+            if complete_traceback:
+                def is_lower_level(tb):
+                    first_line = tb.split('\n')[0]
+                    for level in ('_WARNING', '_ERROR', '_CRITICAL'):
+                        if level in first_line:
+                            return True
+                    return False
+                result = [tb for tb in complete_traceback if not is_lower_level(tb)]
+                if not result:
+                    return 'ok'  # all tracebacks were in a lower login level, ignore them
+            build._log('_make_tests_results', 'Traceback found in logs:\n%s' % ('\n'.join(result))[:10000], level="ERROR")
             return 'ko'
         return 'ok'
 

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -1293,31 +1293,7 @@ Loading stuff
             ('ERROR', 'Modules loaded not found in logs\n\nLoading stuff\n'),
         ])
 
-    def test_make_result_traceback(self):
-        file_content = """
-Loading stuff
-Traceback (most recent call last):
-  File "/data/build/odoo/odoo-bin", line 5, in <module>
-    import odoo
-  File "/data/build/odoo/odoo/__init__.py", line 134, in <module>
-    from . import modules
-  File "/data/build/odoo/odoo/modules/__init__.py", line 8, in <module>
-    from . import db, graph, loading, migration, module, registry, neutralize
-  File "/data/build/odoo/odoo/modules/graph.py", line 11, in <module>
-    import odoo.tools as tools
-  File "/data/build/odoo/odoo/tools/__init__.py", line 25, in <module>
-    from .mail import *
-  File "/data/build/odoo/odoo/tools/mail.py", line 32, in <module>
-    safe_attrs = clean.defs.safe_attrs | frozenset(
-AttributeError: module 'lxml.html.clean' has no attribute 'defs'
-2024-05-14 09:54:22,692 17 INFO dbname path.to.test: aaa
-"""
-        with patch('builtins.open', mock_open(read_data=file_content)):
-            self.config_step._make_results(self.build)
-        self.assertEqual(str(self.build.job_end), '1970-01-01 02:00:00')
-        self.assertEqual(self.build.local_result, 'ko')
-        expected = """Traceback found in logs:
-Traceback (most recent call last):
+    traceback_example = """Traceback (most recent call last):
   File "/data/build/odoo/odoo-bin", line 5, in <module>
     import odoo
   File "/data/build/odoo/odoo/__init__.py", line 134, in <module>
@@ -1331,10 +1307,61 @@ Traceback (most recent call last):
   File "/data/build/odoo/odoo/tools/mail.py", line 32, in <module>
     safe_attrs = clean.defs.safe_attrs | frozenset(
 AttributeError: module 'lxml.html.clean' has no attribute 'defs'"""
+
+    def test_make_result_traceback(self):
+        self.maxDiff = None
+        file_content = f"""
+2025-05-04 08:39:00,000 42 INFO other info
+2025-05-04 08:40:00,000 42 INFO test_runbot odoo.addons.runbot.tests.test_build_config_step: FAIL: TestMakeResult.test_make_result_traceback
+{self.traceback_example}
+2024-05-14 09:54:22,692 17 INFO dbname path.to.test: aaa
+"""
+        with patch('builtins.open', mock_open(read_data=file_content)):
+            self.config_step._make_results(self.build)
+        self.assertEqual(str(self.build.job_end), '1970-01-01 02:00:00')
+        self.assertEqual(self.build.local_result, 'ko')
+        expected = f"""Traceback found in logs:
+2025-05-04 08:40:00,000 42 INFO test_runbot odoo.addons.runbot.tests.test_build_config_step: FAIL: TestMakeResult.test_make_result_traceback
+{self.traceback_example}"""
         self.assertEqual(self.logs, [
             ('INFO', 'Getting results for build %s' % self.build.dest),
             ('ERROR', expected),
         ])
+
+    def test_make_result_traceback_alone(self):
+        self.maxDiff = None
+        file_content = f"""{self.traceback_example}
+2024-05-14 09:54:22,692 17 INFO dbname path.to.test: aaa
+"""
+        with patch('builtins.open', mock_open(read_data=file_content)):
+            self.config_step._make_results(self.build)
+        self.assertEqual(str(self.build.job_end), '1970-01-01 02:00:00')
+        self.assertEqual(self.build.local_result, 'ko')
+        expected = f"""Traceback found in logs:
+{self.traceback_example}"""
+        self.assertEqual(self.logs, [
+            ('INFO', 'Getting results for build %s' % self.build.dest),
+            ('ERROR', expected),
+        ])
+
+    def test_make_result_traceback_retry(self):
+        self.maxDiff = None
+        file_content = f"""
+2025-05-04 08:39:00,000 42 INFO other info
+2025-05-04 08:40:00,000 42 _ERROR test_runbot odoo.addons.runbot.tests.test_build_config_step: FAIL: TestMakeResult.test_make_result_traceback
+{self.traceback_example}
+2024-05-14 09:54:22,692 17 INFO dbname path.to.test: aaa
+2024-05-14 09:54:22,692 17 INFO dbname odoo.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+"""
+        with patch('builtins.open', mock_open(read_data=file_content)):
+            self.config_step._make_results(self.build)
+        self.assertEqual(str(self.build.job_end), '1970-01-01 02:00:00')
+        self.assertEqual(self.logs, [
+            ('INFO', 'Getting results for build %s' % self.build.dest),
+        ])
+        self.assertEqual(self.build.local_result, 'ok')
 
     def test_make_result_error(self):
         file_content = """


### PR DESCRIPTION
When parsing the logs to find traceback, runbot will catch errors that should be hidden by autoretry

2025-12-03 01:22:00,501 26 _WARNING 94760443-saas-18-2-all odoo.tests.common: Error during browser shutdown Traceback (most recent call last):
  File "/data/build/odoo/odoo/tests/common.py", line 1511, in _websocket_request
    return f.result(timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/concurrent/futures/_base.py", line 458, in result
    raise TimeoutError()
TimeoutError

The Traceback (most recent call last): will be parsed and make the build fail.

This pr will detect if the previous line was a "autoretry" line by checking if it contains a log level starting with _ and ignore traceback in this case.

This was paritially solved in odoo by altering the log to alter the traceback prefix but this does not cover all cases, and makes odoo code more complex than needed.