### PR TITLE
[FIX] runbot: fix drop database timeout

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1114,7 +1114,7 @@ class BuildResult(models.Model):
             with local_pgadmin_cursor() as local_cr:
                 query = 'SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname=%s'
                 local_cr.execute(query, [dbname])
-                local_cr.execute('SET LOCAL statement_timeout=10000')  # avoid to be stuck if the dropdb is locked
+                local_cr.execute('SET statement_timeout=10000')  # avoid to be stuck if the dropdb is locked
                 local_cr.execute('DROP DATABASE IF EXISTS "%s"' % dbname)
         except Exception as e:
             msg = f"Failed to drop local logs database : {dbname} with exception: {e}"

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -395,7 +395,7 @@ class ConfigStep(models.Model):
     enable_auto_tags = fields.Boolean('Allow auto tag', default=True, tracking=True)
     sub_command = fields.Char('Subcommand', tracking=True)
     extra_params = fields.Char('Extra cmd args', tracking=True)
-    additionnal_env = fields.Char('Extra env', help='Example: foo="bar";bar="foo". Cannot contains \' ', tracking=True)
+    additionnal_env = fields.Char('Extra env', help='Example: foo=bar;bar=foo. Cannot contains \' ', tracking=True)
     enable_log_db = fields.Boolean("Enable log db", default=True)
     demo_mode = fields.Selection(
         [('default', 'Default'), ('without_demo', 'Without Demo'), ('with_demo', 'With Demo')],


### PR DESCRIPTION
- fixes the drop database timeout: since the connection is autocommit the LOCAL statement had no effect on the dropdatabase. Since the connection is not used for anything else and not added to a pool, we can just set the statement timeout for the whole connection.

- removes confusing quotes in the help of the additionnal_env field