### PR TITLE
[IMP] runbot: only fetch commits

### DIFF
--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -106,7 +106,7 @@ class Commit(models.Model):
         export_path = self._source_path()
 
         if os.path.isdir(export_path):
-            _logger.info('git export: exporting to %s (already exists)', export_path)
+            _logger.debug('git export: exporting to %s (already exists)', export_path)
             return export_path
 
         _logger.info('git export: exporting to %s (new)', export_path)

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -524,17 +524,14 @@ class Repo(models.Model):
 
     def _fetch(self, sha):
         if not self._hash_exists(sha):
-            self._update(force=True)
+            for remote in self.remote_ids:
+                try:
+                    self._git(['fetch', remote.remote_name, sha])
+                    break
+                except subprocess.CalledProcessError:
+                    pass
             if not self._hash_exists(sha):
-                for remote in self.remote_ids:
-                    try:
-                        self._git(['fetch', remote.remote_name, sha])
-                        _logger.info('Success fetching specific head %s on %s', sha, remote)
-                        break
-                    except subprocess.CalledProcessError:
-                        pass
-                if not self._hash_exists(sha):
-                    raise RunbotException("Commit %s is unreachable. Did you force push the branch?" % sha)
+                raise RunbotException("Commit %s is unreachable, most likely because it is not attached to any branch anymore" % sha)
 
     def _hash_exists(self, commit_hash):
         """ Verify that a commit hash exists in the repo """


### PR DESCRIPTION
When runbot fetch a commit, it will try to fetch the complete repo first

The main reason is that the other commit, branches, bob, .... could be needed later, so making one call to github looks more efficient.

With the increasing number of dev branches and workers, the fetch becomes a problem and can be slow, mainly when no fetch was done for a while, and the repo has a tons of pending updates.

This pr tries another approch to only fetch the single requested commit, which could be faster.