### PR TITLE
[REM] runbot: remove ebaysdk dependency

### DIFF
--- a/runbot/data/dockerfile_data.xml
+++ b/runbot/data/dockerfile_data.xml
@@ -184,7 +184,6 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1</field>
         <field name="layer_type">reference_layer</field>
         <field name="name">Install external_dependencies deps</field>
         <field name="packages">
-            ebaysdk==2.1.5  # no debian package but needed in odoo requirements
             pdf417gen==0.7.1  # needed by l10n_cl_edi
         </field>
         <field name="reference_docker_layer_id" ref="runbot.docker_layer_pip_packages_template"/>

--- a/runbot/tests/test_dockerfile.py
+++ b/runbot/tests/test_dockerfile.py
@@ -71,7 +71,7 @@ RUN deluser ubuntu
 RUN groupadd -g 1337 TestUser && useradd --create-home -u 4242 -g TestUser -G audio,video TestUser
 USER TestUser
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-RUN python3 -m pip install --no-cache-dir ebaysdk==2.1.5 pdf417gen==0.7.1
+RUN python3 -m pip install --no-cache-dir pdf417gen==0.7.1
 ADD --chown=TestUser https://raw.githubusercontent.com/odoo/odoo/master/requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 USER TestUser""", docker_render)


### PR DESCRIPTION
Following the removal of ebaysdk in odoo/enterprise#70109, this package is no longer required in Odoo 18.0 dependencies.

This commit removes ebaysdk from the reference docker layer.

:warning: Still required in 17.0