### PR TITLE
[FIX] runbot: properly sort version on build error

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -262,7 +262,7 @@ class BuildError(models.Model):
     unique_build_error_link_ids = fields.Many2many('runbot.build.error.link', compute='_compute_unique_build_error_link_ids')
     build_ids = fields.Many2many('runbot.build', compute=_compute_related_error_content_ids('build_ids'), search=_search_related_error_content_ids('build_ids'))
     bundle_ids = fields.Many2many('runbot.bundle', compute=_compute_related_error_content_ids('bundle_ids'), search=_search_related_error_content_ids('bundle_ids'))
-    version_ids = fields.Many2many('runbot.version', string='Versions', compute=_compute_related_error_content_ids('version_ids'), search=_search_related_error_content_ids('version_ids'))
+    version_ids = fields.Many2many('runbot.version', string='Versions', compute='_compute_version_ids', search=_search_related_error_content_ids('version_ids'))
     trigger_ids = fields.Many2many('runbot.trigger', string='Triggers', compute=_compute_related_error_content_ids('trigger_ids'), store=True)
     tag_ids = fields.Many2many('runbot.build.error.tag', string='Tags', compute=_compute_related_error_content_ids('tag_ids'), search=_search_related_error_content_ids('tag_ids'))
     random = fields.Boolean('Random', compute="_compute_random", store=True)
@@ -321,6 +321,11 @@ class BuildError(models.Model):
     def _compute_fixing_bundle_id(self):
         for record in self:
             record.fixing_bundle_id = record.fixing_pr_id.bundle_id if record.fixing_pr_id else False
+
+    @api.depends('error_content_ids.version_ids')
+    def _compute_version_ids(self):
+        for record in self:
+            record['version_ids'] = record.error_content_ids['version_ids'].sorted('number')
 
     def _compute_disappearing_batch_ids(self):
         # this is really inefficient but should only be used in form view


### PR DESCRIPTION
Obviously #1312 was not enough, it was only applied on BuildErrorContent. So it was working when all build error contents had the same version ids or if they appeared in the right order.

With this commit, the sorting is applied on the build error computed versions.