### PR TITLE
[IMP] runbot: improve runbot slot visuals

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -584,6 +584,7 @@ class BatchLog(models.Model):
 
 
 fa_link_types = {'created': 'hashtag', 'matched': 'link', 'rebuild': 'refresh'}
+fa_results = {'ok': 'check', 'warn': 'exclamation-triangle', 'skipped': 'ban', 'ko': 'times'}
 
 class BatchSlot(models.Model):
     _name = 'runbot.batch.slot'
@@ -611,6 +612,11 @@ class BatchSlot(models.Model):
 
     def _fa_link_type(self):
         return fa_link_types.get(self.link_type, 'exclamation-triangle')
+
+    def _fa_result(self):
+        #if self.build_id.global_result == "ok" and self.build_id.global_state != "done":
+        #    return 'spinner fa-spin'
+        return fa_results.get(self.build_id.global_result, '')
 
     def _create_missing_build(self):
         """Create a build when the slot does not have one"""

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -4,6 +4,7 @@
 	--btn-default-bg: var(--bs-body-bg);
 	--btn-default-border: #ccc;
 	--active-project-color: #777;
+	--text-color-link: #507279;
 }
 
 /*
@@ -29,6 +30,7 @@
 :root[data-bs-theme=dark] {
 	--btn-default-border: #333;
 	--active-project-color: #CCC;
+	--text-color-link: #97d4e0;
 }
 
 [data-bs-theme=legacy] .text-bg-info {
@@ -277,6 +279,11 @@ body, .table {
 .slot_button_group {
 	display: flex;
 	padding: 0 1px;
+}
+
+.slot_link_matched > .slot_name {
+	--bs-btn-color: var(--text-color-link);
+	font-style: italic;
 }
 
 .slot_button_group .btn {

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -87,7 +87,7 @@
       <t t-if="batch.state=='done' and all(slot.build_id.global_result == 'ok' for slot in batch.slot_ids if slot.build_id)" t-set="klass">success</t>
       <t t-if="batch.state=='done' and any(slot.build_id.global_result in ('ko', 'warn') for slot in batch.slot_ids)" t-set="klass">danger</t>
 
-      <div t-attf-class="batch_tile if more">
+      <div t-attf-class="batch_tile">
         <div t-attf-class="card bg-{{klass}}-subtle">
           <a t-attf-href="/runbot/batch/#{batch.id}" t-att-title="batch.create_date.strftime('%Y-%m-%d %H:%M:%S')">
             <div class="batch_header">

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -279,12 +279,14 @@
         <template id="runbot.slot_button">
             <t t-set="bu" t-value="slot.build_id"/>
             <t t-set="color" t-value="bu._get_color_class()"/>
-            <div t-attf-class="btn-group btn-group-ssm slot_button_group">
-                <span t-attf-class="btn btn-{{color}} disabled" t-att-title="slot.link_type">
-                    <i t-attf-class="fa fa-{{slot._fa_link_type()}}"/>
+            <div t-attf-class="btn-group btn-group-ssm slot_button_group {{'slot_link_created' if slot.link_type == 'created' else 'slot_link_matched'}}">
+                <span t-attf-class="btn btn-{{color}} disabled">
+                    <i t-if="slot.build_id.global_state in ('testing', 'pending', 'waiting')" class="fa fa-spinner fa-spin fa-fw"/>
+                    <i t-else="" t-attf-class="fa fa-{{slot._fa_result()}} fa-fw"/>
                 </span>
                 <a t-if="slot.params_id.config_id == slot.trigger_id.light_config_id" class="badge btn btn-info" t-attf-href="/runbot/bundle/{{slot.batch_id.bundle_id.id}}">Light</a>
                 <a t-if="bu" t-attf-href="/runbot/batch/{{slot.batch_id.id}}/build/#{bu.id}" t-attf-class="btn btn-default slot_name">
+                    <!--i t-if="slot.link_type != 'created'" t-att-title="slot.link_type" t-attf-class="fa fa-{{slot._fa_link_type()}}"/-->
                     <span t-out="slot.trigger_id.name"/>
                 </a>
                 <span t-else="" t-attf-class="btn btn-default disabled slot_name">
@@ -354,8 +356,8 @@
         </template>
 
         <template id="runbot.build_menu">
-            <button t-attf-class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown" title="Build options" aria-label="Build options" aria-expanded="false">
-                <i t-attf-class="fa  {{'fa-spinner' if bu.global_state == 'pending' else 'fa-cog'}} {{'' if bu.global_state in ('done', 'running') else 'fa-spin'}} fa-fw"/>
+            <button t-attf-class="btn {{'btn-default' if bu.global_state not in ('waiting', 'pending', 'testing') else 'btn-info'}} dropdown-toggle" data-bs-toggle="dropdown" title="Build options" aria-label="Build options" aria-expanded="false">
+                <i t-attf-class="fa  {{'fa-spinner' if bu.global_state == 'pending' else 'fa-cog'}} fa-fw"/>
                 <span class="caret"/>
             </button>
             <div class="dropdown-menu dropdown-menu-end" role="menu">


### PR DESCRIPTION
The main motivation is to make the difference between testing and done build more obvious, especially when in failure

In the first batch it may look like the Enterprise Test (yellow) is finished, even if it is not the case. The only visual clue is that the cog is spinning. 

This is made more obvious with two changes: 
- The cog menu will appear blue if the build is pending/testing/waiting. 
- the match type icon is replace with a state/result icon. The icon represent the state (spinner) when the build is still running and replaced by an icon giving the result once done (making it more obvious for color blind people, in addition to the custom theme)
- the match type information is transferred to the trigger name, italic and blue when it is a link to an existing build.


Before 

<img width="792" height="284" alt="image" src="https://github.com/user-attachments/assets/1bce3fa2-d0bb-40dc-af10-5c89d53863ca" />


After

<img width="792" height="300" alt="image" src="https://github.com/user-attachments/assets/fac91bfa-280f-478d-8039-ab7118d11601" />
