### PR TITLE
[IMP] runbot: create database inside docker

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1206,15 +1206,6 @@ class BuildResult(models.Model):
             host_name = self.env['runbot.host']._get_current_name()
             self.env['runbot.runbot']._warning(f'Host {host_name}: {msg}')
 
-    def _local_pg_createdb(self, dbname):
-        icp = self.env['ir.config_parameter']
-        db_template = icp.get_param('runbot.runbot_db_template', default='template0')
-        self._local_pg_dropdb(dbname)
-        _logger.info("createdb %s", dbname)
-        with local_pgadmin_cursor() as local_cr:
-            local_cr.execute(sql.SQL("""CREATE DATABASE {} TEMPLATE %s LC_COLLATE 'C' ENCODING 'unicode'""").format(sql.Identifier(dbname)), (db_template,))
-        self.env['runbot.database'].create({'name': dbname, 'build_id': self.id})
-
     def _log(self, func, message, *args, level='INFO', log_type='runbot', path='runbot'):
         def truncate(message, maxlenght=300000):
             if len(message) > maxlenght:

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -428,8 +428,8 @@ class ConfigStep(models.Model):
     dockerfile_id = fields.Many2one('runbot.dockerfile', string='Dockerfile')
     dockerfile_variant = fields.Char('Docker Variant')
     # install_odoo
-    create_db = fields.Boolean('Create Db', default=True, tracking=True)  # future
-    custom_db_name = fields.Char('Custom Db Name', tracking=True)  # future
+    create_db = fields.Boolean('Create Db', default=True, tracking=True)  # TODO remove
+    custom_db_name = fields.Char('Custom Db Name', tracking=True)
     install_modules = fields.Char('Modules to install', help="List of module patterns to install, use * to install all available modules, prefix the pattern with dash to remove the module.", default='', tracking=True)
     db_name = fields.Char('Db Name', compute='_compute_db_name', inverse='_inverse_db_name', tracking=True)
     cpu_limit = fields.Integer('Cpu limit', default=3600, tracking=True)
@@ -777,9 +777,8 @@ class ConfigStep(models.Model):
         db_suffix = config_data.get('db_name') or (build.params_id.dump_db.db_suffix if not self.create_db else False) or self._get_db_name(build)
         db_suffix = re.sub(r'[^a-z0-9\-_]', '_', db_suffix.lower())
         db_name = '%s-%s' % (build.dest, db_suffix)
-        if modules_to_install and self.create_db:
-            build._local_pg_createdb(db_name)
         cmd += ['-d', db_name]
+        self.env['runbot.database'].create({'name': db_name, 'build_id': self.id})
 
         # Demo data behavior changed in 18.1 -> demo data became opt-in instead of opt-out
         available_options = build._parse_config()
@@ -1167,7 +1166,9 @@ class ConfigStep(models.Model):
         target_suffix = config_data.get('target_suffix', self.restore_rename_db_suffix or download_db_suffix)
         restore_db_name = '%s-%s' % (build.dest, target_suffix)
 
-        build._local_pg_createdb(restore_db_name)
+        icp = self.env['ir.config_parameter']
+        db_template = icp.get_param('runbot.runbot_db_template', default='template0')
+        self.env['runbot.database'].create({'name': restore_db_name, 'build_id': self.id})
         cmd = ' && '.join([
             'mkdir /data/build/restore',
             'cd /data/build/restore',
@@ -1177,6 +1178,7 @@ class ConfigStep(models.Model):
             'mkdir -p /data/build/datadir/filestore/%s' % restore_db_name,
             'mv filestore/* /data/build/datadir/filestore/%s' % restore_db_name,
             'echo "### restoring db"',
+            'createdb %s -T %s' % (restore_db_name, db_template),
             'psql -q %s < dump.sql' % (restore_db_name),
             'echo "### performing an analyze"',
             'psql -q -d %s -c "ANALYZE;"' % restore_db_name,

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -227,7 +227,6 @@ class RunbotCase(TransactionCase):
         self.start_patcher('set_psql_conn_count', 'odoo.addons.runbot.models.host.Host._set_psql_conn_count', None)
         self.start_patcher('reload_nginx', 'odoo.addons.runbot.models.runbot.Runbot._reload_nginx', None)
         self.start_patcher('update_commits_infos', 'odoo.addons.runbot.models.batch.Batch._update_commits_infos', None)
-        self.start_patcher('_local_pg_createdb', 'odoo.addons.runbot.models.build.BuildResult._local_pg_createdb', True)
         self.start_patcher('getmtime', 'odoo.addons.runbot.common.os.path.getmtime', datetime.datetime.now().timestamp())
         self.start_patcher('file_exist', 'odoo.tools.misc.os.path.exists', True)
         self.start_patcher('_get_py_version', 'odoo.addons.runbot.models.build.BuildResult._get_py_version', 3)


### PR DESCRIPTION
To allow to run postgres in docker we cannot make any maintenance on database from outside the docker anymore, meaning that the database creations needs to be done in the docker.