### PR TITLE
[FIX] git-fw: parse remotes on partial clones

### DIFF
--- a/runbot_merge/scripts/git-fw
+++ b/runbot_merge/scripts/git-fw
@@ -196,7 +196,7 @@ def remotes() -> typing.Iterator[tuple[str, str, str]]:
             \x20
             \((?P<kind>.+)\)
             # promisor filters
-            (?: \[.*])?
+            (?:\x20\[.*])?
             ''',
             line,
             re.VERBOSE,


### PR DESCRIPTION
On partial clones, `git remote -v` prints "... (fetch) [blob:none]". 
We are supposed to catch this pattern with the `(?: \[.*])?`
However, since we are using `re.VERBOSE`, the unescaped white space in 
the previous pattern got removed from the pattern, i.e. it would have matched 
"... (fetch)[blob:none]" instead of "... (fetch) [blob:none]". 
We explicitly use `\x20` as done in other places of that same pattern.