### PR TITLE
EXAMPLE AI PR, FEEL FREE TO DELETE, RE-USE ....

### DIFF
--- a/runbot/models/build_config.py
+++ b/runbot/models/build_config.py
@@ -1168,6 +1168,22 @@ class ConfigStep(models.Model):
                     build._log('_run_restore', f'No dump with suffix {dump_suffix} found in build [{reference_build.id}]({reference_build.build_url})', log_type='markdown', level='ERROR')
                     build._kill(result='ko')
                     return
+            if not dump_db:
+                # No reference build was found, e.g. because the bundle is
+                # based on a commit that is not the head of a base batch and
+                # has therefore no base reference batch. A dump producing
+                # trigger started manually to prepare the restore is not
+                # necessarily `dump_trigger`, but it sits in the current batch
+                # and builds a database that is just as good. Without this, the
+                # restore falls back on `reference_build_id`, which never
+                # created a database when that build only creates children, and
+                # ends up on an url pointing to a dump that never existed.
+                dump_suffix = config_data.get('dump_suffix', self.restore_download_db_suffix or 'all')
+                batch_builds = params.create_batch_id.slot_ids.mapped('build_id')
+                finished_builds = batch_builds.filtered(lambda b: b.local_state in ('done', 'running'))
+                dump_db = finished_builds.mapped('database_ids').filtered(lambda d: d.db_suffix == dump_suffix)[:1]
+                if dump_db:
+                    build._log('_run_restore', f'Using the dump of build [{dump_db.build_id.id}]({dump_db.build_id.build_url}) found in the current batch', log_type='markdown')
             if dump_db:
                 download_db_suffix = dump_db.db_suffix
                 dump_build = dump_db.build_id


### PR DESCRIPTION
[IMP] runbot: restore a dump from any build of the current batch

When a custom trigger uses `restore_mode = auto`, the dump is looked up through `dump_trigger` in the base reference batch. That batch is only set when the merge base of the bundle is the head of a batch of the base bundle, which is not the case when starting a build from an arbitrary commit, e.g. to bisect an undeterministic error.

The lookup then returns an empty recordset, the `if reference_build:` block is silently skipped, and the restore falls back on `reference_build_id`. When that build only creates children it never created a database, so the composed url points to a dump that never existed: the restore fails on a 404 and the following steps report an unhelpful `Database not initialized`.

Fall back on any finished build of the current batch holding a database with the expected suffix. A dump producing trigger started manually to prepare the restore is not necessarily `dump_trigger`, but the database it builds is just as good. Only builds in `done` or `running` are considered, the dump of a build still testing would be incomplete.