### PR TITLE
[FIX] runbot: fetch threehash

### DIFF
--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -103,7 +103,7 @@ class Commit(models.Model):
         """Export a git repo into a sources"""
         #  TODO add automated tests
         self.ensure_one()
-        self.repo_id._fetch(self.name)
+        self.repo_id._fetch(self.tree_hash)
         if not self.env['runbot.commit.export'].search([('build_id', '=', build.id), ('commit_id', '=', self.id)]):
             self.env['runbot.commit.export'].create({'commit_id': self.id, 'build_id': build.id})
         export_path = self._source_path()


### PR DESCRIPTION
Before this commit, to export some threehash, the commit is used to check if the commit is present or not.

This can be a problem when rebuilding an old build that was linked to a previous one by a threehash after a forcepush, because the old commit may not be known by github anymore.

Not sure why it was the case since it looks like fetch works fine with a threehash, so fixing it by fetching the threehash should be enough.