### PR TITLE
[IMP] runbot: make parent_id a params

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -101,6 +101,7 @@ class BuildParameters(models.Model):
 
     build_ids = fields.One2many('runbot.build', 'params_id')
     builds_reference_ids = fields.Many2many('runbot.build', relation='runbot_build_params_references', copy=True)
+    reference_build_id = fields.Many2one('runbot.build', 'Reference Build', index=True)
     modules = fields.Char('Modules')
 
     upgrade_to_build_id = fields.Many2one('runbot.build', index=True)  # use to define sources to use with upgrade script
@@ -146,6 +147,8 @@ class BuildParameters(models.Model):
                 'dockerfile_id': param.dockerfile_id.id,
                 'skip_requirements': param.skip_requirements,
             }
+            if param.reference_build_id:
+                cleaned_vals['reference_build_id'] = param.reference_build_id.id
             if param.upgrade_to_build_id:
                 cleaned_vals['upgrade_to_build_dockerfile_id'] = param.upgrade_to_build_id.params_id.dockerfile_id.id
                 cleaned_vals['upgrade_to_build_commits'] = get_commit_links_ident(param.upgrade_to_build_id.params_id.commit_link_ids)
@@ -532,7 +535,7 @@ class BuildResult(models.Model):
 
         return res
 
-    def _add_child(self, param_values, orphan=False, description=False, additionnal_commit_links=False):
+    def _add_child(self, param_values, orphan=False, description=False, additionnal_commit_links=False, reference_parent=...):
         build_values = {key: value for key, value in param_values.items() if key not in self.params_id._fields}
         param_values = {key: value for key, value in param_values.items() if key in self.params_id._fields}
 
@@ -544,6 +547,15 @@ class BuildResult(models.Model):
             commit_link_ids = self.params_id.commit_link_ids
             commit_link_ids |= additionnal_commit_links
             param_values['commit_link_ids'] = commit_link_ids
+
+        config = param_values.get('config_id') or self.params_id.config_id
+        if isinstance(config, int):
+            config = self.env['runbot.build.config'].browse(config)
+
+        if reference_parent == ...:
+            reference_parent = config._default_uses_parent(param_values)
+        if reference_parent:
+            param_values['reference_build_id'] = self.id
 
         return self.create({
             'params_id': self.params_id.copy(param_values).id,
@@ -1418,8 +1430,9 @@ class BuildResult(models.Model):
 
         faketime = []
         if faketime_params := self.params_id.config_data.get('faketime'):
-            if self.parent_id:
-                parent_time_offset = (self.parent_id.build_end or self.create_date) - self.parent_id.build_start
+            reference_build = self.params_id.reference_build_id or self.parent_id  # TODO cleanup parent_id
+            if reference_build:
+                parent_time_offset = (reference_build.build_end or self.create_date) - reference_build.build_start
                 faketime_params = (parser.parse(faketime_params) + parent_time_offset).strftime('%Y-%m-%d %H:%M %Z')
             faketime = ['faketime', faketime_params]
 

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -307,6 +307,7 @@ class Config(models.Model):
             'max_builds': OPTIONAL(INT),
             'if': OPTIONAL(DYNAMIC_VALUE),
             'log': OPTIONAL(DYNAMIC_VALUE),
+            'reference_parent': OPTIONAL(BOOL),
         }
         valid_steps['restore'] = {
             'name': REQUIRED(NAME),
@@ -382,6 +383,20 @@ class Config(models.Model):
             if step.job_type == 'create_build':
                 for create_config in step.create_config_ids:
                     create_config._check_recursion(visited[:])
+
+    def _default_uses_parent(self, param_values, has_restore=False):
+        if param_values.get('reference_build_id'):
+            return False
+        if param_values.get('dump_db'):
+            return False
+        config_data = param_values.get('config_data', {}) or {}
+        if config_data.get('dump_url'):
+            return False
+        if config_data.get('restore_build_id'):
+            return False
+        if config_data.get('dump_trigger_id'):
+            return False
+        return has_restore or any(step.job_type == 'restore' for step in self.step_ids)
 
 
 class ConfigStepUpgradeDb(models.Model):
@@ -612,7 +627,7 @@ class ConfigStep(models.Model):
             return build._docker_run(self, **docker_params)
         return True
 
-    def _run_create_build(self, build, config_data=None, max_build=200):
+    def _run_create_build(self, build, config_data=None, max_build=200, reference_parent=...):
         if config_data:
             config_data = {**config_data, **build.params_id.config_data}
         else:
@@ -636,7 +651,7 @@ class ConfigStep(models.Model):
                         build._log('create_build', f'More than {max_build} build created, stopping', level='WARNING')
                         return
                     config_name = config_name or create_config.name
-                    child = build._add_child(child_data_values, orphan=self.make_orphan, description=description or config_name)
+                    child = build._add_child(child_data_values, orphan=self.make_orphan, description=description or config_name, reference_parent=reference_parent)
                     build._log('create_build', 'created with config %s' % config_name, log_type='subbuild', path=str(child.id))
 
     def _make_python_ctx(self, build):
@@ -1158,8 +1173,11 @@ class ConfigStep(models.Model):
                 dump_build = dump_db.build_id
             else:
                 download_db_suffix = config_data.get('dump_suffix', self.restore_download_db_suffix or 'all')
-                dump_build = build.parent_id
-            assert download_db_suffix and dump_build
+                dump_build = params.reference_build_id or build.parent_id  # TODO cleanup parent_id
+            if not (download_db_suffix and dump_build):
+                build._log('_run_restore', 'No dump suffix or reference build specified', level='ERROR')
+                build._kill(result='ko')
+                return
             download_db_name = f'{dump_build.dest}-{download_db_suffix}'
             zip_name = f'{download_db_name}.zip'
             dump_url = f'{dump_build._http_log_url()}{zip_name}'
@@ -1647,11 +1665,15 @@ class ConfigStep(models.Model):
                         'config_name': config_name,
                         'description': description,
                     }
+                    if current_step.get('reference_parent') or (current_step.get('reference_parent') is None):
+                        if build.params_id.config_id._default_uses_parent(child_data, has_restore=any(step.get('job_type') == 'restore' for step in child.get('steps', []))):
+                            child_data['reference_build_id'] = build.id
                     child_data_list.append(child_data)
             return self._run_create_build(
                 build,
                 {'child_data': child_data_list, 'number_build': current_step.get('number_builds', 1)},
                 max_build=min(current_step.get('max_builds', 50), 200),
+                reference_parent=current_step.get('reference_parent', ...),
             )
 
         if current_step['job_type'] == 'restore':

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -151,8 +151,15 @@
                     <t t-out="build.params_id.extra_params"/>
                     <br/>
                 </t>
+                <t t-if="build.params_id.reference_build_id">
+                    <b>Main build reference (parent):</b>
+                    <a t-attf-href="/runbot/build/{{build.params_id.reference_build_id.id}}">
+                        <t t-out="build.params_id.reference_build_id.id"/>
+                    </a>
+                    <br/>
+                </t>
                 <t t-if="build.params_id.builds_reference_ids">
-                  <b>Reference builds:</b>
+                  <b>Other builds reference:</b>
                   <div t-foreach="build.params_id.builds_reference_ids" t-as="reference">
                     <a t-attf-href="/runbot/build/{{reference.id}}"><t t-esc="reference.id"/></a> - <em t-out="reference.params_id.version_id.name"/>
                   </div>

--- a/runbot/views/build_views.xml
+++ b/runbot/views/build_views.xml
@@ -13,6 +13,7 @@
                             <field name="extra_params"/>
                             <field name="dockerfile_id"/>
                             <field name="dump_db"/>
+                            <field name="reference_build_id"/>
                             <field name="config_data" widget="runbotjsonb" readonly="0"/>
                             <field name="dynamic_config" widget="runbotjsonb" readonly="0"/>
                         </group>


### PR DESCRIPTION
Some build will use the parent to restore a database, this commits makes taht more explicit by storing the parent as a param when needed.