### PR TITLE
[FIX] runbot: restore cpu_limit

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -317,7 +317,7 @@ class BuildResult(models.Model):
     active_step = fields.Many2one('runbot.build.config.step', 'Active step')
     job = fields.Char('Active step display name', compute='_compute_job')
     dynamic_active_step_index = fields.Integer('Dynamic active step index')
-
+    cpu_limit = fields.Integer('CPU limit for the current running docker')
     job_start = fields.Datetime('Job start')
     job_end = fields.Datetime('Job end')
     build_start = fields.Datetime('Build start')
@@ -886,7 +886,8 @@ class BuildResult(models.Model):
         else:
             _docker_state = docker_state(build._get_docker_name(), build._path())
             if _docker_state == 'RUNNING':
-                timeout = min(build.active_step.cpu_limit, int(icp.get_param('runbot.runbot_timeout', default=10000)))
+                build_limit = build.cpu_limit or build.active_step.cpu_limit
+                timeout = min(build_limit, int(icp.get_param('runbot.runbot_timeout', default=10000)))
                 if build.local_state != 'running' and build.job_time > timeout:
                     build.active_step._make_stats(build)
                     build._log('_schedule', '%s time exceeded (%ss)' % (build.active_step._get_display_name(self) if build.active_step else "?", build.job_time))
@@ -1064,6 +1065,7 @@ class BuildResult(models.Model):
         self.env.flush_all()
         env_variables = env_variables or []
         env_variables.append('ODOO_RUNBOT=1')
+        self.cpu_limit = kwargs.get('cpu_limit')
         def start_docker():
             docker_run(
                 cmd=cmd,

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -598,7 +598,7 @@ class ConfigStep(models.Model):
 
             config_data = {**kwargs.get('config_data', {}), **build.params_id.config_data}
             if docker_params['cpu_limit'] and config_data.get('cpu_limit_factor'):
-                docker_params['cpu_limit'] = int(docker_params['cpu_limit'] * min(float(config_data['cpu_limit_factor']), 2))
+                docker_params['cpu_limit'] = int(docker_params['cpu_limit'] * min(float(config_data['cpu_limit_factor']), 3))
 
             container_cpus = float(self.container_cpus or self.env['ir.config_parameter'].sudo().get_param('runbot.runbot_containers_cpus', 0))
             if 'cpus' not in docker_params and container_cpus:
@@ -1642,6 +1642,9 @@ class ConfigStep(models.Model):
 
             if 'extra_params' in current_step:
                 config_data['extra_params'] = self._parse_dynamic_entry(current_step.get('extra_params'), build, dynamic_vars)
+
+            if 'cpu_limit' in current_step:
+                config_data['cpu_limit'] = int(current_step.get('cpu_limit'))
 
             for key in ('screencast', 'demo_mode', 'enable_auto_tags'):
                 if key in current_step:


### PR DESCRIPTION
Since dynamic config were introduced, a Falsy value was given as cpu limit bypassing the step limit and max limit in run_odoo_odoo

This is fixed by setting the step limit fist in run_odoo_odoo

The limit is also set on the docker but improprely used to kill the build manually. To avoid having to compute it twice the same way, the limit is now stored on the build and the same value is used to gc the build. We still have a fallback on the step limit, so both values needs to be Falsy in order to disable the limit, and provide a default waiting for the build.cpu_limit to be set on all builds.