### PR TITLE
[IMP] runbot: allow to define if a trigger needs the version or not

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -364,7 +364,7 @@ class Batch(models.Model):
         base_commit_link_by_repos = {commit_link.commit_id.repo_id.id: commit_link for commit_link in self.base_reference_batch_id.commit_link_ids}
         if use_base_commits:
             commit_link_by_repos = base_commit_link_by_repos
-        version_id = self.bundle_id.version_id.id
+        bundle_version_id = self.bundle_id.version_id.id
         project_id = self.bundle_id.project_id.id
         trigger_customs = {}
         for trigger_custom in self.bundle_id.all_trigger_custom_ids:
@@ -384,6 +384,7 @@ class Batch(models.Model):
                 self._warning(f'This batch will use base commits instead of bundle commits for trigger {trigger.name}')
                 trigger_commit_link_by_repos = base_commit_link_by_repos
             commits_links = [trigger_commit_link_by_repos[repo.id].id for repo in trigger_repos]
+            version_id = bundle_version_id if trigger.version_dependent else False
             params_value = {
                 'version_id':  version_id,
                 'extra_params': extra_params,

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -75,6 +75,7 @@ class Trigger(models.Model):
     config_data = JsonDictField('Config Data')
     network_enabled = fields.Boolean('Network Enabled')
     batch_dependent = fields.Boolean('Batch Dependent', help="Force adding batch in build parameters to make it unique and give access to bundle")
+    version_dependent = fields.Boolean('Version Dependent', default=True, help="Add the version in build parameters. Uncheck if the version is not needed to determine the build result")
 
     ci_context = fields.Char("CI context", tracking=True)
     category_id = fields.Many2one('runbot.category', default=lambda self: self.env.ref('runbot.default_category', raise_if_not_found=False))

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -25,6 +25,7 @@
                 <group>
                   <field name="description"/>
                   <field name="batch_dependent"/>
+                  <field name="version_dependent"/>
                   <field name="upgrade_dumps_trigger_id"/>
                   <field name="version_domain" widget="domain" options="{'model': 'runbot.version', 'in_dialog': True}"/>
                   <field name="on_base"/>


### PR DESCRIPTION
Most standard build (testing, installing, ...) don't really need the version to runbot

The version is mostly needed for upgrades builds and lint builds using conditionnal logic based on version.

As an example, the template build used for the freeze is first created in master, and after the freeze with (almost) the same commit becames the freezed version. With this change, the template build can be linked immediatly (if the docker file is the same)