### PR TITLE
[PERF] runbot: avoid to use not in selection in domains

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -287,7 +287,7 @@ class Batch(models.Model):
         # 1.2 FIND merge_base info for those commits
         #  use last not preparing batch to define previous repos_heads instead of branches heads:
         #  Will allow to have a diff info on base bundle, compare with previous bundle
-        last_base_batch = self.env['runbot.batch'].search([('bundle_id', '=', bundle.base_id.id), ('state', '!=', 'preparing'), ('category_id', '=', self.category_id.id), ('id', '!=', self.id)], order='id desc', limit=1)
+        last_base_batch = self.env['runbot.batch'].search([('bundle_id', '=', bundle.base_id.id), ('state', 'in', ('ready', 'done')), ('category_id', '=', self.category_id.id), ('id', '!=', self.id)], order='id desc', limit=1)
         if last_base_batch:
             base_head_per_repo = {commit.repo_id.id: commit for commit in last_base_batch.commit_ids}
             self._update_commits_infos(base_head_per_repo)  # set base_commit, diff infos, ...

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -277,7 +277,7 @@ class Runbot(models.AbstractModel):
                 cannot_be_deleted_path.add(commit._source_path())
 
             # the following part won't be usefull anymore once runbot.commit.export is populated
-            cannot_be_deleted_builds = self.env['runbot.build'].search([('host', '=', host_name), ('local_state', '!=', 'done')])
+            cannot_be_deleted_builds = self.env['runbot.build'].search([('host', '=', host_name), ('local_state', 'in', ('pending', 'testing', 'running'))])
             cannot_be_deleted_builds |= cannot_be_deleted_builds.mapped('params_id.builds_reference_ids')
             for build in cannot_be_deleted_builds:
                 for build_commit in build.params_id.commit_link_ids:


### PR DESCRIPTION
The "not in" or '!=' operator on indexed selection will prevent the usage of the index on this field, while using the inverse condition will

In particular, the following queries was very slow:

SELECT "runbot_build"."id"
FROM "runbot_build"
WHERE ("runbot_build"."host" IN ('runbot160.odoo.com')
       AND "runbot_build"."local_state" NOT IN ('done'))
ORDER BY "runbot_build"."id" DESC

with more that 2.5 seconde.

The new query

SELECT "runbot_build"."id"
FROM "runbot_build"
WHERE ("runbot_build"."host" IN ('runbot160.odoo.com')
       AND "runbot_build"."local_state" IN ('pending', 'testing', 'running'))
ORDER BY "runbot_build"."id" DESC

Takes 15 ms, using the index.