### PR TITLE
[FIX] runbot_merge: prevent marking PRs as errored when skipping validation

### DIFF
--- a/runbot_merge/models/crons/validate.py
+++ b/runbot_merge/models/crons/validate.py
@@ -72,6 +72,8 @@ class BatchValidate(models.Model):
                 validate_pr(pr, states[pr.repository.name, pr.target.name])
             except exceptions.Mismatch as e:
                 mismatch_warn(e, "data mismatch during check:\n{diff}")
+            except exceptions.Skip as e:
+                continue
             except exceptions.MergeError as e:
                 if len(e.args) > 1 and e.args[1]:
                     reason = e.args[1]


### PR DESCRIPTION
When validate_pr() is called as a pre-validation step before staging, it can raise exceptions.Skip (for instance, on multi-commit PRs missing a merge_method).

Since Skip is a subclass of MergeError, and validate.py lacked an explicit handler for it, these PRs were previously caught by the general MergeError block. This resulted in the PR being incorrectly marked with pr.error = True and receiving an "unable to stage" comment. Once in this error state, the PR is blocked from further staging attempts even after the missing information (like the merge method) is provided.

This fix adds a specific handler for exceptions.Skip to ensure the validation simply bypasses the PR without flagging it as a failure, matching the behavior already present in stagings_create.py.