### PR TITLE
[IMP] runbot: add link to project's "next freeze"

### DIFF
--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -24,6 +24,7 @@ class Project(models.Model):
     hidden = fields.Boolean('Hidden', help='Hide this project from the main page')
     active = fields.Boolean("Active", default=True)
     process_delay = fields.Integer('Process delay', default=60, required=True, help="Delay between a push and a batch starting its process.")
+    next_freeze_tag_id = fields.Many2one('runbot.bundle.tag', string="Next freeze tag")
 
     @api.constrains('process_delay')
     def _constraint_process_delay(self):

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -91,6 +91,11 @@
                                                 </a>
                                             </li>
                                         </t>
+                                        <li t-if="project and project.next_freeze_tag_id" class="nav-item" title="Freeze">
+                                            <a class="nav-link" t-attf-href="/runbot/{{slug(project)}}/bundle/tag/{{slug(project.next_freeze_tag_id)}}">
+                                                <i class="fa fa-snowflake-o"/>
+                                            </a>
+                                        </li>
                                         <t t-call="runbot.build_errors_link"/>
                                         <li class="nav-item dropdown" t-ignore="true">
                                             <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -10,6 +10,7 @@
                     <field name="keep_sticky_running"/>
                     <field name="always_use_foreign"/>
                     <field name="dockerfile_id"/>
+                    <field name="next_freeze_tag_id"/>
                     <field name="group_ids"/>
                     <field name="trigger_ids"/>
                     <field name="sequence"/>
@@ -29,6 +30,7 @@
                 <field name="name"/>
                 <field name="keep_sticky_running"/>
                 <field name="dockerfile_id"/>
+                <field name="next_freeze_tag_id"/>
                 <field name="group_ids"/>
                 <field name="trigger_ids"/>
                 <field name="sequence"/>


### PR DESCRIPTION
Add the "next freeze" tag field on runbot's project and the link to the
current project's "next freeze" tag in the frontend's navbar.