### PR TITLE
[FIX] runbot: avoid invalid success status on rebuild

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -180,7 +180,7 @@ class Batch(models.Model):
 
         slot.link_type = link_type
         slot.build_id = build
-        build._github_status()
+        build._prepare_github_status()
 
     def _get_latest_batch_per_version(self, skip_versions):
         return self.env['runbot.batch'].browse(result[1] for result in self.env['runbot.batch']._read_group(

--- a/runbot/models/build.py
+++ b/runbot/models/build.py
@@ -390,7 +390,7 @@ class BuildResult(models.Model):
         for record in self:
             record.host_id = get_host(record.host)
 
-    def _update_global_state(self):
+    def _update_globals(self):
         for record in self:
             waiting_score = record._get_state_score('waiting')
             children_ids = [child for child in record.children_ids if not child.orphan_result]
@@ -403,8 +403,6 @@ class BuildResult(models.Model):
             else:
                 record.global_state = record.local_state
 
-    def _update_global_result(self):
-        for record in self:
             if record.local_result and record._get_result_score(record.local_result) >= record._get_result_score('ko'):
                 record.global_result = record.local_result
             else:
@@ -510,8 +508,7 @@ class BuildResult(models.Model):
         # so we can assume that we don't need to update the created records globals,
         # but we need to update the parents global state and result as the new build can impact them
         if parents:
-            parents._update_global_state()
-            parents._update_global_result()
+            parents._update_globals()
         return records
 
     def write(self, values):
@@ -535,19 +532,16 @@ class BuildResult(models.Model):
             init_local_states = self.mapped('local_state')
 
         res = super(BuildResult, self).write(values)
-        if 'local_state' in values:
-            self._update_global_state()
-        if 'local_result' in values:
-            self._update_global_result()
+        if 'local_state' in values or 'local_result' in values:
+            self._update_globals()
 
         if 'orphan_result' in values:
-            self.parent_id._update_global_result()
-            self.parent_id._update_global_state()
+            self.parent_id._update_globals()
 
         if "global_result" in values:
             for init_global_result, build in zip(init_global_results, self):
                 if init_global_result != build.global_result:
-                    build._github_status()
+                    build._prepare_github_status()
 
         if "local_state" in values:
             for init_local_state, build in zip(init_local_states, self):
@@ -557,7 +551,7 @@ class BuildResult(models.Model):
         if "global_state" in values:
             for init_global_state, build in zip(init_global_states, self):
                 if init_global_state not in ('done', 'running') and build.global_state in ('done', 'running'):
-                    build._github_status()
+                    build._prepare_github_status()
 
         return res
 
@@ -693,11 +687,11 @@ class BuildResult(models.Model):
                 'parent_id': self.parent_id.id,
                 'description': self.description,
             })
-            self.orphan_result = True
-
+        
         new_build = self.create(values)
         if self.parent_id:
-            new_build._github_status()  # not sure this is needed since creating a child should trigger an update of parent global state.
+            self.orphan_result = True
+
         user = self.env.user
         new_build._log('rebuild', 'Rebuild initiated by %s%s' % (user.name, (' :%s' % message) if message else ''))
 
@@ -1682,6 +1676,36 @@ class BuildResult(models.Model):
                 title += f'\n{test_line}: {test_data[test_line]}'
         return title
 
+    def _prepare_github_status(self):
+        """Queue a github status recomputation on transaction precommit."""
+        if not self:
+            return
+        for build in self:
+            if build.parent_id:
+                if build.orphan_result:
+                    _logger.info('Skipping result for orphan build %s', build.id)
+                else:
+                    build.parent_id._prepare_github_status()
+                continue
+
+            env = build.env
+            cr = env.cr
+            cache_key = '_runbot_pending_github_status_build_ids'
+            pending_ids = cr.cache.get(cache_key)
+            if pending_ids is None:
+                pending_ids = set()
+                cr.cache[cache_key] = pending_ids
+                def _flush_github_status():
+                    ids = list(cr.cache.get(cache_key, set()))
+                    cr.cache[cache_key] = None
+                    if ids:
+                        for build in env['runbot.build'].browse(ids).exists():
+                            build._github_status()
+
+                cr.precommit.add(_flush_github_status)
+
+            pending_ids.add(build.id)
+
     def _github_status(self):
         """Notify github of failed/successful builds"""
         for build in self:
@@ -1706,7 +1730,7 @@ class BuildResult(models.Model):
                     desc = "This build used a light config. Enable default build configuration to restore default ci"
                 if build.global_result in ('ko', 'warn'):
                     state = 'error'
-                elif build.global_state in ('pending', 'testing'):
+                elif build.global_state in ('pending', 'testing', 'waiting'):
                     state = 'pending'
                 elif build.global_state in ('running', 'done'):
                     state = 'error'
@@ -1753,9 +1777,9 @@ class BuildResult(models.Model):
                     if trigger.ci_url:
                         target_url = trigger.ci_url
                     elif batch:
-                        target_url = f"{self.get_base_url()}/runbot/batch/{batch.id}/build/{build.id}"
+                        target_url = f"{build.get_base_url()}/runbot/batch/{batch.id}/build/{build.id}"
                     else:
-                        target_url = f"{self.get_base_url()}/runbot/build/{build.id}"
+                        target_url = f"{build.get_base_url()}/runbot/build/{build.id}"
 
                     commit._github_status(build, ci_context, state, target_url, desc, ci_strategy=trigger.ci_strategy)
 

--- a/runbot/models/runbot.py
+++ b/runbot/models/runbot.py
@@ -68,8 +68,7 @@ class Runbot(models.AbstractModel):
                 self._commit()
         for build in host._get_builds([('global_state', 'in', ['pending', 'testing', 'waiting', 'running'])]):
             build = build.browse(build.id)  # remove preftech ids, manage build one by one
-            build._update_global_state()
-            build._update_global_result()
+            build._update_globals()
             self._commit()
         self._gc_running(host)
         self._commit()

--- a/runbot/tests/test_batch.py
+++ b/runbot/tests/test_batch.py
@@ -66,6 +66,7 @@ class TestBatch(RunbotCase):
         self.assertEqual(build_2.params_id._get_batch_commit_link_ids(batch_4).commit_id.name, 'bbbbbb2')
 
         def assert_status_info(commit):
+            self.env.cr.precommit.run()
             infos = commit._get_last_statuses()[1]['test']
             parts = infos.target_url.split('/')
             return {

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -617,15 +617,59 @@ class TestBuildResult(RunbotCase):
         build1_1_2.local_state = 'done'
 
         # simulate scheduler ran
-        build1_1._update_global_state()
-        build1_2._update_global_state()
-        build1._update_global_state()
+        build1_1._update_globals()
+        build1_2._update_globals()
+        build1._update_globals()
 
         self.assertEqual('done', build1.global_state)
         self.assertEqual('done', build1_1.global_state)
         self.assertEqual('done', build1_2.global_state)
         self.assertEqual('done', build1_1_1.global_state)
         self.assertEqual('done', build1_1_2.global_state)
+
+    def test_rebuild_sent_status(self):
+        # setup everything to ensure status are created
+        # TODO rework default setup to have a consistent state for all tests
+        bundle = self.dev_bundle
+        self.trigger_addons.unlink()  # TODO should not be needed, but will generate a warning without that
+        batch = bundle._force()
+        batch._prepare()
+        bundle.last_batch = batch
+        self.server_params.trigger_id = self.trigger_server
+        self.trigger_server.ci_context = 'ci/test'
+        batch.commit_link_ids[0].match_type = 'head'
+        batch.commit_link_ids[0].commit_id = self.server_params.commit_link_ids[0].commit_id
+
+        current_max = self.env['runbot.commit.status'].search([], order='id desc', limit=1).id or 0
+        build1 = self.Build.create({
+            'params_id': self.server_params.id,
+        })
+        batch.slot_ids[0].build_id = build1
+
+        build1_1 = self.Build.create({
+            'params_id': self.server_params.id,
+            'parent_id': build1.id,
+        })
+        build1.local_state = 'done'
+        build1.local_result = 'ok'
+        build1_1.local_state = 'done'
+        build1_1.local_result = 'ko'
+        build1_1._update_globals()
+        build1._update_globals()
+        self.assertEqual('ko', build1.global_result)
+        self.assertEqual('done', build1.global_state)
+        self.cr.precommit.run()
+
+        new_status = self.env['runbot.commit.status'].search([('id', '>', current_max)], order='id')
+        current_max = new_status[-1].id
+        self.assertEqual(new_status.mapped('state'), ['error'])
+        new_build = build1_1._rebuild()
+        self.assertEqual('ok', build1.global_result)
+        self.assertEqual('waiting', build1.global_state)
+
+        self.cr.precommit.run()
+        new_status = self.env['runbot.commit.status'].search([('id', '>', current_max)], order='id')
+        self.assertEqual(new_status.mapped('state'), ['pending'])        
 
     def test_rebuild_sub_sub_build(self):
         build1 = self.Build.create({
@@ -652,10 +696,8 @@ class TestBuildResult(RunbotCase):
         build1_1_1.local_state = 'done'
 
         # simulate scheduler ran
-        build1_1._update_global_state()
-        build1._update_global_state()
-        build1_1._update_global_result()
-        build1._update_global_result()
+        build1_1._update_globals()
+        build1._update_globals()
 
         self.assertEqual('done', build1.global_state)
         self.assertEqual('done', build1_1.global_state)
@@ -671,10 +713,8 @@ class TestBuildResult(RunbotCase):
         build1_1_1.orphan_result = True
 
         # simulate scheduler ran
-        build1_1._update_global_state()
-        build1._update_global_state()
-        build1_1._update_global_result()
-        build1._update_global_result()
+        build1_1._update_globals()
+        build1._update_globals()
 
         self.assertEqual('ok', build1.global_result)
         self.assertEqual('ok', build1_1.global_result)
@@ -688,10 +728,8 @@ class TestBuildResult(RunbotCase):
         rebuild1_1_1.local_state = 'done'
 
         # simulate scheduler ran
-        build1_1._update_global_state()
-        build1._update_global_state()
-        build1_1._update_global_result()
-        build1._update_global_result()
+        build1_1._update_globals()
+        build1._update_globals()
 
         self.assertEqual('ok', build1.global_result)
         self.assertEqual('ok', build1_1.global_result)
@@ -858,19 +896,19 @@ class TestGithubStatus(RunbotCase):
         def github_status(build):
             self.callcount += 1
 
-        with patch('odoo.addons.runbot.models.build.BuildResult._github_status', github_status):
+        with patch('odoo.addons.runbot.models.build.BuildResult._prepare_github_status', github_status):
             self.callcount = 0
             self.build.local_state = 'testing'
             self.assertEqual(self.build.global_state, 'testing')
 
-            self.assertEqual(self.callcount, 0, "_github_status shouldn't have been called")
+            self.assertEqual(self.callcount, 0, "_prepare_github_status shouldn't have been called")
 
             self.callcount = 0
             self.build.local_state = 'running'
             self.assertEqual(self.build.global_state, 'running')
 
-            self.assertEqual(self.callcount, 1, "_github_status should have been called")
+            self.assertEqual(self.callcount, 1, "_prepare_github_status should have been called")
 
             self.callcount = 0
             self.build.local_state = 'done'
-            self.assertEqual(self.callcount, 0, "_github_status shouldn't have been called")
+            self.assertEqual(self.callcount, 0, "_prepare_github_status shouldn't have been called")

--- a/runbot/tests/test_build_config_step.py
+++ b/runbot/tests/test_build_config_step.py
@@ -316,7 +316,7 @@ class TestBuildConfigStepCreate(TestBuildConfigStepCommon):
             self.assertEqual(child_build.global_result, 'ko')
 
         # simulate sheduler ran
-        self.parent_build._update_global_result()
+        self.parent_build._update_globals()
 
         self.assertEqual(self.parent_build.global_result, 'ko')
 

--- a/runbot/tests/test_upgrade.py
+++ b/runbot/tests/test_upgrade.py
@@ -575,8 +575,8 @@ class TestUpgradeFlow(RunbotCase):
                 # self.assertEqual(current_build.global_result, 'ok')
 
         # simulate scheduler ran
-        from_version_builds._update_global_state()
-        to_version_builds._update_global_state()
+        from_version_builds._update_globals()
+        to_version_builds._update_globals()
 
         self.assertEqual(from_version_builds.mapped('global_state'), ['done'] * 10)
 


### PR DESCRIPTION
On rebuild, make_orphan was set on the old build before creating the new one, which can cause a status with a success state to be generated.

Additionnally, the github_status was called multiple time creating multiple invalid entries before generating the correct one. (kind of expected but dirty)

In theory, all status to send to github are aggregated so only the last one should be taken into account, the bug was only there because the new updated (passing the parent build in waiting) was ignored, not sending a "pending" github status after the ok one was created.

To fix this behaviour, 
- the github status is added to a precommit hook that will only be executed at the end.
- the build is marked orphan after creating the new sub build to ensure the state is immediately "waiting"
- pending state is sent to github when a build goes into waiting state

To ensure a better consistency, we also always compute state and result at the same time.