### PR TITLE
[IMP] runbot: add is_template on docker

### DIFF
--- a/runbot/models/docker.py
+++ b/runbot/models/docker.py
@@ -172,6 +172,7 @@ class Dockerfile(models.Model):
     dockerfile = fields.Text(compute='_compute_dockerfile', recursive=True, tracking=True)
     in_error = fields.Boolean('In error', help='The last build failed.', default=False)
     to_build = fields.Boolean('To Build', help='Build Dockerfile. Check this when the Dockerfile is ready.', default=True)
+    is_template = fields.Boolean('Is template', help='This dockerfile is a template and should not be used directly.', default=False)
     nocache = fields.Boolean('No Cache', help='Force a full rebuild on next build, bypassing the Docker layer cache. Automatically reset to False after the build.', copy=False)
     always_pull = fields.Boolean('Always pull', help='Always Pull on the hosts, not only at the use time', default=False, tracking=True, copy=False)
     version_ids = fields.One2many('runbot.version', 'dockerfile_id', string='Versions')
@@ -226,12 +227,13 @@ class Dockerfile(models.Model):
     def _compute_message(self):
         for record in self:
             messages = []
-            if record.in_error:
-                messages.append("The last build failed and this docker image won't be build anymore, remove the in_error flag to reenable.")
-            elif not record.to_build:
-                messages.append("The docker won't be build automatically")
-            if missing_variants := record.get_missing_variants():
-                messages.append(f'This variants is missing on the following docker files: {", ".join(missing_variants.mapped("name"))}')
+            if not record.is_template:
+                if record.in_error:
+                    messages.append("The last build failed and this docker image won't be build anymore, remove the in_error flag to reenable.")
+                elif not record.to_build:
+                    messages.append("The docker won't be build automatically")
+                if missing_variants := record.get_missing_variants():
+                    messages.append(f'This variants is missing on the following docker files: {", ".join(missing_variants.mapped("name"))}')
             record.message = '\n'.join(messages)
 
     def get_missing_variants(self):
@@ -301,6 +303,11 @@ class Dockerfile(models.Model):
     @api.onchange('dockerfile')
     def onchange_dockerfile(self):
         self.in_error = False
+
+    @api.onchange('is_template')
+    def onchange_is_template(self):
+        self.in_error = False
+        self.to_build = not self.is_template
 
     @api.depends('name', 'parent_id.image_tag')
     def _compute_image_tag(self):

--- a/runbot/models/host.py
+++ b/runbot/models/host.py
@@ -186,7 +186,7 @@ class Host(models.Model):
         else:
             _logger.info('Building docker images...')
             # as variants depend on their parent we want to build the parents first
-            for dockerfile in self.env['runbot.dockerfile'].search([('to_build', '=', True)], order='parent_id nulls first'):
+            for dockerfile in self.env['runbot.dockerfile'].search([('to_build', '=', True), ('is_template', '=', False)], order='parent_id nulls first'):
                 future_identifier = None
                 if not dockerfile.in_error:
                     future_identifier = dockerfile._build(self)

--- a/runbot/views/dockerfile_views.xml
+++ b/runbot/views/dockerfile_views.xml
@@ -14,19 +14,20 @@
                 <field name="active" invisible="1"/>
                 <field name="name" invisible="parent_id" required="not parent_id"/>
                 <field name="name" invisible="not parent_id" required="parent_id" label="Variant Name"/>
-                <field name="parent_id" invisible="variant_ids"/>
+                <field name="is_template"/>
+                <field name="parent_id" invisible="variant_ids or is_template"/>
                 <field name="variant_ids" widget="many2many_tags" readonly="1" invisible="not variant_ids"/>
-                <field name="image_identifier"/>
-                <field name="image_future_identifier"/>
-                <field name="auto_sync"/>
-                <field name="image_tag"/>
-                <field name="pull_on_build"/>
-                <field name="to_build"/>
-                <field name="in_error"/>
-                <field name="nocache"/>
-                <field name="always_pull"/>
-                <field name="version_ids" widget="many2many_tags"/>
-                <field name="project_ids" widget="many2many_tags"/>
+                <field name="image_identifier" invisible="is_template"/>
+                <field name="image_future_identifier" invisible="is_template"/>
+                <field name="auto_sync" invisible="is_template"/>
+                <field name="image_tag" invisible="is_template"/>
+                <field name="pull_on_build" invisible="is_template"/>
+                <field name="to_build" invisible="is_template and not to_build"/>
+                <field name="in_error" invisible="not in_error and is_template"/>
+                <field name="nocache" invisible="is_template"/>
+                <field name="always_pull" invisible="is_template"/>
+                <field name="version_ids" widget="many2many_tags" invisible="is_template"/>
+                <field name="project_ids" widget="many2many_tags" invisible="is_template"/>
                 <field name="public_visibility"/>
                 <field name="description"/>
               </group>
@@ -104,6 +105,7 @@
             <field name="parent_id"/>
             <field name="to_build" groups="!runbot.group_runbot_admin"/>
             <field name="to_build" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
+            <field name="is_template"/>
             <field name="in_error" groups="!runbot.group_runbot_admin"/>
             <field name="in_error" widget="boolean_toggle" groups="runbot.group_runbot_admin"/>
             <field name="always_pull" groups="!runbot.group_runbot_admin"/>
@@ -131,9 +133,9 @@
             <separator/>
             <filter string="Variants Only" name="variants_only" domain="[('parent_id', '!=', False)]"/>
             <separator/>
-            <filter string="To Build" name="to_build" domain="[('to_build', '=', True)]"/>
+            <filter string="Enabled" name="to_build" domain="['|', ('to_build', '=', True), ('is_template', '=', True)]"/>
             <separator/>
-            <filter string="Not To Build" name="not_to_build" domain="[('to_build', '=', False)]"/>
+            <filter string="Disabled" name="not_to_build" domain="[('to_build', '=', False), ('is_template', '=', False)]"/>
             <separator/>
             <filter string="Newer Identifier" name="newer_identifier" domain="[('has_future', '=', True)]"/>
             <separator/>

--- a/runbot_builder/builder.py
+++ b/runbot_builder/builder.py
@@ -25,7 +25,7 @@ class BuilderClient(RunbotClient):
         if self.host.is_registry:
             self.env['runbot.runbot']._start_docker_registry()
         if self.host.is_registry or self.host.is_builder:
-            last_docker_updates = self.env['runbot.dockerfile'].search([('to_build', '=', True)]).mapped('write_date')
+            last_docker_updates = self.env['runbot.dockerfile'].search(['|', ('to_build', '=', True), ('is_template', '=', True)]).mapped('write_date')
             if self.count == 1 or self.last_docker_updates != last_docker_updates:
                 self.last_docker_updates = last_docker_updates
                 self.host._docker_update_images()


### PR DESCRIPTION
A docker file can be referenced by another layer (mostly to be used as a base) but it can also be used to make a group of layer to use inside another docker file. This commit adds a boolean field to mark a docker file as a template. This will be used mostly for rendering to avoid to show many fields that are not relevant for a template.