### PR TITLE
[FIX] runbot: logs links should be visible even when not authenticated

### DIFF
--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -376,7 +376,7 @@
                             <i class="fa fa-fw fa-sign-in"/> Database selector
                         </a>
                     </li>
-                    <t groups="runbot.group_user">
+                    <t groups="base.group_user">
                         <li t-attf-t-if="global_state in ['done','running'] or to_kill">
                             <button type="button" class="dropdown-item" data-runbot="rebuild" data-runbot-build="{{id}}" title="Retry this build, usefull for false positive">
                                 <i class="fa fa-fw fa-refresh"/> Rebuild
@@ -402,13 +402,13 @@
                                 <i class="fa fa-fw fa-coffee"/> Waking up <i class="fa fa-spinner fa-spin"/>
                             </span>
                         </li>
-                        <li t-attf-t-if="host and log_list[0]"><hr class="dropdown-divider"/></li>
-                        <li t-attf-t-if="host" t-attf-t-foreach="log_list" t-attf-t-as="log_name">
-                            <a class="dropdown-item" href="http://{{host}}/runbot/static/build/{{dest}}/logs/{{log_name}}.txt">
-                                <i class="fa fa-fw fa-file-text-o"/> Full {{log_name}} logs
-                            </a>
-                        </li>
                     </t>
+                    <li t-attf-t-if="host and log_list[0]"><hr class="dropdown-divider"/></li>
+                    <li t-attf-t-if="host" t-attf-t-foreach="log_list" t-attf-t-as="log_name">
+                        <a class="dropdown-item" href="http://{{host}}/runbot/static/build/{{dest}}/logs/{{log_name}}.txt">
+                            <i class="fa fa-fw fa-file-text-o"/> Full {{log_name}} logs
+                        </a>
+                    </li>
                     <t groups="runbot.group_runbot_advanced_user">
                         <li><hr class="dropdown-divider"/></li>
                         <li>


### PR DESCRIPTION
This commit fixes a regression introduced by commit 70bf58325d4a54b79c61a3979410caec6ecacf80 where access rights to logs' links where more restrictive than before.