### PR TITLE
[IMP] runbot: upgrade refactor model update

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -119,13 +119,22 @@ class BuildParameters(models.Model):
                 'modules': param.modules or '',
                 'commit_link_ids': commit_ident,
                 'builds_reference_ids': sorted(param.builds_reference_ids.ids),
-                'upgrade_from_build_id': param.upgrade_from_build_id.id,
-                'upgrade_to_build_id': param.upgrade_to_build_id.id,
                 'dump_db': param.dump_db.id,
                 'dockerfile_id': param.dockerfile_id.id,
                 'skip_requirements': param.skip_requirements,
             }
+            if param.upgrade_to_build_id:
+                cleaned_vals['upgrade_to_build_dockerfile_id'] = param.upgrade_to_build_id.params_id.dockerfile_id.id
+                cleaned_vals['upgrade_to_build_commits'] = sorted([c.tree_hash or c.id for c in param.upgrade_to_build_id.params_id.commit_link_ids.commit_id])
+            if param.upgrade_from_build_id:
+                cleaned_vals['upgrade_from_build_commits'] = param.upgrade_from_build_id.id
             if param.trigger_id.batch_dependent:
+                cleaned_vals['create_batch_id'] = param.create_batch_id.id
+            if param.trigger_id.upgrade_step_id.upgrade_matrix_id:
+                # when using new matrix, the build references are not set on the build (removing uniquification)
+                # but a build could come from the current batch (testing template)
+                # so the build bust be considered as if build was batch_dependent
+                # Thanks to allow_similar_build_quick_result (when enabled) it should'nt cause any additional load.
                 cleaned_vals['create_batch_id'] = param.create_batch_id.id
             if param.used_custom_trigger:
                 cleaned_vals['used_custom_trigger'] = True

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -428,11 +428,15 @@ class ConfigStep(models.Model):
 
     # wip replace previous field by matrix
     upgrade_matrix_id = fields.Many2one('runbot.upgrade.matrix', 'Upgrade matrix', tracking=True)
-    upgrade_current_source = fields.Boolean('Upgrade Curent source', help='Use current build as Source if version match', default=True, tracking=True)
-    upgrade_current_target = fields.Boolean('Upgrade Curent target', help='Use current build as target if version match', default=True, tracking=True)
-    # TODO maybe remove this field in the future, should all work in the same build
+    upgrade_current = fields.Boolean('Upgrade Current', help='Use current build as Source and Target if version match', default=True, tracking=True)
+    # TODO remove upgrade cleanup
+    upgrade_current_source = fields.Boolean('Upgrade Current source', help='Use current build as Source if version match', default=True, tracking=True)
+    upgrade_current_target = fields.Boolean('Upgrade Current target', help='Use current build as target if version match', default=True, tracking=True)
+    # TODO maybe remove this fields in the future, should all work in the same build
     upgrade_from_bellow = fields.Boolean('Upgrade from bellow', help="Standard upgrade behaviour", default=True, tracking=True)
     upgrade_to_above = fields.Boolean('Upgrade to above', help="Will behave as a complement", default=True, tracking=True)
+    upgrade_from_base = fields.Boolean('Upgrade from base', help="Allow upgrade from base version to current", default=False, tracking=True)
+    allow_similar_build_quick_result = fields.Boolean('Allow similar build quick result', help="Allow to find result on a similar build with the same parameters, and mark the result and state when creating the child build", default=False, tracking=True)
 
     upgrade_flat = fields.Boolean("Flat", help="Take all decisions in on build")
 

--- a/runbot/models/upgrade.py
+++ b/runbot/models/upgrade.py
@@ -111,6 +111,7 @@ class UpgradeMatrix(models.Model):
     upgrade_from_previous_major_version = fields.Boolean()
     upgrade_from_last_intermediate_version = fields.Boolean()
     upgrade_from_all_intermediate_version = fields.Boolean()
+    step_ids = fields.One2many('runbot.build.config.step', 'upgrade_matrix_id', 'Upgrade steps', readonly=True)
 
     matrix_summary = fields.Text('Matrix summary', compute='_compute_matrix_summary', store=True, tracking=True)
 

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -152,6 +152,27 @@
                     <a t-attf-href="/runbot/build/{{reference.id}}"><t t-esc="reference.id"/></a> - <em t-out="reference.params_id.version_id.name"/>
                   </div>
                 </t>
+                <t t-if="build.params_id.upgrade_to_build_id">
+                  <b>Upgrade target build:</b>
+                  <a t-attf-href="/runbot/build/{{build.params_id.upgrade_to_build_id.id}}">
+                    <t t-out="build.params_id.upgrade_to_build_id.id"/>
+                  </a>
+                  <br/>
+                </t>
+                <t t-if="build.params_id.upgrade_from_build_id">
+                  <b>Upgrade source build:</b>
+                  <a t-attf-href="/runbot/build/{{build.params_id.upgrade_from_build_id.id}}">
+                    <t t-out="build.params_id.upgrade_from_build_id.id"/>
+                  </a>
+                  <br/>
+                </t>
+                <t t-if="build.params_id.dump_db">
+                  <b>Dump database</b>
+                  <a t-attf-href="/runbot/build/{{build.params_id.dump_db.build_id.id}}">
+                    <t t-out="build.params_id.dump_db.build_id.dest"/>-<t t-out="build.params_id.dump_db.db_suffix"/>
+                  </a>
+                  <br/>
+                </t>
                 <t t-if="len(build.params_id.build_ids) > 1">
                   <b>Similar builds:</b>
                   <t t-foreach="build.params_id.build_ids" t-as="simbuild">

--- a/runbot/views/config_views.xml
+++ b/runbot/views/config_views.xml
@@ -101,14 +101,15 @@
                             <field name="min_target_version_id"/>
                         </list>
                       </field>
+                      <field name="allow_similar_build_quick_result"/>
                       <field name="upgrade_matrix_id"/>
                     </group>
                     <group invisible="job_type not in ('python', 'configure_upgrade', 'dynamic')">
                       <group class="col" string="Upgrade matrix settings"  invisible="not upgrade_matrix_id">
-                        <field name="upgrade_current_source"/>
-                        <field name="upgrade_current_target"/>
-                        <field name="upgrade_from_bellow"/>
-                        <field name="upgrade_to_above"/>
+                        <field name="upgrade_current"/>
+                        <field name="upgrade_from_bellow" invisible="not upgrade_current"/>
+                        <field name="upgrade_to_above" invisible="not upgrade_current"/>
+                        <field name="upgrade_from_base" invisible="not upgrade_current"/>
                       </group>
                       <group class="col" string="Target version settings" invisible="upgrade_matrix_id">
                         <field string="Current" name="upgrade_to_current"/>

--- a/runbot/views/upgrade_matrix_views.xml
+++ b/runbot/views/upgrade_matrix_views.xml
@@ -10,23 +10,24 @@
                 <button name="update_matrix_entries" string="Create missing entries" type="object" class="oe_highlight"/>
                 <button name="reset_matrix_enabled" string="Reset matrix entries default enabled state" type="object" class="oe_highlight"/>
               </header>
-              <group >
-                <group >
+              <group>
+                <group>
                   <field name="name"/>
                   <field name="project_id"/>
                   <field name="auto_update"/>
-                </group >
-                <group >
+                </group>
+                <group>
                   <field name="upgrade_to_major_versions"/>
                   <field name="upgrade_to_all_versions"/>
                   <field name="upgrade_from_previous_major_version"/>
                   <field name="upgrade_from_last_intermediate_version"/>
                   <field name="upgrade_from_all_intermediate_version"/>
-
-                </group >
+                </group>
               </group >
+              <group>
+                <field name="step_ids" widget="many2many_tags"/>
+              </group>
               <group >
-
                 <field name="entry_ids" widget="version_matrix">
                     <list>
                       <field name="from_version_id"/>


### PR DESCRIPTION
Prepare the models for #1289

This pr contains teh changes needed for the new upgrade strategy without any other change to the code reducing the risk to break something

Some new fiels are added, mainly upgrade_current and upgrade_from_base to replace upgrade_current_source and upgrade_current_target with a more understandable configuration.

Some views are adapted to reflect this changes

The compute of the fingerprint was modified to inlude upgrade related informations in a more precise way, to make
allow_similar_build_quick_result more effective.