### PR TITLE
[IMP] runbot: detect and list duplicate breaking PR on build errors

### DIFF
--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -242,6 +242,7 @@ class BuildError(models.Model):
     breaking_bundle_id = fields.Many2one('runbot.bundle', 'Breaking bundle', tracking=True, help="Bundle that introduced the error", related='breaking_pr_id.bundle_id')
     breaking_bundle_url = fields.Char('Breaking bundle url', related='breaking_bundle_id.frontend_url')
     breaking_pr_date = fields.Datetime('Breaking date', related="breaking_pr_id.close_date", help="Date of the merge of the first pr")
+    duplicate_breaking_pr_count = fields.Integer('Same Breaking PR', compute='_compute_duplicate_breaking_pr_count', help='Other errors with same breaking PR')
 
     test_tags = fields.Char(string='Test tags', help="Comma separated list of test_tags to use to reproduce/remove this error", tracking=True)
     canonical_tags = fields.Char('Canonical tag', compute='_compute_canonical_tags', store=True)
@@ -321,6 +322,25 @@ class BuildError(models.Model):
     def _compute_fixing_bundle_id(self):
         for record in self:
             record.fixing_bundle_id = record.fixing_pr_id.bundle_id if record.fixing_pr_id else False
+
+    @api.depends('breaking_pr_id')
+    def _compute_duplicate_breaking_pr_count(self):
+        breaking_counts = self.env["runbot.build.error"]._read_group(
+            domain=[
+                ("breaking_pr_id", "in", self.breaking_pr_id.ids),
+                ("active", "=", True),
+            ],
+            groupby=["breaking_pr_id"],
+            aggregates=["id:count"],
+            having=[('id:count', '>', 1)],
+        )
+
+        count_by_pr = {pr_count[0]: pr_count[1] for pr_count in breaking_counts}
+
+        for record in self:
+            # remove 1 to not count the current error
+            record.duplicate_breaking_pr_count = count_by_pr.get(record.breaking_pr_id, 1) - 1
+
 
     @api.depends('error_content_ids.version_ids')
     def _compute_version_ids(self):
@@ -699,6 +719,19 @@ class BuildError(models.Model):
             'context': {'active_test': False},
             'target': 'current',
             'name': 'Similary Qualified Contents'
+        }
+
+    def action_view_duplicate_breaking_pr(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'runbot.build.error',
+            'domain': [
+                ('breaking_pr_id', '=', self.breaking_pr_id.id),
+                ('active', '=', True),
+            ],
+            'view_mode': 'list,form',
+            'name': 'Errors with same breaking PR',
         }
 
     @api.depends('manual_team_id', 'auto_team_id')

--- a/runbot/models/build_error.py
+++ b/runbot/models/build_error.py
@@ -242,6 +242,7 @@ class BuildError(models.Model):
     breaking_bundle_id = fields.Many2one('runbot.bundle', 'Breaking bundle', tracking=True, help="Bundle that introduced the error", related='breaking_pr_id.bundle_id')
     breaking_bundle_url = fields.Char('Breaking bundle url', related='breaking_bundle_id.frontend_url')
     breaking_pr_date = fields.Datetime('Breaking date', related="breaking_pr_id.close_date", help="Date of the merge of the first pr")
+    duplicate_breaking_pr_count = fields.Integer('Same Breaking PR', compute='_compute_duplicate_breaking_pr_count', help='Other errors with same breaking PR')
 
     test_tags = fields.Char(string='Test tags', help="Comma separated list of test_tags to use to reproduce/remove this error", tracking=True)
     canonical_tags = fields.Char('Canonical tag', compute='_compute_canonical_tags', store=True)
@@ -321,6 +322,18 @@ class BuildError(models.Model):
     def _compute_fixing_bundle_id(self):
         for record in self:
             record.fixing_bundle_id = record.fixing_pr_id.bundle_id if record.fixing_pr_id else False
+
+    @api.depends('breaking_pr_id')
+    def _compute_duplicate_breaking_pr_count(self):
+        for record in self:
+            if record.breaking_pr_id:
+                record.duplicate_breaking_pr_count = self.search_count([
+                    ('breaking_pr_id', '=', record.breaking_pr_id.id),
+                    ('id', '!=', record.id),
+                    ('active', '=', True),
+                ])
+            else:
+                record.duplicate_breaking_pr_count = 0
 
     @api.depends('error_content_ids.version_ids')
     def _compute_version_ids(self):
@@ -699,6 +712,19 @@ class BuildError(models.Model):
             'context': {'active_test': False},
             'target': 'current',
             'name': 'Similary Qualified Contents'
+        }
+
+    def action_view_duplicate_breaking_pr(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'runbot.build.error',
+            'domain': [
+                ('breaking_pr_id', '=', self.breaking_pr_id.id),
+                ('active', '=', True),
+            ],
+            'view_mode': 'list,form',
+            'name': 'Errors with same breaking PR',
         }
 
     @api.depends('manual_team_id', 'auto_team_id')

--- a/runbot/tests/test_build_error.py
+++ b/runbot/tests/test_build_error.py
@@ -219,6 +219,44 @@ class TestBuildError(TestBuildErrorCommon):
         self.assertEqual(error_a.fixing_pr_id, self.dev_pr)
         self.assertEqual(error_a.breaking_pr_id, self.dev_pr)
 
+    def test_duplicate_breaking_pr(self):
+        pr_branch = self.Branch.create({
+            'name': '242',
+            'is_pr': True,
+            'alive': True,
+            'remote_id': self.remote_odoo.id,
+            'target_branch_name': self.branch_odoo.name,
+            'pull_head_name': f'{self.remote_odoo.owner}:{self.dev_branch.name}',
+        })
+
+        error_a = self.BuildError.create({'content': 'error A', 'breaking_pr_id': pr_branch.id})
+        error_b = self.BuildError.create({'content': 'error B', 'breaking_pr_id': pr_branch.id})
+        error_c = self.BuildError.create({'content': 'error C', 'breaking_pr_id': pr_branch.id})
+        error_d = self.BuildError.create({'content': 'error D'})
+
+        # Test compute count (excludes self)
+        self.assertEqual(error_a.duplicate_breaking_pr_count, 2)
+        self.assertEqual(error_b.duplicate_breaking_pr_count, 2)
+        self.assertEqual(error_c.duplicate_breaking_pr_count, 2)
+        self.assertEqual(error_d.duplicate_breaking_pr_count, 0)
+
+        # Test action returns all errors including self
+        action = error_a.action_view_duplicate_breaking_pr()
+        self.assertEqual(action['type'], 'ir.actions.act_window')
+        self.assertEqual(action['res_model'], 'runbot.build.error')
+        errors_in_action = self.BuildError.search(action['domain'])
+        self.assertIn(error_a, errors_in_action)
+        self.assertEqual(len(errors_in_action), 3)
+
+        # Test count update on deactivation
+        error_b.active = False
+        error_a.invalidate_recordset(['duplicate_breaking_pr_count'])
+        self.assertEqual(error_a.duplicate_breaking_pr_count, 1)
+
+        # Test count update on breaking PR removal
+        error_a.breaking_pr_id = False
+        self.assertEqual(error_a.duplicate_breaking_pr_count, 0)
+
     def test_relink_contents(self):
         build_a = self.create_test_build({'local_result': 'ko', 'local_state': 'done'})
         error_content_a = self.BuildErrorContent.create({'content': 'foo bar'})

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -10,6 +10,9 @@
                 <button class="oe_stat_button" type="object" icon="fa-exclamation-circle" name="action_get_build_link_record">
                   <field string="Builds Link" name="build_count" widget="statinfo"/>
                 </button>
+                <button name="action_view_duplicate_breaking_pr" type="object" class="oe_stat_button" icon="fa-external-link" invisible="duplicate_breaking_pr_count == 0">
+                  <field name="duplicate_breaking_pr_count" widget="statinfo"/>
+                </button>
               </div>
               <widget name="web_ribbon" title="Test-tags" bg_color="bg-danger" invisible="not test_tags"/>
               <button name="action_view_errors" string="See all linked errors" type="object" class="oe_highlight"/>

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -56,6 +56,9 @@
                   <field name="breaking_pr_id" options="{'no_create': True}"/>
                   <field name="breaking_pr_url"  widget="pull_request_url" invisible="not breaking_pr_id"/>
                   <field name="breaking_bundle_url" invisible="not breaking_pr_id"/>
+                  <button name="action_view_duplicate_breaking_pr" type="object" class="oe_stat_button" icon="fa-external-link" invisible="duplicate_breaking_pr_count == 0">
+                    <field name="duplicate_breaking_pr_count" widget="statinfo"/>
+                  </button>
                   <field name="first_seen_date" widget="frontend_url" options="{'link_field': 'first_seen_build_id', 'numeric': True}"/>
                   <field name="last_seen_date" widget="frontend_url" options="{'link_field': 'last_seen_build_id', 'numeric': True}"/>
                   <field name="first_seen_build_id" invisible="True"/>


### PR DESCRIPTION
With this commit, when a breaking PR is assigned to multiple build errors, a button appears showing the count of duplicates. Clicking it opens a list of those errors, allowing the user to decide whether to merge them.