### PR TITLE
[IMP] runbot: enable light config by default

### DIFF
--- a/runbot/common.py
+++ b/runbot/common.py
@@ -24,6 +24,13 @@ _logger = logging.getLogger(__name__)
 dest_reg = re.compile(r'^\d{5,}-.+$')
 
 
+try:
+    from odoo.addons.saas_worker.util import from_role
+except ImportError:
+    def from_role(*_, **__):
+        return lambda _: None
+
+
 def transactioncache(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -677,13 +677,13 @@ class Runbot(Controller):
         if bundle.is_base or bundle.is_staging:
             raise NotFound()
         if action == 'disable_all':
-            bundle.sudo().configure_custom_trigger_start_mode('disabled')
+            bundle.sudo()._configure_custom_trigger_start_mode('disabled')
         elif action == 'force_all':
-            bundle.sudo().configure_custom_trigger_start_mode('force')
+            bundle.sudo()._configure_custom_trigger_start_mode('force')
         elif action == 'auto_all':
-            bundle.sudo().configure_custom_trigger_start_mode('auto')
+            bundle.sudo()._configure_custom_trigger_start_mode('auto')
         elif action == 'light_all':
-            bundle.sudo().configure_custom_trigger_start_mode('light')
+            bundle.sudo()._configure_custom_trigger_start_mode('light')
         else:
             raise NotFound()
         expand_kwrags = '?expand_custom=1' if expand_custom else ''

--- a/runbot/controllers/hook.py
+++ b/runbot/controllers/hook.py
@@ -4,8 +4,9 @@ import time
 import json
 import logging
 
-from odoo import http
+from odoo import http, fields
 from odoo.http import request
+from ..common import from_role
 
 _logger = logging.getLogger(__name__)
 
@@ -50,3 +51,18 @@ class Hook(http.Controller):
                 branch = request.env['runbot.branch'].sudo().search([('remote_id', '=', remote.id), ('name', '=', branch_ref)])
                 branch.alive = False
         return ""
+
+    @from_role('mergebot', signed=True)
+    @http.route(['/runbot/request_ci'], type='http', methods=["POST"], auth="public", website=True, csrf=False, sitemap=False)
+    def force_ci(self):
+        pull_request_names = request.get_json_data().get('pull_requests', [])
+        pull_domains = []
+        for pull_request_names in pull_request_names:
+            remote_short_name, name = pull_request_names.split('#')
+            owner, repo_name = remote_short_name.split('/')
+            pull_domains.append([('remote_id.owner', '=', owner), ('remote_id.repo_name', '=', repo_name), ('name', '=', name)])
+        pull_domains = fields.Domain.OR(pull_domains)
+        pull_requests = request.env['runbot.branch'].sudo().search([('is_pr', '=', True)] + pull_domains)
+        bundles = pull_requests.bundle_id
+        _logger.info('Received CI request for bundles: %s', bundles.mapped('name'))
+        bundles._force_ci()

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -383,10 +383,20 @@ class Batch(models.Model):
                 continue
             # in any case, search for an existing build
             config = trigger.config_id
+            if trigger.light_config_id:
+                if (project.use_light_default
+                    or
+                    project.use_light_draft and any(branch.draft for branch in self.bundle_id.branch_ids)
+                    or
+                    project.use_light_no_pr and not any(branch.is_pr for branch in self.bundle_id.branch_ids)
+                ):
+                    config = trigger.light_config_id
+
             if trigger_custom.config_id:
                 config = trigger_custom.config_id
             elif trigger_custom.start_mode == 'light' and trigger.light_config_id:
                 config = trigger.light_config_id
+
             extra_params = trigger_custom.extra_params or ''
             config_data = dict(trigger.config_data or {}) | dict(trigger_custom.config_data or {})
             trigger_commit_link_by_repos = commit_link_by_repos

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -322,9 +322,11 @@ class Bundle(models.Model):
         return self._generate_custom_trigger_action(context)
 
     def action_disable_all_triggers(self):
-        self.configure_custom_trigger_start_mode('disable')
+        self._configure_custom_trigger_start_mode('disable')
 
-    def configure_custom_trigger_start_mode(self, mode):
+    def _configure_custom_trigger_start_mode(self, mode):
+        self.ensure_one()
+
         triggers_to_create = (
             self.env["runbot.trigger"]
             .search([
@@ -338,17 +340,26 @@ class Bundle(models.Model):
             )
         )
         vals = []
+        bundle_repos = self.branch_ids.remote_id.repo_id
         for trigger in triggers_to_create:
-            vals.append({
-                'bundle_id': self.id,
-                'trigger_id': trigger.id,
-            })
+            if trigger.repo_ids & bundle_repos or trigger.dependency_ids & bundle_repos:
+                vals.append({
+                    'bundle_id': self.id,
+                    'trigger_id': trigger.id,
+                })
         self.env['runbot.bundle.trigger.custom'].create(vals)
         for custom_trigger in self.trigger_custom_ids:
             trigger_mode = mode
             if mode == 'light' and not custom_trigger.trigger_id.light_config_id:
                 trigger_mode = 'auto'
             custom_trigger.start_mode = trigger_mode
+
+    def _force_ci(self):
+        for bundle in self:
+            bundle._configure_custom_trigger_start_mode('force')
+            # we need to create a new batch in case some of the triggers were in minimal mode
+            batch = bundle._force() or bundle.last_batch
+            batch._log("Batch was requested for ci")
 
 
 class BundleTag(models.Model):

--- a/runbot/models/project.py
+++ b/runbot/models/project.py
@@ -25,6 +25,9 @@ class Project(models.Model):
     active = fields.Boolean("Active", default=True)
     process_delay = fields.Integer('Process delay', default=60, required=True, help="Delay between a push and a batch starting its process.")
     next_freeze_tag_id = fields.Many2one('runbot.bundle.tag', string="Next freeze tag")
+    use_light_default = fields.Boolean('Use light config by default', help="Use the light config when possible for all triggers")
+    use_light_draft = fields.Boolean('Use light config for draft PRs', help="Use the light config when possible for bundle having draft pr")
+    use_light_no_pr = fields.Boolean('Use light config when no PR', help="Use the light config when possible for all bundles not having any pr")
 
     @api.constrains('process_delay')
     def _constraint_process_delay(self):

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -18,20 +18,22 @@
                                         <a groups="base.group_user" class="btn btn-default" t-attf-href="/runbot/stats/{{bundle.id}}" title="View stats">
                                             <i class="fa fa-bar-chart"/> Stats
                                         </a>
-                                        <button type="button" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-                                            <i class="fa fa-play"/> Actions <i class="fa fa-caret-down ms-1"/>
-                                        </button>
-                                        <ul class="dropdown-menu">
-                                            <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force a new batch using base commits mainly for random errors debugging">
-                                                <i class="fa fa-fast-backward"/> Start a batch without the branch commits
-                                            </a>
-                                            <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Create a new Batch, applies new trigger configurations and updates build references for upgrades if needed">
-                                                <i class="fa fa-play"/> Start a new batch
-                                            </a>
-                                            <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" class="btn btn-default dropdown-item"  title="Force A New Batch with automatic rebase, useful to test outdated branches without pushing before a merge">
-                                                <i class="fa fa-fast-forward"/> Start a batch with simulated autorebase
-                                            </a>
-                                        </ul>
+                                        <t groups="runbot.group_runbot_advanced_user">
+                                            <button type="button" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                                                <i class="fa fa-play"/> Actions <i class="fa fa-caret-down ms-1"/>
+                                            </button>
+                                            <ul class="dropdown-menu">
+                                                <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force a new batch using base commits mainly for random errors debugging">
+                                                    <i class="fa fa-fast-backward"/> Start a batch without the branch commits
+                                                </a>
+                                                <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Create a new Batch, applies new trigger configurations and updates build references for upgrades if needed">
+                                                    <i class="fa fa-play"/> Start a new batch
+                                                </a>
+                                                <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" class="btn btn-default dropdown-item"  title="Force A New Batch with automatic rebase, useful to test outdated branches without pushing before a merge">
+                                                    <i class="fa fa-fast-forward"/> Start a batch with simulated autorebase
+                                                </a>
+                                            </ul>
+                                        </t>
                                 </div></h5>
                             
                             <table class="table table-condensed table-responsive table-stripped">

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -18,6 +18,9 @@
                     <field name="hidden"/>
                     <field name="active"/>
                     <field name="process_delay"/>
+                    <field name="use_light_default"/>
+                    <field name="use_light_draft"/>
+                    <field name="use_light_no_pr"/>
                 </group>
             </form>
         </field>


### PR DESCRIPTION
This branches adds
- a hook for mergebot to request the start of all builds in full mode
- fields on project to define ways to enable light config by default.
- fixes Action visibility for non advanced users