### PR TITLE
[FIX] runbot: fix teams bundles done count

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -2,11 +2,11 @@
 {
     'name': "runbot",
     'summary': "Runbot",
-    'description': "Runbot for Odoo 17.0",
+    'description': "Runbot for Odoo 19.0",
     'author': "Odoo SA",
     'website': "http://runbot.odoo.com",
     'category': 'Website',
-    'version': '5.17',
+    'version': '5.18',
     'application': True,
     'depends': ['base', 'base_automation', 'website', 'auth_oauth'],
     'data': [

--- a/runbot/controllers/frontend.py
+++ b/runbot/controllers/frontend.py
@@ -104,7 +104,7 @@ class Runbot(Controller):
                 domain.append(('no_build', '=', False))
 
             if has_pr is not None:
-                domain.append(('has_pr', '=', bool(has_pr)))
+                domain.append(('has_active_pr', '=', bool(has_pr)))
 
             filter_mode = request.httprequest.cookies.get('filter_mode', 'default')
             if filter_mode == 'sticky':
@@ -908,13 +908,10 @@ class Runbot(Controller):
         if not project and projects:
             project = projects[0]
         bundles_by_team = defaultdict(list)
-        nb_bundles_done = 0
         bundles = self.env['runbot.bundle'].search([('tag_ids', 'in', bundle_tag_id.id)])
+        nb_bundles_done = len(bundles.filtered(lambda b: b.has_pr and not b.has_active_pr))
         for bundle in bundles:
             bundles_by_team[bundle.team_id.name or 'No Team Defined'].append(bundle)
-            bundle_prs = bundle.branch_ids.filtered(lambda rec: rec.is_pr)
-            if any(bundle_prs) and not any(bundle_prs.mapped('alive')):
-                nb_bundles_done += 1
 
         qctx = {
             'tag': bundle_tag_id,

--- a/runbot/migrations/19.0.5.18/pre-migration.py
+++ b/runbot/migrations/19.0.5.18/pre-migration.py
@@ -1,0 +1,3 @@
+def migrate(cr, version):
+    cr.execute("ALTER TABLE runbot_bundle RENAME COLUMN has_pr TO has_active_pr;")
+    cr.execute("COMMENT ON COLUMN runbot_bundle.has_active_pr IS 'Has Active PR';")

--- a/runbot/models/bundle.py
+++ b/runbot/models/bundle.py
@@ -38,7 +38,8 @@ class Bundle(models.Model):
     defined_base_id = fields.Many2one('runbot.bundle', 'Forced base bundle', domain="[('project_id', '=', project_id), ('is_base', '=', True)]")
     base_id = fields.Many2one('runbot.bundle', 'Base bundle', compute='_compute_base_id', store=True)
 
-    has_pr = fields.Boolean('Has PR', compute='_compute_has_pr', store=True)
+    has_pr = fields.Boolean('Has PR', compute='_compute_has_pr')
+    has_active_pr = fields.Boolean('Has Active PR', compute='_compute_has_active_pr', store=True)
 
     version_id = fields.Many2one('runbot.version', 'Version', compute='_compute_version_id', store=True, recursive=True)
     version_number = fields.Char(related='version_id.number', store=True, index=True)
@@ -124,10 +125,15 @@ class Bundle(models.Model):
             else:
                 bundle.base_id = master_base or fallback
 
-    @api.depends('branch_ids.is_pr', 'branch_ids.alive')
+    @api.depends('branch_ids.is_pr')
     def _compute_has_pr(self):
         for bundle in self:
-            bundle.has_pr = any(branch.is_pr and branch.alive for branch in bundle.branch_ids)
+            bundle.has_pr = any(bundle.branch_ids.filtered('is_pr'))
+
+    @api.depends('branch_ids.is_pr', 'branch_ids.alive')
+    def _compute_has_active_pr(self):
+        for bundle in self:
+            bundle.has_active_pr = any(branch.is_pr and branch.alive for branch in bundle.branch_ids)
 
     @tools.ormcache('project_id')
     def _get_base_ids(self, project_id):

--- a/runbot/templates/bundles_by_tag.xml
+++ b/runbot/templates/bundles_by_tag.xml
@@ -68,7 +68,7 @@
                         <t t-foreach="sorted(bundles_by_team.keys())" t-as="team">
                             <t t-set="team_bundles" t-value="bundles_by_team.get(team)"/>
                             <t t-set="nb_team_bundles" t-value="len(team_bundles)"/>
-                            <t t-set="nb_team_bundles_done" t-value="len(list(filter(lambda b: not b.has_pr, team_bundles)))"/>
+                            <t t-set="nb_team_bundles_done" t-value="len(list(filter(lambda b: b.has_pr and not b.has_active_pr, team_bundles)))"/>
                             <tbody class="table-group-divider">
                                 <tr class="table-active">
                                     <th colspan="3" class="py-1">

--- a/runbot/views/bundle_views.xml
+++ b/runbot/views/bundle_views.xml
@@ -69,6 +69,7 @@
                             <field name="base_id"/>
                             <field name="defined_base_id" readonly="is_base"/>
                             <field name="version_id"/>
+                            <field name="has_active_pr"/>
                             <field name="has_pr"/>
                         </group>
                         <group string="Testing options">
@@ -177,7 +178,7 @@
             <field name="name"/>
             <field name="version_id"/>
             <separator/>
-            <filter string="Has open pr" name="has_pr" domain="[('has_pr', '=', True)]"/>
+            <filter string="Has open pr" name="has_active_pr" domain="[('has_active_pr', '=', True)]"/>
             <filter string="No pr" name="no_pr" domain="[('branch_ids', '!=', []), '!', ('branch_ids', 'any', [('is_pr', '=', True)])]"/>
             <filter string="Is base" name="is_base" domain="[('is_base', '=', True)]"/>
             <filter string="Is sticky" name="is_sticky" domain="[('sticky', '=', True)]"/>


### PR DESCRIPTION
When counting bundles done, we need to differentiate bundles without any PR from bundles with closed PR's.

With this commit, we count the done bundles for a team using the same filter as the count for all bundles.