### PR TITLE
[IMP] runbot: recompute error randomness on content update

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -396,7 +396,7 @@ class BuildError(models.Model):
         for record in self:
             record.error_count = len(record.error_content_ids)
 
-    @api.depends('error_content_ids')
+    @api.depends('error_content_ids.random')
     def _compute_random(self):
         for record in self:
             record.random = any(error.random for error in record.error_content_ids)

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -24,7 +24,7 @@
                       <field name="version_ids" widget="many2many_tags" optional="hide"/>
                       <field name="trigger_ids" widget="many2many_tags" optional="hide"/>
                       <field name="tag_ids" widget="many2many_tags" readonly="1" optional="hide"/>
-                      <field name="random" optional="hide"/>
+                      <field name="random" readonly="False" optional="hide"/>
                       <field name="first_seen_date" widget="frontend_url" options="{'link_field': 'first_seen_build_id', 'numeric': True}"/>
                       <field name="last_seen_date" widget="frontend_url" options="{'link_field': 'last_seen_build_id', 'numeric': True}"/>
                       <field name="first_seen_build_id" column_invisible="True"/>


### PR DESCRIPTION
Before this commit, build error's random field is recomputed on error_content_ids change. But flagging an existing error content as random doesn't change it (which could be useful when manually flagging one as such). This commit adapts the dependency accordingly.