### PR TITLE
[IMP] runbot: add a nocache toggle to docker build

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -108,21 +108,22 @@ class Command():
         return res.read()
 
 
-def docker_build(build_dir, image_tag, pull=False):
-    return _docker_build(build_dir, image_tag, pull)
+def docker_build(build_dir, image_tag, pull=False, nocache=False):
+    return _docker_build(build_dir, image_tag, pull, nocache)
 
 
-def _docker_build(build_dir, image_tag, pull=False):
+def _docker_build(build_dir, image_tag, pull=False, nocache=False):
     """Build the docker image
     :param build_dir: the build directory that contains Dockerfile.
     :param image_tag: name used to tag the resulting docker image
+    :param nocache: bypass Docker layer cache when True
     :return: dict
     """
 
     with DockerManager(image_tag) as dm:
         last_step = None
         dm.result['success'] = False  # waiting for an image_id
-        for chunk in dm.consume(dm.docker_client.api.build(path=build_dir, tag=image_tag, rm=True, pull=pull)):
+        for chunk in dm.consume(dm.docker_client.api.build(path=build_dir, tag=image_tag, rm=True, pull=pull, nocache=nocache)):
             if 'stream' in chunk:
                 stream = chunk['stream']
                 if stream.startswith('Step '):

--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -145,6 +145,7 @@ class Dockerfile(models.Model):
     dockerfile = fields.Text(compute='_compute_dockerfile', recursive=True, tracking=True)
     in_error = fields.Boolean('In error', help='The last build failed.', default=False)
     to_build = fields.Boolean('To Build', help='Build Dockerfile. Check this when the Dockerfile is ready.', default=True)
+    nocache = fields.Boolean('No Cache', help='Force a full rebuild on next build, bypassing the Docker layer cache. Automatically reset to False after the build.', copy=False)
     always_pull = fields.Boolean('Always pull', help='Always Pull on the hosts, not only at the use time', default=False, tracking=True, copy=False)
     version_ids = fields.One2many('runbot.version', 'dockerfile_id', string='Versions')
     description = fields.Text('Description')
@@ -383,7 +384,7 @@ class Dockerfile(models.Model):
             content = self._get_cached_content(docker_build_path)
             with open(self.env['runbot.runbot']._path('docker', tag_dir, 'Dockerfile'), 'w', encoding="utf-8") as Dockerfile:
                 Dockerfile.write(content)
-            result = docker_build(docker_build_path, self.image_future_tag, self.pull_on_build)
+            result = docker_build(docker_build_path, self.image_future_tag, self.pull_on_build, self.nocache)
             duration = result['duration']
             msg = result['msg']
             success = image_id = result.get('image_id')
@@ -427,6 +428,9 @@ class Dockerfile(models.Model):
                 message = f'Build failure, check results for more info ({result.summary})'
                 self.message_post(body=message)
                 _logger.error(message)
+
+        if self.nocache:
+            self.nocache = False
         return image_id
 
 

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -23,6 +23,7 @@
                 <field name="pull_on_build"/>
                 <field name="to_build"/>
                 <field name="in_error"/>
+                <field name="nocache"/>
                 <field name="always_pull"/>
                 <field name="version_ids" widget="many2many_tags"/>
                 <field name="project_ids" widget="many2many_tags"/>
@@ -107,6 +108,8 @@
             <field name="in_error" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
             <field name="always_pull" groups="!runbot.group_runbot_admin"/>
             <field name="always_pull" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
+            <field name="nocache" groups="!runbot.group_runbot_admin"/>
+            <field name="nocache" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
             <field name="version_ids" widget="many2many_tags"/>
             <field name="project_ids" widget="many2many_tags"/>
             <field name="use_count"/>


### PR DESCRIPTION
When building Dockerfiles, it happens that even if nothing changed in the Dockerfile itself, the image should be rebuilt.

e.g.: depending on when an image is built, an `apt-get install foobartool` may give a newer version of `foobartool`.