### PR TITLE
[IMP] runbot: add docker layer for dynamic files

### DIFF
--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -34,7 +34,9 @@ class DockerLayer(models.Model):
         ('template', "Template"),
         ('reference_layer', "Reference layer"),
         ('reference_file', "Reference file"),
+        ('file', "File"),
     ], string="Layer type", default='raw', tracking=True)
+    file_destination = fields.Char("File destination", help="Destination path of the file in the docker image, only used when layer_type is 'file'", tracking=True)
     content = fields.Text("Content", tracking=True)
     packages = fields.Text("Packages", help="List of package, can be on multiple lines with comments", tracking=True)
     rendered = fields.Text("Rendered", compute="_compute_rendered", recursive=True)
@@ -45,7 +47,6 @@ class DockerLayer(models.Model):
     all_referencing_dockerlayer_ids = fields.One2many('runbot.docker_layer', compute="_compute_references", string='Layers referencing this one', readonly=True)
     reference_count = fields.Integer('Number of references', compute='_compute_references')
     has_xml_id = fields.Boolean(compute='_compute_has_xml_id')
-
 
     @api.depends('referencing_dockerlayer_ids', 'dockerfile_id.referencing_dockerlayer_ids')
     def _compute_references(self):
@@ -61,19 +62,44 @@ class DockerLayer(models.Model):
     @api.depends('layer_type', 'content', 'reference_docker_layer_id.rendered', 'reference_dockerfile_id.layer_ids.rendered', 'values', 'packages', 'name')
     def _compute_rendered(self):
         for layer in self:
-            rendered = layer._render_layer({})
+            if layer.layer_type == 'file':
+                rendered = f'-> FILE {layer.file_destination}\n' + layer._render_file_content(layer._get_values({}))
+            else:
+                rendered = layer._render_layer({})
             layer.rendered = rendered
 
-    def _render_layer(self, custom_values):
+    def _render_file_content(self, values):
+        if not self.content:
+            return f'# No content for file layer {self.name}'
+        content = self._render_template(values, header=False)
+        return content
+
+    def _render_file_layer(self, values):
+        content = self._render_file_content(values)
+        lines = content.splitlines()
+        quoted_lines = ["'" + line.replace("'", "'\"'\"'") + "'" for line in lines]
+
+        rendered = (
+            "RUN printf '%s\\n' \\\n"
+            + " \\\n".join(quoted_lines)
+            + f" \\\n> {self.file_destination}"
+        )
+        return rendered
+
+    def _get_values(self, custom_values=None):
         base_values = {
             'USERUID': USERUID,
             'USERGID': USERGID,
             'USERNAME': USERNAME,
+            ** self.dockerfile_id._get_default_values(),
         }
         if packages := self._parse_packages():
             base_values['$packages'] = packages
 
-        values = {**base_values, **self.values, **custom_values}
+        return {**base_values, **self.values, **(custom_values or {})}
+
+    def _render_layer(self, custom_values):
+        values = self._get_values(custom_values)
 
         if self.layer_type == 'raw':
             rendered = self.content
@@ -84,23 +110,24 @@ class DockerLayer(models.Model):
                 rendered = 'ERROR: no reference_docker_layer_id defined'
         elif self.layer_type == 'reference_file':
             if self.reference_dockerfile_id:
-                rendered = self.reference_dockerfile_id.layer_ids.render_layers(values)
+                rendered = self.reference_dockerfile_id.layer_ids.render_layers(custom_values=values)
             else:
                 rendered = 'ERROR: no reference_docker_layer_id defined'
         elif self.layer_type == 'template':
             rendered = self._render_template(values)
+        elif self.layer_type == 'file':
+            rendered = self._render_file_layer(values)
         if not rendered or rendered[0] != '#':
             rendered = f'# {self.name}\n{rendered}'
         return rendered
 
-    def render_layers(self, values=None):
-        values = values or {}
-        return "\n\n".join(layer._render_layer(values) or "" for layer in self) + '\n'
+    def render_layers(self, custom_values=None):
+        return "\n\n".join(layer._render_layer(custom_values or {}) or "" for layer in self) + '\n'
 
-    def _render_template(self, values):
+    def _render_template(self, values, header=True):
         values = {key: value for key, value in values.items() if f'{key}' in (self.content or '')}  # filter on keys mainly to have a nicer comment. All default must be defined in self.values
         rendered = self.content
-        if self.values.keys() - ['$packages']:
+        if header and self.values.keys() - ['$packages']:
             values_repr = str(values).replace("'", '"')
             rendered = f"# {self.name or 'Rendering'} with values {values_repr}\n{rendered}"
 
@@ -258,15 +285,13 @@ class Dockerfile(models.Model):
         for rec in self:
             content = ''
             layers = rec.layer_ids
-            values = dict(rec.default_values)
             if rec.parent_id:
                 layers = self.env['runbot.docker_layer'].new({
                     'name': 'TEMP LAYER',
                     'layer_type': 'reference_file',
                     'reference_dockerfile_id': rec.parent_id.id,
                 }) + layers
-                values.update(rec.parent_id.default_values)
-            content = layers.render_layers(values)
+            content = layers.render_layers()
             switch_user = f"\nUSER {USERNAME}\n"
             if not content.endswith(switch_user):
                 content = content + switch_user
@@ -306,6 +331,9 @@ class Dockerfile(models.Model):
         for dockerfile in self:
             if dockerfile.image_future_identifier and dockerfile.image_future_identifier != dockerfile.image_identifier:
                 dockerfile.image_identifier = dockerfile.image_future_identifier
+
+    def _get_default_values(self):
+        return {**self.parent_id.default_values, **self.default_values}
 
     def _get_docker_metadata(self, image_id):
         _logger.info(f'Fetching metadata for image {image_id}')

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -39,7 +39,7 @@
                   <field name="layer_ids">
                     <list default_order="sequence,id">
                       <field name="sequence" widget="handle"/>
-                      <field name="rendered" decoration-it="layer_type in ('reference_layer', 'reference_file')" decoration-bg-info="layer_type == 'template' or (layer_type == 'reference_layer' and (packages or values))" decoration-bg-success="layer_type == 'raw'"/>
+                      <field name="rendered" decoration-it="layer_type in ('reference_layer', 'reference_file')" decoration-bg-info="layer_type == 'template' or (layer_type == 'reference_layer' and (packages or values))" decoration-bg-success="layer_type == 'raw'" decoration-bg-dark="layer_type == 'file'"/>
                       <field name="reference_count" string="#" decoration="True" decoration-bg-danger="referencing_dockerlayer_ids" decoration-bg-warning="reference_count != 0"/>
                       <field name="referencing_dockerlayer_ids" column_invisible="True"/>
                       <field name="layer_type" column_invisible="True"/>
@@ -158,10 +158,11 @@
               <field name="name" readonly="has_xml_id"/>
               <field name="dockerfile_id" invisible="dockerfile_id" readonly="has_xml_id"/>
               <field name="layer_type" readonly="has_xml_id"/>
-              <field name="content" widget="ace" invisible="layer_type not in ('raw', 'template')" readonly="has_xml_id"/>
+              <field name="file_destination" invisible="layer_type not in ('file',)" readonly="has_xml_id"/>
+              <field name="content" widget="ace" invisible="layer_type not in ('raw', 'template', 'file')" readonly="has_xml_id"/>
               <field name="reference_docker_layer_id" invisible="layer_type not in ('reference_layer')" readonly="has_xml_id"/>
               <field name="reference_dockerfile_id"  invisible="layer_type != 'reference_file'" readonly="has_xml_id"/>
-              <field name="values" widget="runbotjsonb" invisible="layer_type not in ('template', 'reference_layer', 'reference_file')" readonly="has_xml_id"/>
+              <field name="values" widget="runbotjsonb" invisible="layer_type not in ('file', 'template', 'reference_layer', 'reference_file')" readonly="has_xml_id"/>
               <field name="packages" widget="ace" invisible="layer_type not in ('template', 'reference_layer', 'reference_file')" readonly="has_xml_id"/>
               <field name="all_referencing_dockerlayer_ids"  widget="many2many_tags" readonly="1"/>
             </group>
@@ -187,7 +188,7 @@
           <field name="values" column_invisible="True"/>
           <field name="reference_count" string="#refs" decoration-danger="referencing_dockerlayer_ids" decoration-warning="reference_count != 0"/>
           <field name="all_referencing_dockerlayer_ids" string="#referencing" widget="many2many_tags"/>
-          <field name="rendered" decoration-warning="layer_type in ('reference_layer', 'reference_file')" decoration-info="layer_type == 'template' or (layer_type == 'reference_layer' and (packages or values))" decoration-success="layer_type == 'raw'"/>
+          <field name="rendered" decoration-it="layer_type in ('reference_layer', 'reference_file')" decoration-bg-info="layer_type == 'template' or (layer_type == 'reference_layer' and (packages or values))" decoration-bg-success="layer_type == 'raw'" decoration-bg-dark="layer_type == 'file'"/>
         </list>
       </field>
     </record>


### PR DESCRIPTION
In some case we want to create file in the docker images but the dockerfile COPY does not work for this prurpose without buildx, and RUN printf makes it hard to read and maintain.

Introducing a new docker layer that will create the files in the image, supporting template formating.