### PR TITLE
[IMP] runbot: add a wizard to set pr on errors

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -229,6 +229,7 @@ class BuildError(models.Model):
     team_id = fields.Many2one('runbot.team', 'Assigned team', compute='_compute_team_id', inverse='_inverse_team_id', store=True, tracking=True)
     manual_team_id = fields.Many2one('runbot.team', 'Manually assigned team')
     auto_team_id = fields.Many2one('runbot.team', 'Automatically assigned team', readonly=True) # This is a computed field but not really
+    can_set_pr = fields.Boolean(compute='_compute_can_set_pr')
     fixing_commit = fields.Char('Fixing commit', tracking=True)
     fixing_pr_id = fields.Many2one('runbot.branch', 'Fixing PR', tracking=True, domain=[('is_pr', '=', True)])
     fixing_pr_alive = fields.Boolean('Fixing PR alive', related='fixing_pr_id.alive')
@@ -390,6 +391,10 @@ class BuildError(models.Model):
 
     def _search_content(self, operator, value):
         return [('error_content_ids', 'any', [('content', operator, value)])]
+
+    def _compute_can_set_pr(self):
+        for record in self:
+            record.can_set_pr = self.env.user == record.responsible
 
     @api.depends('error_content_ids')
     def _compute_count(self):
@@ -1317,3 +1322,18 @@ class QualifyErrorTest(models.Model):
     def _compute_content(self):
         for record in self:
             record.build_error_content = '\n'.join([record.error_content_id[sf] or '' for sf in record.qualify_regex_id.check_fields.split(',')])
+
+
+class BuildErrorSetPR(models.TransientModel):
+    _name = 'runbot.error.setpr'
+    _description = "Errors Set PR Wizard"
+
+    fixing_pr_id = fields.Many2one('runbot.branch', 'Fixing PR', domain=[('is_pr', '=', True)])
+
+    def action_submit(self):
+        if not self.env.user.has_group('runbot.runbot_error_manager'):
+            errors = self.env['runbot.build.error'].sudo().browse(self.env.context.get('active_ids')).filtered(lambda rec: rec.responsible == self.env.user)
+        else:
+            errors = self.env['runbot.build.error'].browse(self.env.context.get('active_ids'))
+        for error in errors:
+            error.fixing_pr_id = self.fixing_pr_id

--- a/runbot/security/ir.model.access.csv
+++ b/runbot/security/ir.model.access.csv
@@ -178,3 +178,5 @@ access_runbot_build_error_merge_filters_user,access_runbot_build_error_merge_fil
 
 access_runbot_bundle_tag_admin,access_runbot_bundle_tag_admin,runbot.model_runbot_bundle_tag,runbot.group_runbot_admin,1,1,1,1
 access_runbot_bundle_tag_user,access_runbot_bundle_tag_user,runbot.model_runbot_bundle_tag,group_user,1,0,0,0
+
+access_runbot_error_error_setpr_user,access_runbot_error_error_setpr_user,runbot.model_runbot_error_setpr,runbot.group_user,1,1,1,1

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -1,5 +1,31 @@
 <odoo>
   <data>
+    <record model="ir.ui.view" id="runbot_error_setpr_form">
+        <field name="name">runbot_error_setpr</field>
+        <field name="model">runbot.error.setpr</field>
+        <field name="arch" type="xml">
+          <form>
+            <sheet>
+              <group name="Fix">
+                <field name="fixing_pr_id" options="{'no_create': True}"/>
+              </group>
+              <footer>
+                <button string="Submit" name="action_submit" type="object" class="btn-primary"/>
+                <button string="Cancel" class="btn-secondary" special="cancel"/>
+              </footer>
+            </sheet>
+          </form>
+        </field>
+    </record>
+    <record id="runbot_open_error_setpr_form" model="ir.actions.act_window">
+        <field name="name">Set PR on error</field>
+        <field name="res_model">runbot.error.setpr</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="view_id" ref="runbot_error_setpr_form"/>
+        <field name="binding_model_id" ref="runbot.model_runbot_build_error"/>
+        <field name="binding_view_types">list</field>
+    </record>
     <record id="runbot_build_error_form" model="ir.ui.view">
       <field name="name">runbot.build.error.form</field>
       <field name="model">runbot.build.error</field>
@@ -10,11 +36,13 @@
                 <button class="oe_stat_button" type="object" icon="fa-exclamation-circle" name="action_get_build_link_record">
                   <field string="Builds Link" name="build_count" widget="statinfo"/>
                 </button>
+                <button name="%(runbot.runbot_open_error_setpr_form)d" string="Set Fixing PR" type="action" class="btn-success" invisible="not can_set_pr"/>
               </div>
               <widget name="web_ribbon" title="Test-tags" bg_color="bg-danger" invisible="not test_tags"/>
-              <button name="action_view_errors" string="See all linked errors" type="object" class="oe_highlight"/>
+                <button name="action_view_errors" string="See all linked errors" type="object" class="oe_highlight"/>
               <group string="Base info">
                 <field name="name"/>
+                <field name="can_set_pr" invisible="1"/>
                 <field name="error_content_ids" readonly="1">
                     <list limit="5">
                       <field name="content" readonly="1"/>


### PR DESCRIPTION
A simple runbot user is not allowed to set PR on runbot build errors to avoid mess in build errors. So, most of the time when a user wants to set a fixing PR on a build error, he needs to send us a message.

With this commit, an error responsible can set a PR by using a wizard on his own errors.