### PR TITLE
[IMP] runbot: Add a backup service to the runbot

### DIFF
--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -1089,8 +1089,7 @@ class BuildResult(models.Model):
         return self.env['runbot.runbot']._path('build', self.dest, *paths)
 
     def _http_log_url(self):
-        use_ssl = self.env['ir.config_parameter'].get_param('runbot.use_ssl', default=True)
-        return '%s://%s/runbot/static/build/%s/logs/' % ('https' if use_ssl else 'http', self.host, self.dest)
+        return f'{self.host_id._build_url(self)}logs/'
 
     def _server(self, *path):
         """Return the absolute path to the direcory containing the server file, adding optional *path"""

--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -1160,10 +1160,20 @@ class ConfigStep(models.Model):
                 download_db_suffix = config_data.get('dump_suffix', self.restore_download_db_suffix or 'all')
                 dump_build = build.parent_id
             assert download_db_suffix and dump_build
-            download_db_name = '%s-%s' % (dump_build.dest, download_db_suffix)
-            zip_name = '%s.zip' % download_db_name
-            dump_url = '%s%s' % (dump_build._http_log_url(), zip_name)
-            build._log('test-migration', 'Restoring dump [%s](%s) from build [%s](%s)', zip_name, dump_url, dump_build.id, dump_build.build_url, log_type='markdown')
+            download_db_name = f'{dump_build.dest}-{download_db_suffix}'
+            zip_name = f'{download_db_name}.zip'
+            dump_url = f'{dump_build._http_log_url()}{zip_name}'
+            use_backup = False
+            if dump_build.trigger_id.backup_databases and requests.head(dump_url, timeout=5).status_code != 200:
+                for backup_host in self.env['runbot.host'].search([('is_backup', '=', True)]):
+                    backup_url = f'{backup_host._backup_url()}{zip_name}'
+                    if requests.head(backup_url, timeout=5).status_code == 200:
+                        build._log('_run_restore', 'Dump [%s](%s) from build [%s](%s) is missing, using [backup](%s)', zip_name, dump_url, dump_build.id, dump_build.build_url, backup_url, log_type='markdown')
+                        dump_url = backup_url
+                        use_backup = True
+                        break
+            if not use_backup:
+                build._log('_run_restore', 'Restoring dump [%s](%s) from build [%s](%s)', zip_name, dump_url, dump_build.id, dump_build.build_url, log_type='markdown')
         target_suffix = config_data.get('target_suffix', self.restore_rename_db_suffix or download_db_suffix)
         restore_db_name = '%s-%s' % (build.dest, target_suffix)
 

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -51,6 +51,7 @@ class Host(models.Model):
     is_leader = fields.Boolean('Is leader', help='This host is the leader of the cluster', default=False)
     is_builder = fields.Boolean('Is builder', help='This host is a builder of the cluster', default=True)
     is_registry = fields.Boolean('Is docker registry', help='This host is a docker regisrty', default=False)
+    is_backup = fields.Boolean('Is backup', help='This host backup the most important databases', default=False)
     send_status = fields.Boolean('Send status', help='If leader, this host will send status updates, disable to use the status service', default=True)
 
     use_remote_docker_registry = fields.Boolean('Use remote Docker Registry', default=False, help="Use docker registry for pulling images")
@@ -71,6 +72,17 @@ class Host(models.Model):
     def _compute_build_ids(self):
         for host in self:
             host.build_ids = self.env['runbot.build'].search([('host', '=', host.name), ('local_state', 'in', ('pending', 'testing', 'running'))])
+
+    def _static_url(self):
+        use_ssl = self.env['ir.config_parameter'].get_param('runbot.use_ssl', default=True)
+        scheme = 'https' if use_ssl else 'http'
+        return f'{scheme}://{self.name}/runbot/static/'
+
+    def _build_url(self, build):
+        return f'{self._static_url()}build/{build.dest}/'
+
+    def _backup_url(self):
+        return f'{self._static_url()}backups/'
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -77,6 +77,7 @@ class Trigger(models.Model):
     light_config_id = fields.Many2one('runbot.build.config', string="Light config", help="Alternative config to use when light mode is enabled")
     config_data = JsonDictField('Config Data')
     network_enabled = fields.Boolean('Network Enabled')
+    backup_databases = fields.Boolean('Backup Databases', help="If checked, builds from this trigger will be backed up by the backup host for sticky bundles")
     batch_dependent = fields.Boolean('Batch Dependent', help="Force adding batch in build parameters to make it unique and give access to bundle")
     version_dependent = fields.Boolean('Version Dependent', default=True, help="Add the version in build parameters. Uncheck if the version is not needed to determine the build result")
 

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -7,7 +7,7 @@ import signal
 import subprocess
 import time
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import docker
 from requests.exceptions import HTTPError
@@ -364,6 +364,33 @@ class Runbot(models.AbstractModel):
             message = f'Starting registry failed with exception: {e}'
             self.warning(message)
             _logger.error(message)
+
+    def _backup_databases(self):
+        icp = self.env['ir.config_parameter'].sudo()
+        db_gc_days = int(icp.get_param('runbot.db_gc_days', default=30))
+        min_create_date = datetime.now() - timedelta(days=db_gc_days)
+        batches_to_backup = self.env['runbot.batch'].search([('bundle_id.sticky', '=', True), ('create_date', '>', min_create_date)])
+        builds_to_backup = batches_to_backup.slot_ids.filtered('trigger_id.backup_databases').build_id
+        backup_location = self._path('backups')
+        os.makedirs(backup_location, exist_ok=True)
+        existing_backups = {f.removesuffix('.zip') for f in os.listdir(backup_location) if f.endswith('.zip')}
+        _logger.info('Checking %s databases', len(builds_to_backup.database_ids))
+        for database in builds_to_backup.database_ids:
+            if database.name in existing_backups:
+                existing_backups.discard(database.name)
+                continue
+            _logger.info('Backing up database %s', database.name)
+            url = f'{database.build_id._http_log_url()}{database.name}.zip'
+            assert str(database.build_id.id) in database.name  # ensure that database are well uniquified by build in order to avoid to forget to adapt this if it changes in the future
+            try:
+                subprocess.run(['wget', '-O', self._path('backups', f'{database.name}.zip'), url], check=True)
+            except subprocess.CalledProcessError as e:
+                _logger.error('Failed to backup database %s: %s', database.name, e)
+        # cleanup old backup
+        # we could keep them longer than on hosts but let's keep it simple for now
+        for remaining_backup in existing_backups:
+            _logger.info('Removing old backup %s', remaining_backup)
+            os.remove(self._path('backups', f'{remaining_backup}.zip'))
 
     def _warning(self, message, *args):
         if args:

--- a/runbot/templates/nginx.xml
+++ b/runbot/templates/nginx.xml
@@ -53,8 +53,13 @@ server {
           autoindex on;
           add_header 'Access-Control-Allow-Origin' '<t t-out="base_url"/>';
       }
+      location ~ /runbot/static/backups/ {
+          autoindex off;
+          add_header 'Access-Control-Allow-Origin' '<t t-out="base_url"/>';
+      }
     }
 }
+
 
 server {
   listen 8080;

--- a/runbot/views/host_views.xml
+++ b/runbot/views/host_views.xml
@@ -16,6 +16,7 @@
                         <field name="send_status" invisible="not is_leader"/>
                         <field name="is_builder"/>
                         <field name="is_registry"/>
+                        <field name="is_backup"/>
                         <field name="docker_registry_url"/>
                         <field name="last_start_loop" readonly='1' options="{'numeric': true}"/>
                         <field name="last_end_loop" readonly='1' options="{'numeric': true}"/>
@@ -63,6 +64,7 @@
                 <field name="is_leader"/>
                 <field name="is_builder"/>
                 <field name="is_registry"/>
+                <field name="is_backup"/>
 
             </list>
         </field>

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -19,6 +19,7 @@
                   <field name="config_id"/>
                   <field name="light_config_id"/>
                   <field name="network_enabled"/>
+                  <field name="backup_databases"/>
                   <field name="config_data" widget="runbotjsonb"/>
                   <field name="report_view_id"/>
                   <field name="has_stats"/>

--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -21,8 +21,8 @@ class BuilderClient(RunbotClient):
             monitoring_thread.start()
 
     def loop_turn(self):
+        self.env['runbot.runbot']._reload_nginx()
         if self.host.is_registry:
-            self.env['runbot.runbot']._reload_nginx()
             self.env['runbot.runbot']._start_docker_registry()
         if self.host.is_registry or self.host.is_builder:
             last_docker_updates = self.env['runbot.dockerfile'].search([('to_build', '=', True)]).mapped('write_date')
@@ -30,6 +30,9 @@ class BuilderClient(RunbotClient):
                 self.last_docker_updates = last_docker_updates
                 self.host._docker_update_images()
                 self.env.cr.commit()
+        if self.host.is_backup:
+            self.env['runbot.runbot']._backup_databases()
+            self.env.cr.commit()
         if self.host.is_builder:
             self.last_update = self.env['runbot.repo'].search([('write_date', '>', self.last_update)])._update_git_config()
             self.env.cr.commit()


### PR DESCRIPTION
The template databases installed by sticky branches can be used by a lot of upgrade builds. This means that loosing one of them could break a bunch of build before it is regenerated, and even then the links between builds can persist for a while forcing to rebase the branches.

The plan to migrate in 26.04 will erase all servers in fine, making this problem more visible.

This pr introduces a new backup service that allows to give a fallback for a given database. All templates of sticky branches will be stored there, and the restore step will fallback on this server if the database is not found on the initial host.