### PR TITLE
[FIX] runbot: allow upgrade_exception_manager to scan errors

### DIFF
--- a/runbot/views/upgrade.xml
+++ b/runbot/views/upgrade.xml
@@ -6,6 +6,7 @@
          <field name="binding_model_id" ref="runbot.model_runbot_build" />
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
+        <field name="group_ids" eval="[Command.link(ref('runbot.group_runbot_upgrade_exception_manager'))]"/>
         <field name="code">
             action = records._parse_upgrade_errors()
         </field>


### PR DESCRIPTION
This was not working because by default an action needs to have write access on the record, adding the group 'upgrade_exception_manager' to the action sovles the issue by making the chck more specific allowing to run the action with write access on the build.