### PR TITLE
[FIX] runbot: deferred jQuery loading broke stats page

### DIFF
--- a/runbot/static/src/js/stats.js
+++ b/runbot/static/src/js/stats.js
@@ -35,7 +35,6 @@ var config = {
 };
 
 var shifted = false;
-$(document).on('keyup keydown', function(e){shifted = e.shiftKey} );
 
 config.options.onClick = function(event, activeElements) {
     if (activeElements.length === 0){
@@ -285,6 +284,8 @@ window.onload = function() {
     for([key, value] of new URLSearchParams(window.location.hash.replace("#","?"))){
       config.searchParams[key] = value;
     }
+
+    $(document).on('keyup keydown', function(e){shifted = e.shiftKey} );
 
     document.getElementById('backward_button').onclick = function(){
       config.searchParams['center_build_id'] = Object.keys(config.result)[0];


### PR DESCRIPTION
Since the commit [^1] deferring the loading of the runbot frontend JS bundle, the stats page broke due to a jQuery call being made before the actual load of the page.

This commit properly moves it in the "onload" listener.

[^1]: odoo/runbot@99407180def7cc013ad17faf96a917cb1c5e9dab