### PR TITLE
[IMP] light config on triggers

### DIFF
--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -164,7 +164,7 @@ class Runbot(Controller):
         '/runbot/bundle/<model("runbot.bundle"):bundle>/page/<int:page>',
         '/runbot/bundle/<string:bundle>',
         ], website=True, auth='public', type='http', sitemap=False)
-    def bundle(self, bundle=None, page=1, limit=50, **kwargs):
+    def bundle(self, bundle=None, page=1, limit=50, expand_custom=False, **kwargs):
         if isinstance(bundle, str):
             bundle = request.env['runbot.bundle'].search([('name', '=', bundle)], limit=1, order='id')
             if not bundle:
@@ -188,6 +188,7 @@ class Runbot(Controller):
             'project': bundle.project_id,
             'title': 'Bundle %s' % bundle.name,
             'page_info_state': bundle.last_batch._get_global_result(),
+            'expand_custom': expand_custom,
         }
 
         return request.render('runbot.bundle', context)
@@ -667,18 +668,39 @@ class Runbot(Controller):
         request.env['runbot.build.error']._parse_logs(ir_log)
         return werkzeug.utils.redirect('/runbot/build/%s' % ir_log.build_id.id)
 
-    @route(['/runbot/bundle/toggle_no_build/<int:bundle_id>/<int:value>'], type='http', auth='user', sitemap=False)
-    def toggle_no_build(self, bundle_id, value, **kwargs):
-        if not request.env.user.has_group('base.group_user'):
-            return 'Forbidden'
-        bundle = request.env['runbot.bundle'].browse(bundle_id).exists()
-        if bundle.sticky or bundle.is_base:
-            return 'Forbidden'
-        if bundle.project_id.tmp_prefix and bundle.name.startswith(bundle.project_id.tmp_prefix):
-            return 'Forbidden'
-        bundle.sudo().no_build = bool(value)
-        _logger.info('Bundle %s no_build set to %s by %s', bundle.name, bool(value), request.env.user.name)
-        return werkzeug.utils.redirect(f'/runbot/bundle/{bundle_id}')
+    @route(['/runbot/bundle/<int:bundle_id>/triggers/<string:action>'], type='http', auth='user', sitemap=False)
+    def configure_bundle_triggers(self, bundle_id, action, expand_custom=False, **kwargs):
+        if not request.env.user.has_group('runbot.group_user'):
+            raise NotFound()
+
+        bundle = request.env['runbot.bundle'].browse(bundle_id)
+        if bundle.is_base or bundle.is_staging:
+            raise NotFound()
+        if action == 'disable_all':
+            bundle.sudo().configure_custom_trigger_start_mode('disabled')
+        elif action == 'force_all':
+            bundle.sudo().configure_custom_trigger_start_mode('force')
+        elif action == 'auto_all':
+            bundle.sudo().configure_custom_trigger_start_mode('auto')
+        elif action == 'light_all':
+            bundle.sudo().configure_custom_trigger_start_mode('light')
+        else:
+            raise NotFound()
+        expand_kwrags = '?expand_custom=1' if expand_custom else ''
+
+        return werkzeug.utils.redirect(f'/runbot/bundle/{bundle_id}{expand_kwrags}')
+
+    @route(['/runbot/trigger_custom/<int:trigger_custom_id>/set_mode/<string:mode>'], type='http', auth='user', sitemap=False)
+    def configure_custom_trigger(self, trigger_custom_id, mode, **kwargs):
+        if not request.env.user.has_group('runbot.group_user'):
+            raise NotFound()
+        trigger_custom = request.env['runbot.bundle.trigger.custom'].browse(trigger_custom_id)
+        bundle = trigger_custom.bundle_id
+        if bundle.is_base or bundle.is_staging:
+            raise NotFound()
+
+        trigger_custom.sudo().start_mode = mode
+        return werkzeug.utils.redirect(f'/runbot/bundle/{trigger_custom.bundle_id.id}?expand_custom=1')
 
     @route(['/runbot/trigger/report/<model("runbot.trigger"):trigger_id>'], type='http', auth='user', website=True, sitemap=False)
     def report_view(self, trigger_id=None, **kwargs):

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -382,7 +382,11 @@ class Batch(models.Model):
                 self._warning('Missing commit for repo %s for trigger %s', (trigger_repos & missing_repos).mapped('name'), trigger.name)
                 continue
             # in any case, search for an existing build
-            config = trigger_custom.config_id or trigger.config_id
+            config = trigger.config_id
+            if trigger_custom.config_id:
+                config = trigger_custom.config_id
+            elif trigger_custom.start_mode == 'light' and trigger.light_config_id:
+                config = trigger.light_config_id
             extra_params = trigger_custom.extra_params or ''
             config_data = dict(trigger.config_data or {}) | dict(trigger_custom.config_data or {})
             trigger_commit_link_by_repos = commit_link_by_repos
@@ -402,7 +406,7 @@ class Batch(models.Model):
                 'modules': bundle.modules,
                 'dockerfile_id': dockerfile_id,
                 'create_batch_id': self.id,
-                'used_custom_trigger': bool(trigger_custom),
+                'used_custom_trigger': bool(trigger_custom.config_id or trigger_custom.extra_params or trigger_custom.config_data or trigger_custom.use_base_commits),
             }
 
             params = self.env['runbot.build.params'].create(params_value)

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1470,14 +1470,18 @@ class BuildResult(models.Model):
                     build.parent_id._github_status()
             else:
                 trigger = build.params_id.trigger_id
-                if not trigger.ci_context:
+                ci_context = trigger.ci_context
+                if not ci_context:
                     continue
 
                 desc = trigger.ci_description or " (runtime %ss)" % (build.job_time,)
                 if build.params_id.used_custom_trigger:
-                    state = 'error'
+                    ci_context += " (custom)"
                     desc = "This build used custom config. Remove custom trigger to restore default ci"
-                elif build.global_result in ('ko', 'warn'):
+                if build.params_id.config_id == build.trigger_id.light_config_id:
+                    ci_context += " (light)"
+                    desc = "This build used a light config. Enable default build configuration to restore default ci"
+                if build.global_result in ('ko', 'warn'):
                     state = 'error'
                 elif build.global_state in ('pending', 'testing'):
                     state = 'pending'
@@ -1530,7 +1534,7 @@ class BuildResult(models.Model):
                     else:
                         target_url = f"{self.get_base_url()}/runbot/build/{build.id}"
 
-                    commit._github_status(build, trigger.ci_context, state, target_url, desc, ci_strategy=trigger.ci_strategy)
+                    commit._github_status(build, ci_context, state, target_url, desc, ci_strategy=trigger.ci_strategy)
 
     def _parse_config(self):
         return set(findall(self._server("tools/config.py"), r'--[\w-]+', ))

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -322,7 +322,10 @@ class Bundle(models.Model):
         return self._generate_custom_trigger_action(context)
 
     def action_disable_all_triggers(self):
-        triggers_to_disable = (
+        self.configure_custom_trigger_start_mode('disable')
+
+    def configure_custom_trigger_start_mode(self, mode):
+        triggers_to_create = (
             self.env["runbot.trigger"]
             .search([
                 ("id", "not in", self.trigger_custom_ids.trigger_id.ids),
@@ -335,13 +338,17 @@ class Bundle(models.Model):
             )
         )
         vals = []
-        for trigger in triggers_to_disable:
+        for trigger in triggers_to_create:
             vals.append({
                 'bundle_id': self.id,
                 'trigger_id': trigger.id,
-                'start_mode': 'disabled',
             })
         self.env['runbot.bundle.trigger.custom'].create(vals)
+        for custom_trigger in self.trigger_custom_ids:
+            trigger_mode = mode
+            if mode == 'light' and not custom_trigger.trigger_id.light_config_id:
+                trigger_mode = 'auto'
+            custom_trigger.start_mode = trigger_mode
 
 
 class BundleTag(models.Model):

--- a/runbot/models/custom_trigger.py
+++ b/runbot/models/custom_trigger.py
@@ -8,7 +8,7 @@ class BundleTriggerCustomization(models.Model):
     _description = 'Custom trigger'
 
     trigger_id = fields.Many2one('runbot.trigger')
-    start_mode = fields.Selection([('disabled', 'Disabled'), ('auto', 'Auto'), ('force', 'Force')], required=True, default='auto')
+    start_mode = fields.Selection([('disabled', 'Disabled'), ('auto', 'Auto'), ('light', 'Light'), ('force', 'Force')], required=True, default='auto')
     use_base_commits = fields.Boolean("Use base commits",  help="Allow to test a trigger without the branch changes", default=False)
     bundle_id = fields.Many2one('runbot.bundle')
     config_id = fields.Many2one('runbot.build.config')

--- a/runbot/models/ir_qweb.py
+++ b/runbot/models/ir_qweb.py
@@ -1,5 +1,5 @@
-from ..common import s2human, s2human_long, precise_s2human
-from odoo import models
+from ..common import s2human, s2human_long, precise_s2human, transactioncache
+from odoo import models, tools
 from odoo.http import request
 from odoo.addons.website.controllers.main import QueryURL
 
@@ -12,3 +12,10 @@ class IrQweb(models.AbstractModel):
         values['s2human_long'] = s2human_long
         values['precise_s2human'] = precise_s2human
         return response
+
+    @tools.conditional(
+        'xml' in tools.config['dev_mode'],
+        transactioncache,
+    )  # replace ormcache by transaction cache to avoid reading the same template multiple times in the same requests. Context is ignored but should be the same for each call in the same request
+    def _generate_code_cached(self, ref: int):
+        return super()._generate_code_cached(ref)

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -73,6 +73,7 @@ class Trigger(models.Model):
     )
     module_filters = fields.One2many('runbot.module.filter', 'trigger_id', string="Module filters", help='Will be combined with repo module filters when used with this trigger')
     config_id = fields.Many2one('runbot.build.config', string="Config", required=True)
+    light_config_id = fields.Many2one('runbot.build.config', string="Light config", help="Alternative config to use when light mode is enabled")
     config_data = JsonDictField('Config Data')
     network_enabled = fields.Boolean('Network Enabled')
     batch_dependent = fields.Boolean('Batch Dependent', help="Force adding batch in build parameters to make it unique and give access to bundle")

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -6,108 +6,132 @@
                 <div class="container-fluid">
                     <div class="row">
                         <div class='col-md-12'>
-                            <div class="navbar navbar-default">
-                                <span class="text-center" style="font-size: 18px;">
-                                    <t t-out="bundle.name"/>
-                                    <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
-                                    <div class="btn-group" role="group">
-                                        <a groups="runbot.group_runbot_advanced_user"
-                                            t-attf-href="/odoo/bundle/{{bundle.id}}" class="btn btn-default" title="View in Backend">
-                                          <i class="fa fa-list"/>
-                                        </a>
-                                        <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Force A New Batch">
-                                            <i class="fa fa-play"/>
-                                        </a>
-                                        <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" title="Force A New Batch with automatic rebase">
-                                            <i class="fa fa-fast-forward"/>
-                                        </a>
-                                        <a groups="runbot.group_runbot_advanced_user" class="btn btn-default" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force A New Batch using base commits">
-                                            <i class="fa fa-fast-backward"/>
-                                        </a>
+                            <h5><t t-out="bundle.name"/> <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
+                                <div class="btn-group btn-group-sm" role="group">
                                         <t t-call="runbot.branch_copy_button">
                                             <t t-set="btn_size" t-value="'btn'"/>
                                         </t>
-                                         <a groups="base.group_user" class="btn btn-default" t-attf-href="/runbot/stats/{{bundle.id}}">
-                                            <i class="fa fa-bar-chart"/>
+                                        <a groups="runbot.group_runbot_advanced_user"
+                                            t-attf-href="/odoo/bundle/{{bundle.id}}" class="btn btn-default" title="View in Backend">
+                                        <i class="fa fa-list"/> Form view
                                         </a>
-                                    </div>
-                                </span>
-                                <span class="pull-right">
-                                    <t t-call="website.pager" />
-                                </span>
-                            </div>
-                            <div>
-                                <table class="table table-condensed table-responsive table-stripped">
-                                    <tr groups="base.group_user" t-if="not bundle.sticky and not bundle.is_base">
-                                        <t t-if="bundle.no_build">
-                                            <td class="text-danger">Build disabled</td>
-                                            <td>
-                                                <a class="btn btn-primary btn-ssm"
-                                                   t-attf-href="/runbot/bundle/toggle_no_build/{{bundle.id}}/0">
-                                                Enable builds
-                                                </a>
-                                            </td>
-                                        </t>
-                                        <t t-else="">
-                                            <td>Build enabled</td>
-                                            <td>
-                                                <a class="btn btn-secondary btn-ssm"
-                                                   t-attf-href="/runbot/bundle/toggle_no_build/{{bundle.id}}/1">
-                                                Disable builds
-                                                </a>
-                                            </td>
-                                        </t>
-                                    </tr>
-                                    <tr>
-                                        <td>Version</td>
-                                        <td>
-                                            <t t-out="bundle.version_id.name"/>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>Branches</td>
-                                        <td>
-                                            <t t-foreach="bundle._branch_groups().items()" t-as="group">
-                                                <t t-foreach="group[1]" t-as="branch">
-                                                    <small>
-                                                        <div class="btn-toolbar mb-1" role="toolbar">
-                                                            <div class="btn-group btn-group-ssm" role="group">
-                                                                <a t-att-href="branch.branch_url" class="btn btn-default text-start" title="View Branch on Github"><i class="fa fa-github"/></a>
-                                                                <a groups="runbot.group_runbot_admin" class="btn btn-default fa fa-list text-start"
-                                                                    t-attf-href="/odoo/branch/{{branch.id}}" target="_blank" title="View Branch in Backend"/>
-                                                                <a href="#" t-out="branch.remote_id.short_name" class="btn btn-default disabled text-start"/>
-                                                                <a t-attf-href="/runbot/branch/{{branch.id}}" class="btn btn-default text-start" title="View Branch Details"><span t-att-class="'' if branch.alive else 'line-through'" t-out="branch.name"/> <i t-if="not branch.alive" title="deleted/closed" class="fa fa-ban text-danger"/></a>
-                                                                <t t-if="not any (b.is_pr and b.alive for b in group[1]) and not branch.is_pr">
-                                                                    <a t-attf-href="https://{{group[0].main_remote_id.base_url}}/compare/{{bundle.version_id.name}}...{{branch.remote_id.owner}}:{{branch.name}}?expand=1" class="btn btn-default text-start" title="Create pr"><i class="fa fa-code-fork"/> Create pr</a>
-                                                                </t>
-                                                            </div>
+                                        <a groups="base.group_user" class="btn btn-default" t-attf-href="/runbot/stats/{{bundle.id}}" title="View stats">
+                                            <i class="fa fa-bar-chart"/> Stats
+                                        </a>
+                                        <button type="button" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                                            <i class="fa fa-play"/> Actions <i class="fa fa-caret-down ms-1"/>
+                                        </button>
+                                        <ul class="dropdown-menu">
+                                            <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force a new batch using base commits mainly for random errors debugging">
+                                                <i class="fa fa-fast-backward"/> Start a batch without the branch commits
+                                            </a>
+                                            <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Create a new Batch, applies new trigger configurations and updates build references for upgrades if needed">
+                                                <i class="fa fa-play"/> Start a new batch
+                                            </a>
+                                            <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" class="btn btn-default dropdown-item"  title="Force A New Batch with automatic rebase, useful to test outdated branches without pushing before a merge">
+                                                <i class="fa fa-fast-forward"/> Start a batch with simulated autorebase
+                                            </a>
+                                        </ul>
+                                </div></h5>
+                            
+                            <table class="table table-condensed table-responsive table-stripped">
+                                <tr>
+                                    <td>Version</td>
+                                    <td>
+                                        <t t-out="bundle.version_id.name"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Branches</td>
+                                    <td>
+                                        <t t-foreach="bundle._branch_groups().items()" t-as="group">
+                                            <t t-foreach="group[1]" t-as="branch">
+                                                <small>
+                                                    <div class="btn-toolbar mb-1" role="toolbar">
+                                                        <div class="btn-group btn-group-ssm" role="group">
+                                                            <a t-att-href="branch.branch_url" class="btn btn-default text-start" title="View Branch on Github"><i class="fa fa-github"/></a>
+                                                            <a groups="runbot.group_runbot_admin" class="btn btn-default fa fa-list text-start"
+                                                                t-attf-href="/odoo/branch/{{branch.id}}" target="_blank" title="View Branch in Backend"/>
+                                                            <a href="#" t-out="branch.remote_id.short_name" class="btn btn-default disabled text-start"/>
+                                                            <a t-attf-href="/runbot/branch/{{branch.id}}" class="btn btn-default text-start" title="View Branch Details"><span t-att-class="'' if branch.alive else 'line-through'" t-out="branch.name"/> <i t-if="not branch.alive" title="deleted/closed" class="fa fa-ban text-danger"/></a>
+                                                            <t t-if="not any (b.is_pr and b.alive for b in group[1]) and not branch.is_pr">
+                                                                <a t-attf-href="https://{{group[0].main_remote_id.base_url}}/compare/{{bundle.version_id.name}}...{{branch.remote_id.owner}}:{{branch.name}}?expand=1" class="btn btn-default text-start" title="Create pr"><i class="fa fa-code-fork"/> Create pr</a>
+                                                            </t>
                                                         </div>
-                                                    </small>
-                                                </t>
+                                                    </div>
+                                                </small>
                                             </t>
-                                        </td>
-                                    </tr>
+                                        </t>
+                                    </td>
+                                </tr>
+                                <tr t-if="not bundle.sticky and not bundle.is_base">
+                                    <td>Configuration</td>
+                                    <td>
+                                        <t t-set="current_mode" t-value="'custom'"/>
+                                        <t t-set="modified_repos" t-value="bundle.branch_ids.remote_id.repo_id"/>
 
-                                    <tr t-if="more">
-                                        <td>Project</td>
-                                        <td t-out="bundle.project_id.name"/>
-                                    </tr>
-                                    <tr t-if="more">
-                                        <td>New build enabled</td>
-                                        <td>
-                                            <i t-attf-class="fa fa-{{'times' if bundle.no_build else 'check'}}"/>
-                                        </td>
-                                    </tr>
-                                    <tr t-if="more">
-                                        <td>Modules</td>
-                                        <td t-out="bundle.modules or '/'"/>
-                                    </tr>
-                                </table>
-                            </div>
+                                        <t t-if="not bundle.trigger_custom_ids"> <t t-set="current_mode" t-value="'auto'"/></t>
+                                        <t t-elif="all(trigger_custom.start_mode == 'disabled' for trigger_custom in bundle.trigger_custom_ids)"> <t t-set="current_mode" t-value="'disabled'"/></t>
+                                        <t t-elif="all(trigger_custom.start_mode == 'force' for trigger_custom in bundle.trigger_custom_ids)"> <t t-set="current_mode" t-value="'force'"/></t>
+                                        <t t-elif="all(trigger_custom.start_mode == 'auto' for trigger_custom in bundle.trigger_custom_ids)"> <t t-set="current_mode" t-value="'auto'"/></t>
+                                        <t t-elif="all(trigger_custom.start_mode in ('light', 'auto') for trigger_custom in bundle.trigger_custom_ids)"> <t t-set="current_mode" t-value="'light'"/></t>
+                                        <t t-if="current_mode=='disabled'">
+                                            <a role="button" t-attf-class="btn btn-primary btn-ssm" data-bs-toggle="collapse" href="#customTriggers">Disable all</a>
+                                        </t><t t-else="">
+                                            <a role="button" t-attf-class="btn btn-default btn-ssm" t-attf-href="/runbot/bundle/{{bundle.id}}/triggers/disable_all"> Disable all</a>
+                                        </t>
+                                        <t t-if="current_mode=='light'">
+                                            <a role="button" t-attf-class="btn btn-primary btn-ssm" data-bs-toggle="collapse" href="#customTriggers">Light</a>
+                                        </t><t t-else="">
+                                            <a role="button" t-attf-class="btn btn-default btn-ssm" t-attf-href="/runbot/bundle/{{bundle.id}}/triggers/light_all">Light</a>
+                                        </t>
+                                        <t t-if="current_mode=='auto'">
+                                            <a role="button" t-attf-class="btn btn-primary btn-ssm" data-bs-toggle="collapse" href="#customTriggers">Default</a>
+                                        </t><t t-else="">
+                                            <a role="button" t-attf-class="btn btn-default btn-ssm" t-attf-href="/runbot/bundle/{{bundle.id}}/triggers/auto_all">Default</a>
+                                        </t>
+                                         <t t-if="current_mode=='force'">
+                                            <a role="button" t-attf-class="btn btn-primary btn-ssm" data-bs-toggle="collapse" href="#customTriggers">Force all</a>
+                                        </t><t t-else="">
+                                            <a role="button" t-attf-class="btn btn-default btn-ssm" t-attf-href="/runbot/bundle/{{bundle.id}}/triggers/force_all">Force all</a>
+                                        </t>
+                                        <a role="button" t-attf-class="btn btn-{{'primary' if current_mode=='custom' else 'default'}} btn-ssm" data-bs-toggle="collapse" href="#customTriggers" aria-expanded="false" aria-controls="customTriggers"> Custom <i class="fa fa-caret-down ms-1"/></a>
+
+                                        <div t-attf-class="collapse {{'show' if expand_custom else ''}}" id="customTriggers">
+                                            <div class="card card-body mt-2">
+                                                <t t-foreach="bundle.trigger_custom_ids" t-as="trigger_custom">
+                                                    <t t-set="trigger_enabled_by_default" t-value="trigger_custom.trigger_id.repo_ids &amp; modified_repos"/>
+                                                    <t t-set="level_color" t-if="trigger_enabled_by_default and trigger_custom.start_mode == 'disabled'">danger</t>
+                                                    <t t-set="level_color" t-elif="trigger_enabled_by_default and trigger_custom.start_mode == 'light'">info</t>
+                                                    <t t-set="level_color" t-elif="not trigger_enabled_by_default and trigger_custom.start_mode == 'force'">warning</t>
+                                                    <t t-set="level_color" t-elif="trigger_enabled_by_default">success</t>
+                                                    <t t-set="level_color" t-else="">secondary</t>
+                                                    <div>
+                                                        <a href="#" t-attf-class="badge text-bg-{{level_color}} dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                                                            <t t-out="trigger_custom.start_mode"/>
+                                                            <i class="fa fa-caret-down ms-1"/>
+                                                        </a>
+                                                        <form class="dropdown-menu">
+                                                            <li t-foreach="['disabled', 'light', 'auto', 'force']" t-as="mode">
+                                                                <a class="dropdown-item" t-attf-href="/runbot/trigger_custom/{{trigger_custom.id}}/set_mode/{{mode}}" t-if="mode != trigger_custom.start_mode and (mode != 'light' or trigger_custom.trigger_id.light_config_id)">
+                                                                    <span t-out="mode"/>
+                                                                </a>
+                                                            </li>
+                                                        </form>
+                                                        <span t-out="trigger_custom.trigger_id.name"/>
+                                                    </div>
+                                                </t>
+                                            </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
                             <div t-foreach="bundle._consistency_warning()" t-as="warning" t-out="warning[1]" t-attf-class="alert alert-{{warning[0]}}"/>
+                            <t t-call="website.pager" />
                             <div class="batch_row" t-foreach="batchs" t-as="batch">
                                 <t t-call="runbot.batch_tile"/>
                             </div>
+                            <t t-call="website.pager" />
                         </div>
                     </div>
                 </div>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -17,6 +17,7 @@
                   <field name="category_id" required='1'/>
                   <field name="project_id" default=""/>
                   <field name="config_id"/>
+                  <field name="light_config_id"/>
                   <field name="network_enabled"/>
                   <field name="config_data" widget="runbotjsonb"/>
                   <field name="report_view_id"/>


### PR DESCRIPTION
The laod increases on runbot with a test time of 11h+ and many daily pushes. 

This pr proposes a way to add lighter configs on triggers. If not sufficient to provide a complete ci before a potential merge, they will provide a faster way to test a specific branch when only a few modules are impacted.

This first phase provide a way to enable them, and the corresponding changes on how the ci are send on github.

A second phase will enable minimal checks by default,  and automatically enable the full one once a r+ is sent to mergebot (or any other defined signal).

This will also be an opportunity to start l10n/documentations tests before reaching the staging.