### PR TITLE
[FIX] runbot: add missing gitinit

### DIFF
--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -549,6 +549,7 @@ class Repo(models.Model):
         return output.decode(errors=errors)
 
     def _fetch(self, sha):
+        self._git_init()
         if not self._hash_exists(sha):
             for remote in self.remote_ids:
                 try:


### PR DESCRIPTION
Since we don't call update anymore, it is possible that the repo is not initialized yet.