### PR TITLE
[IMP] runbot: add a timeout on git ssh connections

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -503,8 +503,11 @@ class Repo(models.Model):
         """Execute a git command 'cmd'"""
         self.ensure_one()
         config_args = []
+        ssh_timeout = int(self.env['ir.config_parameter'].get_param('runbot.runbot_ssh_timeout', default=20))
+        ssh_args = ['-o', f'ConnectTimeout={ssh_timeout}']
         if self.identity_file:
-            config_args = ['-c', 'core.sshCommand=ssh -i %s/.ssh/%s' % (str(Path.home()), self.identity_file)]
+            ssh_args += ['-i', f'{Path.home()}/.ssh/{self.identity_file}']
+        config_args = ['-c', f'core.sshCommand=ssh {" ".join(ssh_args)}']
         cmd = ['git', '-C', self.path] + config_args + cmd
         return cmd
 

--- a/runbot/tests/test_repo.py
+++ b/runbot/tests/test_repo.py
@@ -386,7 +386,7 @@ class TestIdentityFile(RunbotCase):
         def check_output_helper(self):
             """Helper that returns a mock for repo._git()"""
             def mock_check_output(cmd, *args, **kwargs):
-                expected_option = r'-c core.sshCommand=ssh -i \/.+\/\.ssh\/fake_identity'
+                expected_option = r'-c core.sshCommand=ssh.+-i \/.+\/\.ssh\/fake_identity'
                 git_cmd = ' '.join(cmd)
                 self.assertTrue(re.search(expected_option, git_cmd), '%s did not match %s' % (git_cmd, expected_option))
                 return Mock()


### PR DESCRIPTION
In order to mitigate GitHub fetch time issue, a ConnectTimeout argument is passed to ssh through git command line configuration.