### PR TITLE
[IMP] runbot: update repos once a day

### DIFF
--- a/runbot_builder/tools.py
+++ b/runbot_builder/tools.py
@@ -114,9 +114,14 @@ class RunbotClient():
             _logger.info('Starting git gc on repositories')
             commands = []
             host_name = self.host.name
-            for repo in self.env['runbot.repo'].search([]):
+            repos = self.env['runbot.repo'].search([('mode', '!=', 'disabled')])
+            for repo in repos:
                 commands.append((repo.name, repo._get_git_command(['gc', '--prune=all', '--quiet'])))
+                # update the repos once a day to speed up individual commit fetches
+                repo._update(force=True)
+
             self.env.cr.rollback()
+
             # gc commands can be slow, rollbacking to avoid to keep a transaction idle for multiple minutes.
             messages = []
             for repo_name, command in commands:


### PR DESCRIPTION
Since the runbot builders are only fetching individual commits, those fetches can last for a long time. It appears that fetching the whole repository periodically speeds up the individual fetches.

With this commit, the repo are fetched alongside with the git gc once a day.