### PR TITLE
[IMP] runbot: handle main command exit status

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1032,6 +1032,8 @@ class BuildResult(models.Model):
         starting_config = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_default_odoorc')
         if isinstance(cmd, Command):
             rc_content = cmd.get_config(starting_config=starting_config)
+            if step.check_exit_status:
+                cmd.finals = [['echo', r'$?', '>', f'/data/build/logs/{step.sanitized_name(self)}_exit_status.txt']] + cmd.finals
         else:
             rc_content = starting_config
         self._write_file('.odoorc', rc_content)

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1032,6 +1032,7 @@ class BuildResult(models.Model):
         starting_config = self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_default_odoorc')
         if isinstance(cmd, Command):
             rc_content = cmd.get_config(starting_config=starting_config)
+            cmd.finals = [['echo', r'\$0', '>', f'/data/build/logs/{step.sanitized_name(self)}_exit_status.txt']] + cmd.finals
         else:
             rc_content = starting_config
         self._write_file('.odoorc', rc_content)

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -435,6 +435,9 @@ class ConfigStep(models.Model):
     restore_download_db_suffix = fields.Char('Download db suffix')
     restore_rename_db_suffix = fields.Char('Rename db suffix')
 
+    # TODO change the default to True once we are sure that it works as expected
+    check_exit_status = fields.Boolean('Check exit status', default=False, help='Check exit status of the main command')
+
     semgrep_category = fields.Many2one('runbot.checker_category', string='Semgrep Category', tracking=True)
     custom_link = fields.Char('Custom link for semgrep codes', tracking=True)
     disable_nosem = fields.Boolean('Disable nosem', default=False, tracking=True)
@@ -1228,6 +1231,10 @@ class ConfigStep(models.Model):
         if log_time:
             build.job_end = log_time
 
+        if self.check_exit_status and (exit_status := self._get_exit_status(build)) != 0:
+            build._log('_make_results', f'Main command exited with status code {exit_status}', level='ERROR')
+            build.local_result = 'ko'
+
         if check_logs or expected_logs:
             self._make_custom_result(build, check_logs, expected_logs)
         elif active_job_type == 'python':
@@ -1385,6 +1392,21 @@ class ConfigStep(models.Model):
             if result != 'ok':
                 return result
         return 'ok'
+
+    def _get_exit_status(self, build):
+        exit_status_filename = f'{self.sanitized_name(build)}_exit_status.txt'
+        if not os.path.exists(build._path(exit_status_filename)):
+            build._log('_make_tests_results', f'Exit status file "{exit_status_filename}" not found', level="ERROR")
+            return 1
+        res = build._read_file(exit_status_filename)
+        if res:
+            try:
+                return int(res.strip('\n'))
+            except ValueError:
+                build._log('_make_tests_results', f'Status file "{exit_status_filename}" does not contain an integer', level="ERROR")
+                return -242
+        build._log('_make_tests_results', f'Exception or file empty while reading status file "{exit_status_filename}"', level="ERROR")
+        return -241
 
     def _make_custom_result(self, build, enabled_checkers=None, expected_logs=None):
         build._log('run', 'Getting results for build %s' % build.dest)

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -662,11 +662,14 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         )
 
         # 0.2 run standalone l10n script
+        self.config_step.check_exit_status = True
         self.docker_run_calls = []
         build._schedule()()
         self.assertEqual(len(self.docker_run_calls), 1, "One docker run should have been called for install_all step")
         cmd = self.docker_run_calls[0][0]
-        self.assertEqual(cmd.build(), f'odoo/odoo/tests/test_module_operations.py -d {build.dest}-l10n --data-dir /data/build/datadir/ --addons-path odoo/addons,odoo/core/addons,enterprise --standalone all_l10n')
+        expected_cmd = f'odoo/odoo/tests/test_module_operations.py -d {build.dest}-l10n --data-dir /data/build/datadir/ --addons-path odoo/addons,odoo/core/addons,enterprise --standalone all_l10n'
+        expected_cmd += r' ; echo $? > /data/build/logs/running_standalone_exit_status.txt'
+        self.assertEqual(cmd.build(), expected_cmd)
 
         # 0.3. create post install builds
         build._schedule()
@@ -1474,3 +1477,103 @@ Initiating shutdown
         mock_make_odoo_results.side_effect = make_warn
         config_step._make_results(build)
         self.assertEqual(build.local_result, 'warn')
+
+    def test_check_exit_status_ok(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = "0\n"
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ok')
+
+    def test_check_exit_status_ko(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = "1\n"
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Main command exited with status code 1'), self.logs)
+
+    def test_check_exit_status_file_empty(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = ""
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Exception or file empty while reading status file "all_exit_status.txt"'), self.logs)
+        self.assertIn(('ERROR', 'Main command exited with status code -241'), self.logs)
+
+    def test_check_exit_status_file_non_integer(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = "d0d0caca"
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Status file "all_exit_status.txt" does not contain an integer'), self.logs)
+        self.assertIn(('ERROR', 'Main command exited with status code -242'), self.logs)
+
+    def test_check_exit_status_file_not_found(self):
+        config_step = self.ConfigStep.create({
+            'name': 'test',
+            'job_type': 'install_odoo',
+            'check_exit_status': True,
+        })
+        self.patchers['file_exist'].return_value = False
+        config_step._make_results(self.build)
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Exit status file "test_exit_status.txt" not found'), self.logs)

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -666,7 +666,9 @@ class TestBuildConfigStepDynamic(TestBuildConfigStepCommon):
         build._schedule()()
         self.assertEqual(len(self.docker_run_calls), 1, "One docker run should have been called for install_all step")
         cmd = self.docker_run_calls[0][0]
-        self.assertEqual(cmd.build(), f'odoo/odoo/tests/test_module_operations.py -d {build.dest}-l10n --data-dir /data/build/datadir/ --addons-path odoo/addons,odoo/core/addons,enterprise --standalone all_l10n')
+        expected_cmd = f'odoo/odoo/tests/test_module_operations.py -d {build.dest}-l10n --data-dir /data/build/datadir/ --addons-path odoo/addons,odoo/core/addons,enterprise --standalone all_l10n'
+        expected_cmd += r' ; echo \$0 > /data/build/logs/running_standalone_exit_status.txt'
+        self.assertEqual(cmd.build(), expected_cmd)
 
         # 0.3. create post install builds
         build._schedule()
@@ -1474,3 +1476,103 @@ Initiating shutdown
         mock_make_odoo_results.side_effect = make_warn
         config_step._make_results(build)
         self.assertEqual(build.local_result, 'warn')
+
+    def test_check_exit_status_ok(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = "0\n"
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ok')
+
+    def test_check_exit_status_ko(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = "1\n"
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Main command exited with status code 1'), self.logs)
+
+    def test_check_exit_status_file_empty(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = ""
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Exception or file empty while reading status file "all_exit_status.txt"'), self.logs)
+        self.assertIn(('ERROR', 'Main command exited with status code -241'), self.logs)
+
+    def test_check_exit_status_file_non_integer(self):
+        self.config_step.write({'check_exit_status': True})
+        file_content = """
+Loading stuff
+odoo.stuff.modules.loading: Modules loaded.
+Some post install stuff
+Initiating shutdown
+    """
+        exit_status_content = "d0d0caca"
+
+        def mock_open_files(filename, mode='r', *args, **kwargs):
+            if filename.endswith('_exit_status.txt'):
+                return mock_open(read_data=exit_status_content)()
+            return mock_open(read_data=file_content)()
+
+        with patch('builtins.open', mock_open_files):
+            with patch('os.path.exists', return_value=True):
+                self.config_step._make_results(self.build)
+
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Status file "all_exit_status.txt" does not contain an integer'), self.logs)
+        self.assertIn(('ERROR', 'Main command exited with status code -242'), self.logs)
+
+    def test_check_exit_status_file_not_found(self):
+        config_step = self.ConfigStep.create({
+            'name': 'test',
+            'job_type': 'install_odoo',
+            'check_exit_status': True,
+        })
+        self.patchers['file_exist'].return_value = False
+        config_step._make_results(self.build)
+        self.assertEqual(self.build.local_result, 'ko')
+        self.assertIn(('ERROR', 'Exit status file "test_exit_status.txt" not found'), self.logs)


### PR DESCRIPTION
Since the runbot executes Docker containers non-blockingly, there is no direct way to capture the main command's exit status.

This commit writes the exit status code to a file at the end of the main Docker command. The feature is now used in Semgrep builds.