### PR TITLE
[FIX] git-fw: clear stale commit map on redo

### DIFF
--- a/runbot_merge/scripts/git-fw
+++ b/runbot_merge/scripts/git-fw
@@ -147,6 +147,7 @@ def redo(pr: str) -> int:
         exit(r.returncode)
     print(".")
     commits = r.stdout.splitlines(keepends=False)
+    GIT_DIR.joinpath("FW_CMAP").unlink(missing_ok=True)
     if cm:
         # remap commits to forward port to those which got merged
         commits = [cm[c] for c in commits]


### PR DESCRIPTION
`redo` writes `.git/FW_CMAP` but never removes it, so the next `redo` may read the map left by a previous one and not find its commit in it.

Remove the file at the start of `redo`.