### PR TITLE
[IMP] runbot: add default (view) permissions

### DIFF
--- a/runbot/security/runbot_security.xml
+++ b/runbot/security/runbot_security.xml
@@ -21,7 +21,7 @@
     <record id="group_runbot_admin" model="res.groups">
       <field name="name">Runbot administrator</field>
       <field name="privilege_id" ref="runbot_privilege"/>
-      <field name="user_ids" eval="[(4, ref('base.user_root'))]"/>
+      <field name="user_ids" eval="[Command.link(ref('base.user_root')), Command.link(ref('base.user_admin'))]"/>
     </record>
 
     <record id="base.group_public" model="res.groups">

--- a/runbot/views/menus.xml
+++ b/runbot/views/menus.xml
@@ -15,11 +15,11 @@
 
     <menuitem name="Hosts" id="runbot_menu_host_tree" parent="runbot_menu_root" sequence="300" action="open_view_host_tree" groups="runbot.group_runbot_admin"/>
 
-    <menuitem id="runbot_menu_trigger_root" parent="runbot_menu_root" sequence="500" name="Triggers" groups="runbot.group_runbot_admin"/>
+    <menuitem id="runbot_menu_trigger_root" parent="runbot_menu_root" sequence="500" name="Triggers" groups="runbot.group_runbot_admin,runbot.group_runbot_advanced_user"/>
 
-    <menuitem id="runbot_menu_trigger" parent="runbot_menu_trigger_root" sequence="501" action="runbot_triggers_action" groups="runbot.group_runbot_admin"/>
+    <menuitem id="runbot_menu_trigger" parent="runbot_menu_trigger_root" sequence="501" action="runbot_triggers_action"/>
 
-    <menuitem id="runbot_menu_trigger_dependency" parent="runbot_menu_trigger_root" sequence="502" action="runbot_triggers_dependency_action" groups="runbot.group_runbot_admin"/>
+    <menuitem id="runbot_menu_trigger_dependency" parent="runbot_menu_trigger_root" sequence="502" action="runbot_triggers_dependency_action"/>
 
 
     

--- a/runbot/views/menus.xml
+++ b/runbot/views/menus.xml
@@ -56,7 +56,7 @@
    
     <menuitem name="Warnings" id="runbot_menu_warning_root" parent="runbot_menu_root" sequence="1200" action="open_view_warning_tree" groups="runbot.group_runbot_admin"/>
 
-    <menuitem name="Settings" id="menu_runbot_settings" parent="runbot_menu_root" sequence="9000" groups="runbot.group_runbot_admin"/>
+    <menuitem name="Settings" id="menu_runbot_settings" parent="runbot_menu_root" sequence="9000" groups="runbot.group_runbot_admin,runbot.group_runbot_advanced_user"/>
     <menuitem id="menu_runbot_global_settings" parent="menu_runbot_settings" action="action_runbot_configuration" groups="base.group_system"/>
     <menuitem id="menu_bundle_project" action="action_bundle_project"  sequence="10" parent="menu_runbot_settings"/>
     <menuitem id="menu_bundle_version" action="action_bundle_version"  sequence="20" parent="menu_runbot_settings"/>


### PR DESCRIPTION
'Runbot administrator' permission assignment to user 'admin' improves the fresh setup experience.
The additional menu options that are now visible for 'runbot advanced users' make it easier to navigate the runbot model space.