### PR TITLE
[FIX] runbot: wrong method name

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -254,7 +254,7 @@ class Branch(models.Model):
         return self._recompute_infos()
 
     def action_update_bundle_id(self):
-        return self._update_bundle_ids()
+        return self._update_bundle_id()
 
 
 class RefLog(models.Model):


### PR DESCRIPTION
* _update_bundle_ids no method name _update_bundle_ids.