### PR TITLE
[FIX] runbot: click/middle-click on FrontendUrl fields

### DIFF
--- a/runbot/static/src/js/fields/fields.js
+++ b/runbot/static/src/js/fields/fields.js
@@ -84,7 +84,7 @@ registry.category("fields").add("runbotjsonb", {
 
 export class FrontendUrl extends Component {
     static template = xml`
-        <div><a t-att-href="route" target="_blank"><t t-out="displayValue"/></a></div>
+        <div><a t-att-href="route" t-on-click.stop="" t-on-auxclick.stop="" target="_blank"><t t-out="displayValue"/></a></div>
     `;
 
     static components = { Many2OneField };


### PR DESCRIPTION
Before this commit, and since the update to Odoo 19.0, click/middle-click on FrontendUrl fields in list view opened the record's modal form view in addition to the actual link in a new tab.

This commit fixes it by stopping the event's propagation beyond the actual `<a>` tag.

Steps to reproduce:
- open an error's form view,
- in the Error Content list view, click on the first/last seen date
- related build link opens in a new tab => the error's form view also opens in modal