### PR TITLE
19.0 use log json xdo

### DIFF
--- a/runbot/container.py
+++ b/runbot/container.py
@@ -28,7 +28,7 @@ docker_stop_failures = {}
 
 class Command():
 
-    def __init__(self, pres, cmd, posts, finals=None, config_tuples=None, cmd_checker=None):
+    def __init__(self, pres, cmd, posts, finals=None, config_tuples=None, files=None, cmd_checker=None):
         """ Command object that represent commands to run in Docker container
         :param pres: list of pre-commands
         :param cmd: list of main command only run if the pres commands succeed (&&)
@@ -44,6 +44,7 @@ class Command():
         self.finals = finals or []
         self.config_tuples = config_tuples or []
         self.cmd_checker = cmd_checker
+        self.files = files or {}
 
     def set_pres(self, pres):
         self.pres = pres
@@ -61,7 +62,7 @@ class Command():
         return self.cmd[key]
 
     def __add__(self, l):
-        return Command(self.pres, self.cmd + l, self.posts, self.finals, self.config_tuples, self.cmd_checker)
+        return Command(self.pres, self.cmd + l, self.posts, self.finals, self.config_tuples, self.files, self.cmd_checker)
 
     def __str__(self):
         return self.shell_join(self.cmd)

--- a/runbot/data/runbot_data.xml
+++ b/runbot/data/runbot_data.xml
@@ -31,6 +31,7 @@ admin_passwd=running_master_password</field>
         </record>
 
         <record model="ir.config_parameter" id="runbot.runbot_default_logdb_name">
+            <!--TODO cleanup remove-->
             <field name="key">runbot.logdb_name</field>
             <field name="value">runbot_logs</field>
         </record>

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -28,7 +28,6 @@ from ..common import (
     dest_reg,
     dt2time,
     findall,
-    grep,
     list_local_dbs,
     local_pgadmin_cursor,
     markdown_escape,
@@ -1435,39 +1434,31 @@ class BuildResult(models.Model):
             cmd += ['--addons-path', ",".join(addons_paths)]
 
         # options
-        config_path = build._server("tools/config.py")
-        if grep(config_path, "no-xmlrpcs"):  # move that to configs ?
-            cmd.append("--no-xmlrpcs")
-        if grep(config_path, "no-netrpc"):
-            cmd.append("--no-netrpc")
-
+        available_options = build._parse_config()
         pres += self.params_id.config_data.get('pres', [])
         posts = self.params_id.config_data.get('posts', [])
         finals = self.params_id.config_data.get('finals', [])
         config_tuples = self.params_id.config_data.get('config_tuples', [])
 
-        command = Command(pres, cmd, posts, finals=finals, config_tuples=config_tuples, cmd_checker=build) 
+        command = Command(pres, cmd, posts, finals=finals, config_tuples=config_tuples, cmd_checker=build)
 
         # use the username of the runbot host to connect to the databases
         command.add_config_tuple('db_user', '%s' % pwd.getpwuid(USERUID).pw_name)
 
-        if local_only:
-            if grep(config_path, "--http-interface"):
+        if "--http-interface" in available_options:
+            if local_only:
                 command.add_config_tuple("http_interface", "127.0.0.1")
-            elif grep(config_path, "--xmlrpc-interface"):
-                command.add_config_tuple("xmlrpc_interface", "127.0.0.1")
-        else:
-            if grep(config_path, "--http-interface"):
+            else:
                 command.add_config_tuple("http_interface", "0.0.0.0")
 
         if enable_log_db:
             log_db = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
-            if grep(config_path, "log-db"):
+            if "--log-db" in available_options:
                 command.add_config_tuple("log_db", log_db)
-                if grep(config_path, 'log-db-level'):
+                if "--log-db-level" in available_options:
                     command.add_config_tuple("log_db_level", '25')
 
-        if grep(config_path, "data-dir"):
+        if "--data-dir" in available_options:
             datadir = build._path('datadir')
             if not os.path.exists(datadir):
                 os.mkdir(datadir)

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -725,6 +725,7 @@ class BuildResult(models.Model):
             for _id in self.exists().ids:
                 additionnal_conditions.append("datname like '%s-%%'" % _id)
 
+        # TODO cleanup remove
         log_db = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
         existing_db = [db for db in list_local_dbs(additionnal_conditions=additionnal_conditions) if db != log_db]
 
@@ -906,7 +907,7 @@ class BuildResult(models.Model):
                         build._log('_schedule', 'Docker with state %s not started after 60 seconds, skipping' % _docker_state, level='ERROR')
                     else:
                         build._log('_schedule', 'Docker was likely killed, skipping%s' % details, level='ERROR')
-            if self.env['runbot.host']._fetch_local_logs(build_ids=build.ids):
+            if self.env['runbot.host']._fetch_local_logs(builds=build)[0]:
                 return True  # avoid to make results with remaining logs
             # No job running, make result and select next job
             if build.docker_start:
@@ -1056,6 +1057,8 @@ class BuildResult(models.Model):
             rc_content = cmd.get_config(starting_config=starting_config)
             if step.check_exit_status:
                 cmd.finals = [['echo', r'$?', '>', f'/data/build/logs/{step.sanitized_name(self)}_exit_status.txt']] + cmd.finals
+            for filepath, content in cmd.files.items():
+                self._write_file(filepath, content)
         else:
             rc_content = starting_config
         self._write_file('.odoorc', rc_content)
@@ -1444,7 +1447,6 @@ class BuildResult(models.Model):
 
         # use the username of the runbot host to connect to the databases
         command.add_config_tuple('db_user', '%s' % pwd.getpwuid(USERUID).pw_name)
-
         if "--http-interface" in available_options:
             if local_only:
                 command.add_config_tuple("http_interface", "127.0.0.1")
@@ -1452,6 +1454,31 @@ class BuildResult(models.Model):
                 command.add_config_tuple("http_interface", "0.0.0.0")
 
         if enable_log_db:
+            if '--log-config' in available_options:
+                command.add_config_tuple("log_config", '/data/build/logconfig.json')
+                command.files['odoo_log.seek'] = "0"
+                command.files['logconfig.json'] = """{
+  "version": 1,
+  "keep_odoo_default": true,
+  "formatters": {
+    "runbot": {
+      "()": "odoo.logging.JSONFormatter",
+      "record_keys": ["dbname", "name", "levelname", "pathname", "funcName", "lineno", "test", "created", "message"]
+    }
+  },
+  "handlers": {
+    "runbot": {
+      "class": "logging.handlers.WatchedFileHandler",
+      "formatter": "runbot",
+      "filename": "logs/%s_logs.json",
+      "level": "RUNBOT"
+    }
+  },
+  "root": {
+    "handlers": ["runbot"]
+  }
+}""" % self.active_step.sanitized_name(self)
+            # TODO cleanup remove
             log_db = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
             if "--log-db" in available_options:
                 command.add_config_tuple("log_db", log_db)
@@ -1463,7 +1490,6 @@ class BuildResult(models.Model):
             if not os.path.exists(datadir):
                 os.mkdir(datadir)
             command.add_config_tuple("data_dir", '/data/build/datadir')
-
         return command
 
     def _cmd_check(self, cmd):

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -294,8 +294,8 @@ class Host(models.Model):
 
                             new_seek = f.tell()
                             res.append(log_data)
-                        except Exception as e:
-                            _logger.exception('Failed to parse log line: %s', e)
+                        except (KeyError, json.JSONDecodeError):
+                            _logger.exception('Failed to parse log line:')
                             break
 
                 if new_seek != seek:
@@ -325,7 +325,7 @@ class Host(models.Model):
                 local_cr.execute(query, build_ids)
                 col_names = [col.name for col in local_cr.description]
                 for row in local_cr.fetchall():
-                    vals = {name: value for name, value in zip(col_names, row)}
+                    vals = dict(zip(col_names, row))
                     res.append(vals)
                     log_to_delete = vals.pop('id')
             if log_to_delete:
@@ -347,9 +347,9 @@ class Host(models.Model):
             if not log.get('build_id'):  # TODO cleanup remove condition, not needed once using only json log
                 try:
                     log['build_id'] = int(log['dbname'].split('-', maxsplit=1)[0])
-                except Exception:
+                except (ValueError, AttributeError, KeyError):
                     if log.get('id'):
-                        local_log_ids.append(log['id']) # TODO cleanup remove not needed once using only json log
+                        local_log_ids.append(log['id'])  # TODO cleanup remove not needed once using only json log
             if log.get('build_id'):
                 logs_by_build_id[log['build_id']].append(log)
 

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -1,3 +1,5 @@
+import datetime
+import json
 import logging
 
 from collections import defaultdict
@@ -78,6 +80,7 @@ class Host(models.Model):
         return super().create(vals_list)
 
     def _bootstrap_local_logs_db(self):
+        # TODO cleanup remove
         """ bootstrap a local database that will collect logs from builds """
         logs_db_name = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
         if logs_db_name not in list_local_dbs():
@@ -260,54 +263,103 @@ class Host(models.Model):
         if nb_reserved < (nb_hosts / 2):
             self.assigned_only = True
 
-    def _fetch_local_logs(self, build_ids=None):
-        """ fetch build logs from local database """
-        logs_db_name = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
-        with local_pg_cursor(logs_db_name) as local_cr:
-            res = []
-            where_clause = "WHERE split_part(dbname, '-', 1) IN %s" if build_ids else ''
-            query = f"""
-                    SELECT *
-                    FROM (
-                            SELECT id, create_date, name, level, dbname, func, path, line, type, message, split_part(dbname, '-', 1) as build_id, metadata
-                            FROM ir_logging
-                            )
-                        AS ir_logs
-                    {where_clause}
-                ORDER BY id
-                LIMIT 10000
-                """
-            if build_ids:
-                build_ids = [tuple(str(build) for build in build_ids)]
-            local_cr.execute(query, build_ids)
-            col_names = [col.name for col in local_cr.description]
-            for row in local_cr.fetchall():
-                res.append({name:value for name, value in zip(col_names, row)})
-            return res
+    def _fetch_local_logs(self, builds=None):
+        res = []
+        cleanups = []
+        for build in builds:
+            if build._is_file('odoo_log.seek'):
+                new_seek = seek = int(build._read_file('odoo_log.seek'))
+                log_file_path = 'logs/%s_logs.json' % build.active_step.sanitized_name(build)
+                if not build._is_file(log_file_path):
+                    continue
+                with open(build._path(log_file_path), encoding='utf-8') as f:
+                    f.seek(seek)
+                    for line in f.readlines():
+                        try:
+                            json_log = json.loads(line)
+                            log_data = {
+                                'create_date': datetime.datetime.fromtimestamp(float(json_log['created'])) if json_log.get('created') else datetime.datetime.now(),
+                                'level': str(json_log.get('levelname', 'INFO')),
+                                'name': str(json_log.get('name', '')),
+                                'dbname': str(json_log.get('dbname', '')),
+                                'func': str(json_log.get('funcName', '')),
+                                'path': str(json_log.get('pathname', '')),
+                                'line': str(json_log.get('lineno', '')),
+                                'type': 'server',
+                                'message': str(json_log.get('message', '')),
+                                'build_id': build.id,
+                            }
+                            if json_log.get('test'):
+                                log_data['metadata'] = {'test': json_log.get('test')}
 
-    def _process_logs(self, build_ids=None):
+                            new_seek = f.tell()
+                            res.append(log_data)
+                        except Exception as e:
+                            _logger.exception('Failed to parse log line: %s', e)
+                            break
+
+                if new_seek != seek:
+                    def cleanup(build=build, new_seek=new_seek):
+                        build._write_file('odoo_log.seek', str(new_seek))
+                    cleanups.append(cleanup)
+                continue
+
+            # TODO cleanup remove
+            log_to_delete = []
+            build_ids = build.ids
+            logs_db_name = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
+            with local_pg_cursor(logs_db_name) as local_cr:
+                where_clause = "WHERE split_part(dbname, '-', 1) IN %s" if build_ids else ''
+                query = f"""
+                        SELECT *
+                        FROM (
+                                SELECT id, create_date, name, level, dbname, func, path, line, type, message, metadata
+                                FROM ir_logging
+                                )
+                            AS ir_logs
+                        {where_clause}
+                    ORDER BY id
+                    LIMIT 10000
+                    """
+                build_ids = [tuple(str(build) for build in build_ids)]
+                local_cr.execute(query, build_ids)
+                col_names = [col.name for col in local_cr.description]
+                for row in local_cr.fetchall():
+                    vals = {name: value for name, value in zip(col_names, row)}
+                    res.append(vals)
+                    log_to_delete = vals.pop('id')
+            if log_to_delete:
+                def cleanup(log_to_delete=log_to_delete):
+                    logs_db_name = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
+                    with local_pg_cursor(logs_db_name) as local_cr:
+                        local_cr.execute("DELETE FROM ir_logging WHERE id in %s", [tuple(log_to_delete)])
+                cleanups.append(cleanup)
+
+        return res, cleanups
+
+    def _process_logs(self, testing_builds):
         """move logs from host to the leader"""
-        ir_logs = self._fetch_local_logs()
+        ir_logs, cleanups = self._fetch_local_logs(testing_builds)
         logs_by_build_id = defaultdict(list)
 
         local_log_ids = []
         for log in ir_logs:
-            if log['dbname'] and '-' in log['dbname']:
+            if not log.get('build_id'):  # TODO cleanup remove condition, not needed once using only json log
                 try:
-                    logs_by_build_id[int(log['dbname'].split('-', maxsplit=1)[0])].append(log)
-                except ValueError:
-                    pass
-            else:
-                local_log_ids.append(log['id'])
-
-        builds = self.env['runbot.build'].browse(logs_by_build_id.keys())
+                    log['build_id'] = int(log['dbname'].split('-', maxsplit=1)[0])
+                except Exception:
+                    if log.get('id'):
+                        local_log_ids.append(log['id']) # TODO cleanup remove not needed once using only json log
+            if log.get('build_id'):
+                logs_by_build_id[log['build_id']].append(log)
 
         logs_to_send = []
-        for build in builds.exists():
+        for build in testing_builds:
             log_counter = build.log_counter
             build_logs = logs_by_build_id[build.id]
             for ir_log in build_logs:
-                local_log_ids.append(ir_log['id'])
+                if 'id' in ir_log:  # TODO cleanup
+                    local_log_ids.append(ir_log['id'])
                 ir_log['type'] = 'server'
                 log_counter -= 1
                 if log_counter == 0:
@@ -322,16 +374,15 @@ class Host(models.Model):
                         ir_log['message'] = ir_log['message'][:10000] + "\n ...<message too long, truncated>"
 
                 ir_log['build_id'] = build.id
-                logs_to_send.append({k:ir_log[k] for k in ir_log if k != 'id'})
+                logs_to_send.append(ir_log)
             build.log_counter = log_counter
 
         if logs_to_send:
             self.env['ir.logging'].create(logs_to_send)
         self.env.cr.commit()  # we don't want to remove local logs that were not inserted in main runbot db
-        if local_log_ids:
-            logs_db_name = self.env['ir.config_parameter'].get_param('runbot.logdb_name')
-            with local_pg_cursor(logs_db_name) as local_cr:
-                local_cr.execute("DELETE FROM ir_logging WHERE id in %s", [tuple(local_log_ids)])
+
+        for cleanup in cleanups:
+            cleanup()
 
     def _get_build_domain(self, domain=None):
         domain = domain or []

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -55,7 +55,8 @@ class Runbot(models.AbstractModel):
             self._commit()
         if host._process_messages():
             self._commit()
-        host._process_logs()
+        testing_builds = host._get_builds([('local_state', '=', 'testing')])
+        host._process_logs(testing_builds)
         self._commit()
         for build in host._get_builds([('local_state', 'in', ['testing', 'running'])]) | self._get_builds_to_init(host):
             build = build.browse(build.id)  # remove preftech ids, manage build one by one

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -278,7 +278,7 @@
                 <t t-set="logclass" t-value="dict(CRITICAL='danger', ERROR='danger', WARNING='warning', OK='success', SEPARATOR='separator').get(l.level)"/>
                 <tr t-att-class="'separator' if logclass == 'separator' else 'log-' + l.type" t-att-title="l.active_step_id.description or ''">
                   <td style="white-space: nowrap; width:1%;">
-                    <small t-out="l.create_date.strftime('%Y-%m-%d %H:%M:%S')"/>
+                    <small t-out="l.create_date.strftime('%Y-%m-%d %H:%M:%S') if l.create_date else ''"/>
                   </td>
                   <td style="white-space: nowrap; width:1%;">
                     <t t-if="l.level != 'SEPARATOR' and l.type not in ['link', 'markdown']">

--- a/runbot/tests/common.py
+++ b/runbot/tests/common.py
@@ -232,7 +232,8 @@ class RunbotCase(TransactionCase):
         self.start_patcher('file_exist', 'odoo.tools.misc.os.path.exists', True)
         self.start_patcher('_get_py_version', 'odoo.addons.runbot.models.build.BuildResult._get_py_version', 3)
         self.start_patcher('_write_file', 'odoo.addons.runbot.models.build.BuildResult._write_file', None)
-        self.start_patcher('_parse_config', 'odoo.addons.runbot.models.build.BuildResult._parse_config', {'--test-enable', '--test-tags', '--with-demo'})
+        self.start_patcher('_parse_config', 'odoo.addons.runbot.models.build.BuildResult._parse_config', {'--test-enable', '--test-tags', '--with-demo', '--log-config'})
+        self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', ([], []))
 
         def _list_available_modules(self_commit):
             return self.addons_per_repo.get(self_commit.repo_id, [])

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -378,14 +378,13 @@ class TestBuildResult(RunbotCase):
 
         self.assertEqual(modules_to_test, sorted(['other_mod_2']))
 
-    def test_build_cmd_log_db(self):
+    def test_build_cmd_log_config(self):
         """ test that the log_db parameter is set in the .odoorc file """
         build = self.Build.create({
             'params_id': self.server_params.id,
         })
         cmd = build._cmd(py_version=3)
-        self.assertIn('log_db = runbot_logs', cmd.get_config())
-
+        self.assertIn('log_config = /data/build/logconfig.json', cmd.get_config())
 
     def test_build_cmd_custom_pre_post(self):
         """ test that the log_db parameter is set in the .odoorc file """

--- a/runbot/tests/test_host.py
+++ b/runbot/tests/test_host.py
@@ -1,6 +1,6 @@
 import logging
 
-from unittest.mock import call
+from unittest.mock import call, MagicMock
 
 from .common import RunbotCase
 
@@ -12,6 +12,7 @@ def fetch_local_logs_return_value(nb_logs=10, message='', log_type='server', lev
 
     log_date = datetime(2022, 8, 17, 21, 55)
     logs = []
+    cleanups = []
     for i in range(nb_logs):
         logs += [{
             'id': i,
@@ -25,8 +26,9 @@ def fetch_local_logs_return_value(nb_logs=10, message='', log_type='server', lev
             'type': log_type,
             'message': '75 modules loaded in 0.92s, 717 queries (+1 extra)' if message == '' else message,
         }]
+        cleanups.append(MagicMock())
         log_date += timedelta(seconds=20)
-    return logs
+    return (logs, cleanups)
 
 class TestHost(RunbotCase):
 
@@ -68,9 +70,9 @@ class TestHost(RunbotCase):
 
         # check that local logs are inserted in leader ir.logging
         logs = fetch_local_logs_return_value(build_dest=build.dest)
-        self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', logs)
-        self.test_host._process_logs()
-        self.patchers['host_local_pg_cursor'].assert_called()
+        self.patchers['fetch_local_logs'].return_value = logs
+        self.test_host._process_logs(build)
+        logs[1][0].assert_called()
         self.assertEqual(
             self.env['ir.logging'].search_count([
                 ('build_id', '=', build.id),
@@ -82,8 +84,8 @@ class TestHost(RunbotCase):
         # check that a warn log sets the build in warning
         logs = fetch_local_logs_return_value(nb_logs=1, build_dest=build.dest, level='WARNING')
         self.patchers['fetch_local_logs'].return_value = logs
-        self.test_host._process_logs()
-        self.patchers['host_local_pg_cursor'].assert_called()
+        self.test_host._process_logs(build)
+        logs[1][0].assert_called()
         self.assertEqual(
             self.env['ir.logging'].search_count([
                 ('build_id', '=', build.id),
@@ -97,8 +99,8 @@ class TestHost(RunbotCase):
         # now check that error logs sets the build in ko
         logs = fetch_local_logs_return_value(nb_logs=1, build_dest=build.dest, level='ERROR')
         self.patchers['fetch_local_logs'].return_value = logs
-        self.test_host._process_logs()
-        self.patchers['host_local_pg_cursor'].assert_called()
+        self.test_host._process_logs(build)
+        logs[1][0].assert_called()
         self.assertEqual(
             self.env['ir.logging'].search_count([
                 ('build_id', '=', build.id),
@@ -113,8 +115,8 @@ class TestHost(RunbotCase):
         # Test log limit
         logs = fetch_local_logs_return_value(nb_logs=11, message='test log limit', build_dest=build.dest)
         self.patchers['fetch_local_logs'].return_value = logs
-        self.test_host._process_logs()
-        self.patchers['host_local_pg_cursor'].assert_called()
+        self.test_host._process_logs(build)
+        logs[1][0].assert_called()
 
     def test_docker_builder_existing_image(self):
         self.start_patcher('build_patcher', 'odoo.addons.runbot.models.docker.Dockerfile._build')

--- a/runbot/tests/test_schedule.py
+++ b/runbot/tests/test_schedule.py
@@ -34,11 +34,10 @@ class TestSchedule(RunbotCase):
         })
         mock_docker_state.return_value = 'UNKNOWN'
         self.assertEqual(build.local_state, 'testing')
-        build._schedule()  # too fast, docker not started
+        build._schedule()
         self.assertEqual(build.local_state, 'testing')
         self.assertEqual(build.local_result, 'ok')
 
-        self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', [])  # the local logs have to be empty
         build.write({'docker_start': datetime.datetime.now() - datetime.timedelta(seconds=70)})  # docker never started
 
         with patch('odoo.addons.runbot.common.file_open', mock_open(read_data='')):

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -335,8 +335,6 @@ class TestUpgradeFlow(RunbotCase):
         self.nightly_batches_per_version[name] = batch_nigthly
         self.nightly_single_per_version[name] = single_module_build
 
-
-
     @patch('odoo.addons.runbot.models.build.BuildResult._parse_config')
     def test_all(self, *_):
         # Test setup
@@ -560,7 +558,7 @@ class TestUpgradeFlow(RunbotCase):
                     )
                     self.assertEqual(
                         str(cmd),
-                        'python3 odoo/server.py {addons_path} --no-xmlrpcs --no-netrpc -u all -d {db_name} --stop-after-init --max-cron-threads=0 --upgrade-path upgrade/migrations'.format(
+                        'python3 odoo/server.py {addons_path} -u all -d {db_name} --stop-after-init --max-cron-threads=0 --upgrade-path upgrade/migrations'.format(
                             addons_path='--addons-path enterprise,odoo/addons,odoo/core/addons',
                             db_name=f'{current_build.dest}-{suffix}')
                     )

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -349,7 +349,6 @@ class TestUpgradeFlow(RunbotCase):
         master_template_build = master_batch.slot_ids.filtered(lambda slot: slot.trigger_id == self.trigger_template).build_id
         self.assertEqual(sorted(master_batch.reference_batch_ids), sorted(self.batches_per_version.values()))
         master_upgrade_build._schedule()
-        self.start_patcher('fetch_local_logs', 'odoo.addons.runbot.models.host.Host._fetch_local_logs', [])  # the local logs have to be empty
         master_upgrade_build._schedule()
         self.assertEqual(master_upgrade_build.local_state, 'done')
         self.assertEqual(len(master_upgrade_build.children_ids), 2)

--- a/runbot_builder/tools.py
+++ b/runbot_builder/tools.py
@@ -263,20 +263,23 @@ def docker_monitoring_loop(builds_dir):
         try:
             stats_per_docker = dict()
             for container in docker_client.containers.list(filters={'status': 'running'}):
-                if re.match(r'^\d+-.+_.+', container.name):
-                    dest, suffix = container.name.split('_', maxsplit=1)
-                    container_log_dir = builds_dir / dest / 'logs'
-                    if not container_log_dir.exists():
-                        _logger.warning('Log dir not found: `%s`', container_log_dir)
-                        continue
-                    current_stats = get_docker_stats(container.id)
-                    previous_stats = previous_stats_per_docker.get(container.name)
-                    previous_stats, log_line = prepare_stats_log(dest, previous_stats, current_stats)
-                    if log_line:
-                        stat_log_file = container_log_dir / f'{suffix}-stats.txt'
-                        with open(stat_log_file, mode='a') as f:
-                            f.write(f'{log_line}\n')
-                    stats_per_docker[container.name] = previous_stats
+                try:
+                    if re.match(r'^\d+-.+_.+', container.name):
+                        dest, suffix = container.name.split('_', maxsplit=1)
+                        container_log_dir = builds_dir / dest / 'logs'
+                        if not container_log_dir.exists():
+                            _logger.warning('Log dir not found: `%s`', container_log_dir)
+                            continue
+                        current_stats = get_docker_stats(container.id)
+                        previous_stats = previous_stats_per_docker.get(container.name)
+                        previous_stats, log_line = prepare_stats_log(dest, previous_stats, current_stats)
+                        if log_line:
+                            stat_log_file = container_log_dir / f'{suffix}-stats.txt'
+                            with open(stat_log_file, mode='a', encoding='utf-8') as f:
+                                f.write(f'{log_line}\n')
+                        stats_per_docker[container.name] = previous_stats
+                except docker.errors.NotFound:
+                    continue
             previous_stats_per_docker = stats_per_docker
             time.sleep(1)
         except Exception as e:


### PR DESCRIPTION
Historically, runbot was receiving logs using the log-db mechanism. 

This solution needs to have a database that is both reachable by the builder process, and the running process. 

A future change is planning to use a postgres inside the docker in order to ensure that the PostgreSQL version is the same as the os one, and improve the isolation of the build.

This will make the communication between the build and the builder more difficult using PostgreSQL. 

Since https://github.com/odoo/odoo/pull/270562 (and backports) it is possible to configure a Json formater in odoo loggin, in order to output some logs and extra in a json file.

This pr introduces a way to use this log config and switches to this mode. 

For now, both options (json and db) are supported, but log-db option will be removed in a followup pr. 