### PR TITLE
[FIX] runbot: use most recent similar build for quick result

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -1027,7 +1027,9 @@ class ConfigStep(models.Model):
                     )
 
                     if self.allow_similar_build_quick_result:
-                        existing_done_build = next((build for build in child.params_id.build_ids.sorted('id') if build.global_state == 'done' and build.local_result not in ('skipped', 'killed')), None)
+                        existing_done_build = next((build for build in child.params_id.build_ids.sorted('id') if build.global_state == 'done' and build.global_result == 'ok'), None)
+                        if not existing_done_build:
+                            existing_done_build = next((build for build in child.params_id.build_ids.sorted('id') if build.global_state == 'done' and build.local_result not in ('skipped', 'killed')), None)
                         if existing_done_build:
                             child._log('', 'A similar [build](%s) has been found, marking as done directly', existing_done_build.build_url, log_type='markdown')
                             child.local_state = 'done'


### PR DESCRIPTION
When looking for an existing done build to reuse via allow_similar_build_quick_result, the oldest matching build was selected. The most recent done build is more likely to carry the correct status for the current build params.