### PR TITLE
[FIX] runbot: typo in table-strip(p)ed BS class

### DIFF
--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -6,7 +6,7 @@
                 <div class="row g-0">
                     <div class="col-lg-6">
                     <t t-set="batch_class" t-value="'bg-info-subtle' if batch.state=='preparing' else 'bg-success-subtle' if not any(log.level != 'INFO' for log in batch.log_ids) else 'bg-warning-subtle'"/>
-                    <table class="table table-stripped">
+                    <table class="table">
                         <tr>
                             <td>Bundle</td>
                             <td>
@@ -182,7 +182,7 @@
                     </table>
                     </div>
                     <div class="col-lg-6">
-                    <table class="table table-stripped">
+                    <table class="table">
                         <tr>
                             <td>Builds</td>
                             <td>

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -16,7 +16,7 @@
                   </div>
                 </h3>
               </div>
-              <table class="table table-condensed table-responsive table-stripped">
+              <table class="table table-condensed table-responsive">
                 <tr>
                   <td>Remote:</td>
                   <td t-out="branch.remote_id.name"></td>
@@ -58,7 +58,7 @@
                   </tr>
                 </t>
               </table>
-                <table t-if="branch.reflog_ids" class="table table-condensed table-stripped" style="table-layout: initial;">
+                <table t-if="branch.reflog_ids" class="table table-condensed table-striped" style="table-layout: initial;">
                   <thead>
                       <tr>
                           <th>Ref Date</th>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -36,7 +36,7 @@
                                         </t>
                                 </div></h5>
                             
-                            <table class="table table-condensed table-responsive table-stripped">
+                            <table class="table table-condensed table-responsive">
                                 <tr>
                                     <td>Version</td>
                                     <td>

--- a/runbot/templates/commit.xml
+++ b/runbot/templates/commit.xml
@@ -25,7 +25,7 @@
         <div class="row g-0">
           <!-- Commit base informations -->
           <div class="col-md-6">
-            <table class="table table-stripped">
+            <table class="table">
               <tr>
                 <td>Name</td>
                 <td>
@@ -97,10 +97,10 @@
             </table>
           </div>
         </div>
-        <div class="row g-0">
+        <div class="row g-1">
           <div class="col-md-6">
             <h3>Branch presence history</h3>
-            <table class="table table-stripped">
+            <table class="table table-striped">
               <tr t-foreach='reflogs' t-as='reflog'>
                 <td t-out="reflog.date"/>
                 <td t-out="reflog.branch_id.remote_id.short_name"/>
@@ -110,7 +110,7 @@
           </div>
           <div class="col-md-6">
             <h3>Status history</h3>
-            <table class="table table-stripped">
+            <table class="table table-striped">
               <tr t-foreach='status_list' t-as='status'>
                 <td t-out="status.sent_date and status.sent_date.strftime('%Y-%m-%d %H:%M:%S') or '—'"/>
                 <td t-out="status.context"/>


### PR DESCRIPTION
This commit removes the table-stripped class in the frontend templates as there is a typo, and thus never actually applied, only keeping it (but with its name fixed) when used for actual datatables (and not just for layout).