### PR TITLE
[IMP] runbot: replace keep_running by gc_running_date

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -360,7 +360,7 @@ class BuildResult(models.Model):
     build_url = fields.Char('Build url', compute='_compute_build_url', store=False)
     build_error_link_ids = fields.One2many('runbot.build.error.link', 'build_id')
     build_error_ids = fields.Many2many('runbot.build.error', compute='_compute_build_error_ids', string='Errors')
-    keep_running = fields.Boolean('Keep running', help='Keep running', index=True)
+    gc_running_date = fields.Date('GC Running Date', help='Running build cannot be killed before this date', index='btree_not_null')
     log_counter = fields.Integer('Log Lines counter', default=100)
 
     slot_ids = fields.One2many('runbot.batch.slot', 'build_id')

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -104,7 +104,7 @@ class Runbot(models.AbstractModel):
     def _gc_running(self, host):
         running_max = host._get_running_max()
         Build = self.env['runbot.build']
-        cannot_be_killed_ids = host._get_builds([('keep_running', '=', True)]).ids
+        cannot_be_killed_ids = host._get_builds([('gc_running_date', '>', fields.Date.today())]).ids
         sticky_bundles = self.env['runbot.bundle'].search([('sticky', '=', True), ('project_id.keep_sticky_running', '=', True)])
         cannot_be_killed_ids += [
             build.id

--- a/runbot/views/build_views.xml
+++ b/runbot/views/build_views.xml
@@ -82,7 +82,7 @@
                         <field name="parent_id"/>
                         <field name="orphan_result"/>
                         <field name="build_url" widget="url" readonly="1"/>
-                        <field name="keep_running"/>
+                        <field name="gc_running_date" placeholder="Keep running until this date"/>
                         <field name="gc_date" readonly="1" options="{'numeric': true}"/>
                         <field name="gc_delay"/>
                         <field name="killable"/>


### PR DESCRIPTION
The `keep_running` boolean field on BuildResult was a simple flag to prevent builds from being automatically killed. The drawback is that sometimes those builds are forgotten and stays alive forever.

This commit replaces it with a `gc_running_date` field.

Now, if a date is set, the build can only be killed by _gc_running after that date.