### PR TITLE
[IMP] runbot: allow to start after failure

### DIFF
--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -459,6 +459,7 @@ class Batch(models.Model):
         self.ensure_one()
         bundle = self.bundle_id
         bundle_repos = bundle.branch_ids.filtered('alive').mapped('remote_id.repo_id')
+        finished_trigger = self.slot_ids.filtered(lambda s: s.build_id.global_state in ('running', 'done')).trigger_id
         success_trigger = self.slot_ids.filtered(lambda s: s.build_id.global_state in ('running', 'done') and s.build_id.global_result == "ok").trigger_id
         trigger_customs = {}
         for trigger_custom in self.bundle_id.all_trigger_custom_ids:
@@ -481,7 +482,10 @@ class Batch(models.Model):
                 continue
             trigger = slot.trigger_id
             trigger_custom = trigger_customs.get(trigger, self.env['runbot.bundle.trigger.custom'])
-            missing_triggers = trigger.starts_after_ids - success_trigger
+            if trigger.starts_after_failure:
+                missing_triggers = trigger.starts_after_ids - finished_trigger
+            else:
+                missing_triggers = trigger.starts_after_ids - success_trigger
             if missing_triggers:
                 if not trigger_custom or (missing_triggers - disabled_triggers):
                     continue

--- a/runbot/models/repo.py
+++ b/runbot/models/repo.py
@@ -22,6 +22,7 @@ from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
+
 class ModuleFilter(models.Model):
     _name = 'runbot.module.filter'
     _description = 'Module filter'
@@ -38,6 +39,7 @@ class TriggerDependency(models.Model):
 
     dependency_id = fields.Many2one('runbot.trigger', string="Dependency", required=True)
     dependant_id = fields.Many2one('runbot.trigger', string="Dependant", required=True)
+
 
 class Trigger(models.Model):
     """
@@ -72,6 +74,7 @@ class Trigger(models.Model):
         column2='dependency_id',
         column1='dependant_id',
     )
+    starts_after_failure = fields.Boolean('Starts after failures', help="If checked, the trigger will also start after a failure", default=False)
     module_filters = fields.One2many('runbot.module.filter', 'trigger_id', string="Module filters", help='Will be combined with repo module filters when used with this trigger')
     config_id = fields.Many2one('runbot.build.config', string="Config", required=True)
     light_config_id = fields.Many2one('runbot.build.config', string="Light config", help="Alternative config to use when light mode is enabled")

--- a/runbot/tests/test_build.py
+++ b/runbot/tests/test_build.py
@@ -186,6 +186,22 @@ class TestBuildParams(RunbotCaseMinimalSetup):
             self.assertEqual(batch.state, 'done')
             sp.rollback()
 
+        with self.env.cr.savepoint() as sp:
+            # same failure, but the dependant trigger opts in to start anyway
+            self.trigger_server.starts_after_failure = True
+            minimal_check_build.local_result = 'ko'
+            minimal_check_build.local_state = 'done'
+            batch._process()
+            all_builds = batch.slot_ids.build_id
+            self.assertEqual(
+                all_builds.trigger_id.mapped('name'),
+                ['minimal_check', 'Server trigger'],
+                'Server trigger should have started despite the failed dependency',
+            )
+            self.assertEqual(all_builds.mapped('local_state'), ['done', 'pending'])
+            self.assertEqual(batch.state, 'ready')
+            sp.rollback()
+
         minimal_check_build.local_result = 'ok'
         minimal_check_build.local_state = 'done'
         batch._process()

--- a/runbot/views/repo_views.xml
+++ b/runbot/views/repo_views.xml
@@ -49,6 +49,7 @@
                       domain="[('category_id', '=', category_id), ('manual', '=', False), ('project_id', '=', project_id), ('id', '!=', id), ('id', 'not in', starts_before_ids)]"
                       widget="many2many_tags">
                   </field>
+                  <field name="starts_after_failure" invisible="manual or not starts_after_ids"/>
                 </group>
                 <group string="Starts before" invisible="manual" colspan="2">
                   <field 


### PR DESCRIPTION
The start_after / start_before relations only works for build in success.

This was the intended behaviour since the minimal check should prevent other builds from running, but in some case we want a check to run even if the dependency failed. For example, we want to run the generation of a specific test report even if the build failed.

This will be used to generate the coverage of failed builds as well as the statistics.