### PR TITLE
[FIX] runbot_merge: ensure compatibility with Python 3.10

### DIFF
--- a/runbot_merge/models/crons/validate.py
+++ b/runbot_merge/models/crons/validate.py
@@ -1,7 +1,10 @@
 import contextlib
 import json
 import logging
-from typing import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from odoo import fields, models, api
 

--- a/runbot_merge/models/ir_cron/__init__.py
+++ b/runbot_merge/models/ir_cron/__init__.py
@@ -2,7 +2,11 @@ import contextvars
 import datetime
 import math
 import time
-from typing import Self, Literal
+from typing import Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from odoo import models
 

--- a/runbot_merge/models/pull_requests.py
+++ b/runbot_merge/models/pull_requests.py
@@ -1949,10 +1949,11 @@ For your own safety I've ignored *everything in your entire comment*.
         (h, out, err, hh) = conflicts.get(previous_pr) or (None, None, None, None)
         if h:
             sout = serr = ''
+            newline_ellipsis = '\n[...]'
             if out.strip():
-                sout = f"\nstdout:\n```\n{utils.shorten(out, 8096, '\n[...]')}\n```\n"
+                sout = f"\nstdout:\n```\n{utils.shorten(out, 8096, newline_ellipsis)}\n```\n"
             if err.strip():
-                serr = f"\nstderr:\n```\n{utils.shorten(err, 8069, '\n[...]')}\n```\n"
+                serr = f"\nstderr:\n```\n{utils.shorten(err, 8069, newline_ellipsis)}\n```\n"
 
             lines = ''
             if len(hh) > 1:


### PR DESCRIPTION
The use of backslashes inside f-string expressions was introduced in Python 3.12. In older versions (like Python 3.10), this triggers a SyntaxError: "f-string expression part cannot include a backslash".

First commit fixes the issue by moving the string with the newline character to a separate variable before using it in the f-string, ensuring compatibility with older Python environments.

The 'Self' type hint was introduced in the 'typing' module in Python 3.11. To maintain compatibility with Python 3.10, this commit adds a fallback to 'typing_extensions'.

Second commit prevents an ImportError when loading the 'ir.cron' and 'runbot_merge.batch.validate' model in
environments running Python 3.10.