### PR TITLE
[IMP] runbot: remove assert

### DIFF
--- a/runbot/models/branch.py
+++ b/runbot/models/branch.py
@@ -117,8 +117,8 @@ class Branch(models.Model):
             for name in r.findall(fowardport.pr_body):
                 base_candidates.setdefault(name, []).append(fowardport)
         base_candidates_pr = self.search([('is_pr', '=', True), ('name', 'in', tuple(base_candidates.keys())), ('pull_head_name', '!=', False)])
-        if base_candidates:
-            assert base_candidates_pr
+        if base_candidates and not base_candidates_pr:
+            self.env['runbot.runbot']._warning(f'Forwardport found in pr body but no corresponding pr found for {list(base_candidates.keys())}')
 
         for pr in base_candidates_pr:
             for forwardport in base_candidates[pr.name]:

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -614,7 +614,7 @@ class Repo(models.Model):
                 return refs
             except Exception:
                 _logger.exception('Fail to get refs for repo %s', self.name)
-                self.env['runbot.runbot'].warning('Fail to get refs for repo %s', self.name)
+                self.env['runbot.runbot']._warning('Fail to get refs for repo %s', self.name)
         return []
 
     def _find_or_create_branches(self, refs):


### PR DESCRIPTION
The assert checking that the forwardport exist was fragile, in some cases the forwardported branch was referencing a branch that does not exist yet runbot side breaking the leader loop.

Replacing it with a simple warning