### PR TITLE
[IMP] Expand readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,47 +6,48 @@ This repository contains the source code of Odoo testing bot [runbot.odoo.com](h
 
 ## Warnings
 
-**Runbot will delete folders/drop databases to free some space during usage.** Even if only elements created by runbot are concerned, don't use runbot on a server with sensitive data.
+**Runbot will delete folders/drop databases to free disk space while running.** Even if only elements created by runbot are concerned, don't use runbot on a server with sensitive data.
 
-**Runbot changes some default odoo behaviours** Runbot database may work with other modules, but without any guarantee.
+**Runbot changes some default odoo behaviours.** Runbot database may work with other modules, but without any guarantee.
 
-**Runbot is not safe by itself** This tutorial describes the minimal way to deploy runbot, without security considerations. Only trusted code should be executed with this single machine setup. For more security the builder should be deployed separately with minimal access.
+**Runbot is not safe by itself.** This user guide describes a minimal deployment of runbot, without security considerations. Only trusted code should be executed with this single machine setup.
 
 ## Glossary/models
-Runbot encodes concepts that cover all the testing and validation use-cases for maintaining Odoo projects:
+Runbot uses the following concepts that cover testing and validation use-cases for maintaining Odoo projects:
 
 - **Project**: Logical grouping of repositories that are related to each other. Usually one project is enough and a default *R&D* project is automatically created.
-- **Repository**: Logical grouping of remotes. Usually you create *odoo* and *enterprise*.
+- **Repository**: Logical grouping of remotes. Usually you create `odoo` and `enterprise`.
 - **Remote**: A location to find (Git) repository information. Example: odoo/odoo, odoo-dev/odoo
-- **Bundle**: A group of matched[^branch-matching] branches across repositories eg, odoo/odoo/19.0 matches odoo/enterprise/19.0. Usually you see one bundle for every discovered branch (including PRs).
-- **Batch**: A group of commits, for all branches defined by the parent bundle. These commits build together.[^batches]
-- **Trigger**: Logic to automate creation of build instances. At a minimum you need one trigger per project to build new code eg, a new commit on odoo/odoo -[automatic batch creation]-> new batch -[trigger]-> new build to run odoo tests.
-- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is launched).[^build-start-delay] Builds generally execute code and produce output (logs, build artifacts, running odoo instance for testing).
+- **Bundle**: A group of branches with the same name and linked[^branch-matching] PRs eg, odoo/odoo/feature-A matches odoo/odoo/pr/1234.
+- **Batch**: A group of commits, logically linking the parent bundle with dependencies. These linked commits are built together.[^batches]
+- **Trigger**: Logic to automate creation of build instances. At a minimum you need one trigger per project to build new code eg, a new commit on odoo/odoo -[trigger]-> new build instance to run odoo tests.
+- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is launched).[^build-start-delay]  
+In more general terms: builds execute code and produce output eg, logs, build artifacts, interactive test-builds.
 
 
 [^branch-matching]: Matching only links related repositories within the same project.  
 [^batches]: Batches are created automatically by the parent bundle after detection of new commits.  
-[^build-start-delay]: By default, build creation is delayed until 60 seconds (debounce) after the most recent commit on the linked batch. This debounce value is part of the project configuration.  
+[^build-start-delay]: By default, build creation is delayed until 60 seconds (debounce) after the most recent commit on the same batch. This debounce value is part of the project configuration.  
 
 ## Processes
 
-Mainly to allow to distribute runbot on multiple machine and avoid cron worker limitations, the runbot is using 2 processes besides the main server.
+Runbot functionality is split to allow some horizontal scaling of the platform and circumvent Odoo cron limitations. Runbot is using 2 processes besides the main server.
 
-- **runbot web process**: The main runbot process serving web requests. A typical Odoo instance (odoo-bin process).
-- **leader process**: This process should only be started once, detect new commits and creates builds for builders.
-- **builder process**: This process can run at most once per physical host, will execute the builds assigned to themselves.
+- **runbot web process**: The main runbot process serving web requests, a typical odoo-bin process.
+- **leader process**: This process should only be started once, detects new commits and creates/assigns builds.
+- **builder process**: This process execute the builds assigned to themselves. Must be run at most once per physical host because of design limitations.
 
 ## Operational requirements
 
-You can safely skip ahead to [First steps with Runbot](#first-steps-with-runbot) if you are interested in trying out Runbot.  
-This section lists Runbot's expectations for the platform it's running on and configuration examples.
+You can skip ahead to [First steps with Runbot](#first-steps-with-runbot) if you are interested to try Runbot.  
+This section describes Runbot's expectations of its host with configuration examples.
 
 ### DNS
 
-You may configure a DNS entry for your runbot domain as well as a CNAME for all subdomain.
+You may configure a DNS entry for your runbot domain as well as a CNAME for all subdomain. DNS configuration is required to access interactive test-builds and download build artifacts.
 
 ```
-;; The documentation writer assumes the reader knows how to interpret this fragment of code.
+;; The documentation writer assumes the reader knows how to interpret this fragment of configuration.
 ;; The reader can also skip DNS configuration to use Runbot with a limited feature set.
 
 $ORIGIN domain.com.
@@ -54,12 +55,9 @@ runbot.domain.com.  IN A      127.0.0.1
 *                   IN CNAME  runbot.domain.com.
 ```
 
-This configuration is not necessary for a minimal setup.  
-You need similar domain setup to deploy Runbot in a production environment that gives access to running test database and test artifacts.
-
 ### nginx
 
-An example of config is given in the `example_scripts` folder.
+An example of config is given in the [./runbot/runbot/example_scripts]() directory.
 
 This may be adapted depending on your setup, mainly for domain names. This can be adapted during the install but serving at least the runbot frontend (proxy pass `80` to `8069`) is the minimal config needed.
 Note that runbot also has a dynamic nginx config listening on the `8080` port, mainly for running build.
@@ -70,12 +68,12 @@ It is also advised to adapt this config to work in `https`.
 
 ### Running unattended
 
-The directory [./runbot/runbot/example_scripts]() has example configuration to launch every Runbot process. This section explains how to configure Systemd to run Runbot unattended.
+The directory [./runbot/runbot/example_scripts]() has example configuration to launch every Runbot process. This section explains how to configure Systemd to start Runbot unattended.
 
-NOTE: This part assumes a dedicated user 'runbot' exists for running Runbot and accessing docker and postgresql.
+NOTE: This part assumes a dedicated user 'runbot' exists to start Runbot and 'runbot' has write permissions to docker and postgresql.
 
 Copy the runbot launch scripts to a known static location on the system.  
-If you want to store your launch scripts elsewhere, update the `ExecStart` parameter inside the systemd service unit files to match.
+If you want to store your launch scripts elsewhere, update the `ExecStart` parameter inside the systemd service files to match.
 
 ```bash
 workspace="/home/runbot/odoo/"
@@ -110,7 +108,7 @@ sudo systemctl start runbot
 sudo systemctl status runbot
 ```
 
-Ensure startup completed succesfully, then start and verify the other runbot processes too.  
+Ensure startup completed succesfully, then start and verify the other runbot processes.  
 Several log files should have been created in `/home/runbot/odoo/logs/`, one per service.
 
 ## User guide
@@ -135,9 +133,9 @@ sudo apt-get install docker.io python3-unidiff python3-docker python3-matplotlib
 ```
 
 Choose a workspace to clone both repositories and checkout the default branch in both of them.
-The directory used in example scripts is `/home/$USER/odoo/` 
+The directory used in the example scripts is `/home/$USER/odoo/` 
 
-Note: It is highly advised to create a dedicated user for runbot.
+Note: It is strongly advised to create a dedicated user for runbot.
 
 ```bash
 # This example creates a new unix user `runbot` with permissions to use docker and postgresql.
@@ -157,9 +155,16 @@ mkdir odoo
 cd odoo
 ```
 
-You may [add a valid ssh key to a github account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
- to be used by user `runbot` to clone the next repositories. You could clone in `https` but this may be a problem later to access your private repositories.  
-It is important to clone the repositories as the runbot user:
+Finally, check that you have access to docker, listing the docker containers should work without error (the list can be empty).
+
+```bash
+docker ps
+```
+If the command returns an error, add the unix user to the 'docker' group and logout/login again.
+
+You may [add a valid ssh key to a github account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) to be used by user `runbot` for cloning repositories. You could clone in `https` but ssh combined with unencrypted ssh key enables non-interactive fetches on private repositories.
+
+Clone the Odoo and Runbot repositories as the runbot user:
 
 ```bash
 git clone --depth=1 --branch=19.0 git@github.com:odoo/odoo.git
@@ -171,19 +176,12 @@ git -C runbot checkout 19.0
 mkdir logs
 ```
 
-Note: `--depth=1 --branch=19.0 ` is optional but this approach requires less available disk space. The odoo community and odoo enterprises repositories are large, monitor your free disk space regularly when you use them inside Runbot. (50+ GiB at minimum)
-
-Finally, check that you have access to docker, listing the docker containers should work without error (but the list will be empty).
-
-```bash
-docker ps 
-```
-If the command returns an error, add the unix user to the 'docker' group and logout/login again.
+Note: `--depth=1 --branch=19.0` is optional but this approach minimizes disk space usage. The odoo community and odoo enterprises repositories are large, monitor your free disk space regularly when you use them inside Runbot. (50+ GiB at minimum)
 
 
 #### Install runbot database
 
-Initialise a new Odoo database with Runbot automatically installed.
+Initialise a new Odoo database with Runbot modules installed.
 
 ```bash
 workspace="/home/$USER/odoo/"
@@ -206,11 +204,11 @@ You can now connect to your running instance and configure runbot.
 - Page [http://127.0.0.1:8069]() shows an empty bundle overview page. Nothing is configured yet.
 - Log into the backend as admin (default password: admin).
 - Visit page [Runbot > Settings > Settings](http://127.0.0.1:8069/odoo/settings) to update your instance settings:
-    - `Default number of workers` equals the maximum number of builds to run in parallel, consider setting the value to `#cpu - 1`.
-    - Modify `Default odoorc for builds` to change the running build master password to something unique ([ideally a hashed one](https://github.com/odoo/odoo/blob/master/odoo/tools/config.py#L1148)).
-    - Tweak the garbage collection settings, if you have limited disk space.
-    - `Max running builds` equals the maximum number of builds that remain externally accessible in parallel. These are the odoo-instances intended for manual intergration testing.
-    - `Max commit age (in days)` ensures new commits are created recently. Increase this limit in exceptional cases to detect older branches.
+    - **Default number of worker**, the maximum number of builds to run in parallel. Consider setting the value to `#cpu - 1`.
+    - **Default odoorc for builds**, modify to change the running build master password to something unique ([ideally a hashed one](https://github.com/odoo/odoo/blob/master/odoo/tools/config.py#L1148)).
+    - Tweak the garbage collection settings if you have limited disk space.
+    - **Max running builds**, the maximum number of builds that remain externally accessible. These are the interactive test-instances intended for manual integration validation.
+    - **Max commit age (in days)**, ensures new commits are created recently. Increase this value if branches (with old commit date) seem to be missing.
 
 If you intend to run this Runbot instance in a production environment, read through the Odoo documentation to secure it properly.  
 - Update the instance master password, which is used at the `/web/database/manager` endpoint. ([More info here](https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html#reset-the-master-password))
@@ -226,7 +224,7 @@ All requirements are met, go ahead and launch!
 ```
 
 Right away the leader process will not do anything, an instance admin must assign the leader role to this process first.
-- Open the backend, navigate to Runbot > Hosts
+- Open the backend, navigate to `Runbot > Hosts`
 - Open the record with hostname 'leader' (configurable name, see 'forced-host-name' parameter)
 - Enable options `Is leader` and `Is assigner`, disable `Is builder`, then save
 
@@ -241,9 +239,9 @@ The launch script `builder.sh` should be adapted, specifically the `forced-host-
 sed -i "s/runbot.domain.com/runbot.my_real_domain.com/" ~/bin/runbot/builder.sh
 ```
 
-*The host name equals the machine hostname and cannot be changed from the backend. The host name should be different per process, having the same host name for leader and builder is not ideal. The forced-host-name parameter is available to manually set a custom host name when launching the process.*
+*The host name equals the machine hostname and cannot be changed from the backend. The host name should be different per process, leader and builder sharing the same host name has security implications. The forced-host-name parameter is available to manually set a custom host name when launching the process.*
 
-Note: The host name of the builder process must match your DNS configuration (resolvable domain name). Runbot uses the host name to construct URLs for running builds (live test-instances), artifact downloads and log files. This value should be a fully qualified domain name that includes your real domain.  
+Note: The host name of the builder process should match your DNS configuration (resolvable domain name). Runbot uses the host name to construct URLs for running builds (interactive test-builds), artifact downloads and log files. This value should be a fully qualified domain name that includes your real domain.  
 The example nginx configuration file demonstrates how to accept and proxy incoming connections on the builder process host.
 
 #### Docker images
@@ -263,13 +261,13 @@ ls ~/odoo/runbot/runbot/static
 
 - **repo** contains bare git repositories for each remote
 - **sources** contains the exported sources needed for each build
-- **build** contains the run-environments (r/w volume mount into docker container) for builds, containing logs/ filestore, ...
+- **build** contains the run-environments (r/w volume mount into docker container) for builds, containing logs/filestore, ...
 - **docker** contains DockerFile and docker build logs
 - **nginx** contains the nginx config used to access running instances
 
 All of the above directories are empty right now, we haven't configured Runbot to build anything.
 
-Runbot also supports picking specific database templates to be initialised before build launch. Runbot uses 'template0' by default, but can be overwritten through `Runbot > Settings > Settings` or instance parameter *runbot.runbot_db_template*.
+Runbot also supports picking specific database templates to be initialised before build launch. By default template 'template0' is used (see [db template](#db template)).
 
 Other cron operations are still disabled for now.
 
@@ -288,14 +286,13 @@ Create a new repository to represent the odoo git repository
 - **Name**: `odoo`, name of the target directory when source code is exported.
 - **Identity File** `<empty>` useful if you want to use a specific ssh key to access the repo.
 - **Project**: `R&D` by default.
-- **Modules to install**: `-*` to remove all from the default value for `-i`([odoo-bin cli](https://www.odoo.com/documentation/19.0/developer/reference/cli.html#cmdoption-odoo-bin-i)). This will speed up installation. [^modules-to-install]
+- **Modules to install**: `-*` to remove all modules passed by default into parameter `-i`([odoo-bin cli](https://www.odoo.com/documentation/19.0/developer/reference/cli.html#cmdoption-odoo-bin-i)). This will speed up installation. [^modules-to-install]
 - **Server files**: `odoo-bin`, will instruct runbot how to launch odoo. [^bin-files]
 - **Manifest files**: `__manifest__.py`. This field is only useful to configure old versions of odoo.  
 - **Addons path**: `addons,odoo/addons`. The paths where addons are stored in this repository.
-- **Mode**: `poll`, since integrating github hooks is out of scope for this guide.  
-    Poll mode is limited to one update every 5 minutes.
+- **Mode**: `poll`, since integrating github hooks is out of scope for this guide. Poll mode is limited to one update every 5 minutes.
 - **Remotes**: `git@github.com:odoo/odoo.git`, the odoo community git repository.[^remotes]  
-    WARNING: Runbot will retrieve _all_ the repository data automatically! Downloading the entire odoo repository will take a long time.
+    WARNING: Runbot will retrieve _all_ the repository data automatically! Downloading the entire odoo repository takes a long time with slow internet speeds.
 
 [^modules-to-install]: To install and test all modules, leave this space empty or use `*`. Some modules may be blacklisted individually, by using `*-module,-other_module, l10n_*`.
 [^bin-files]: `odoo-bin` is the entrypoint to use since Odoo v11, but you may want to add other server files for older versions (comma separated list). All the entrypoint names are tried in definition order.
@@ -306,14 +303,13 @@ Create a new repository to represent the runbot git repository
 ![Odoo repo configuration](runbot/documentation/images/repo_runbot.png "Odoo repo configuration")
 - **Name**: `runbot`
 - **Project**: `R&D`.
-- **Modules to install**: `-*,runbot`, only install the runbot module (and module dependencies of course).
-- **Addons path**: `\<empty>`, without addons path Runbot uses the repository root to find modules.
+- **Modules to install**: `-*,runbot`, only install the runbot module (installs module dependencies automatically).
+- **Addons path**: `<empty>`, without addons path Runbot uses the repository root to find modules.
 - **Mode**: `poll`, since integrating github hooks is out of scope for this guide.
 - **Remotes**: `git@github.com:odoo/runbot.git` 
 - The remote *PR* option can be checked if needed to fetch pull request too. Will work only if a github token is given for this repo.
 
-If you link your own repository, it is advised to set **mode** to `hook`. The endpoint `/runbot/hook` becomes available to process incoming webhooks from Github. Other systems, like cron, can call endpoint `/runbot/hook/<repo_id>` to refresh the repository.  
-*It is advised to change the mode to 'hook' for all repositories to reduce end-to-end test latency.*
+Note: To reduce end-to-end latency it's best to set **mode** to `hook`. The endpoint `/runbot/hook` becomes available to process incoming webhooks from Github. Other systems, like cron, can call endpoint `/runbot/hook/<repo_id>` to refresh the repository.
 
 A config file with your remotes should be created for each repository. Verify the file contents at `/runbot/static/repo/(runbot|odoo)/config`.  
 Data is fetched from the remotes automatically, the first fetch will take a long time.  
@@ -325,7 +321,7 @@ At this point, runbot discovers new branches, new commits, creates bundles, but 
 To test the runbot code we want to create builds when the remote has new commits. To run runbot we also need a commit from the odoo repository. These requirements can be configured as a trigger.  
 When triggers activate, they take the linked config to create one or multiple builds. 
 
-Runbot has a couple of pre-configured configurations (config) that perform common operations like execute tests, keep test-build running, create coverage report, start multiple parallel builds for the same batch etc.
+Runbot has a couple of pre-configured configurations (config) that perform common operations like execute tests, setup interactive test-instances, create coverage report, start multiple parallel builds for the same batch etc.
 
 Configurations are composed of configuration steps. One of the default configuration steps is `all`, configured to test *all addons* including those from dependencies.  
 At the moment we're only interested in testing runbot, skipping tests from odoo `base` and `web` finishes our builds more quickly and doesn't give false positive errors in case some of those tests break.  
@@ -343,7 +339,7 @@ Remove the config step `base` from the config `Default no run`:
 - Open the record named `Default no run`
 - Inside the step order, remove config step `base`
 
-Config and steps are powerful concepts, even allowing Python code to be executed. Advanced usage is out of scope for this guide.
+Config and steps are powerful concepts, but advanced usage is out of scope for this guide.
 
 Open `Runbot > Triggers`
 
@@ -352,7 +348,7 @@ Create a new trigger that will generate builds for the runbot repo:
 - *Project id*: `runbot`, the trigger only reacts to repository updates linked to this project.
 - *Repositories*: Add link to `runbot`, commits from runbot are the main subject.
 - *Dependencies*: Add link to `odoo`, odoo source is required to run Runbot.
-- *Config*: `Default no run`, start a build but don't keep a test-build running at the end. You can still wake up a build.
+- *Config*: `Default no run`, start a build that executes tests, but don't start an interactive test-instance.
 
 You can either push new commits to the remote, or go on the frontend bundle page and use the `Force new batch` button (refresh icon) to test this new trigger. Build 'Runbot' is automatically created.
 
@@ -365,9 +361,9 @@ Runbot is now configured to automatically test changes made to the runbot code. 
 Bundles can be marked as `no_build`, so that new commit(s) won't create batches. The bundle won't be displayed on the overview page either.
 
 ## Hosts
-Runbot is able to automatically assign pending builds across multiple hosts. Currently, this action is performed by the leader process. The platform can run without a leader process or with exactly one active leader process.  
-A builder host will never assign a pending build to itself nor work-steal pending builds from other builders.
+Runbot is able to automatically assign pending builds across multiple hosts. Currently, this action is performed by the leader process. The platform requires exactly one active leader to process commit updates and automate build creation.
 
+A builder host will never assign a pending build to itself nor work-steal pending builds from other builders.  
 To manually assign builds to your fleet, exclude your buildhosts from the assignment pool and assign your build records directly to a specific builder.
 
 Open `Runbot > Hosts`
@@ -392,7 +388,7 @@ Tests can be filtered separately from modules, and an unconfigured value will ru
 ## db template
 Database creation before starting a build will use `template0` by default. It is possible to specify a specific template to use in the runbot settings field *Postgresql template*. A custom database is mainly used to add extensions.
 
-The Odoo Runbot team recommends generating a new template database `template_runbot` based on `template0`, prepare it according to your needs, and set its name in the runbot settings.
+The Odoo Runbot team recommends generating a new template database `template_runbot` based on `template0`, prepare it according to your needs, and set its name in field `Postgresql template` (`Runbot > Settings > Settings`) or instance parameter *runbot.runbot_db_template*.
 
 ```bash
 su postgres

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This repository contains the source code of Odoo testing bot [runbot.odoo.com](h
 
 ## Warnings
 
-**Runbot will delete folders/ drop databases to free some space during usage.** Even if only elements created by runbot are concerned, don't use runbot on a server with sensitive data.
+**Runbot will delete folders/drop databases to free some space during usage.** Even if only elements created by runbot are concerned, don't use runbot on a server with sensitive data.
 
 **Runbot changes some default odoo behaviours** Runbot database may work with other modules, but without any guarantee.
 
 **Runbot is not safe by itself** This tutorial describes the minimal way to deploy runbot, without security considerations. Only trusted code should be executed with this single machine setup. For more security the builder should be deployed separately with minimal access.
 
 ## Glossary/models
-Runbot use a set of concept in order to cover all the use cases we need
+Runbot encodes concepts that cover all the testing and validation use-cases for maintaining Odoo projects:
 
 - **Project**: Logical grouping of repositories that are related to each other. Usually one project is enough and a default *R&D* project is automatically created.
 - **Repository**: Logical grouping of remotes. Usually you create *odoo* and *enterprise*.
@@ -21,7 +21,7 @@ Runbot use a set of concept in order to cover all the use cases we need
 - **Bundle**: A group of matched[^1] branches across repositories eg, odoo/odoo/19.0 matches odoo/enterprise/19.0. Usually you see one bundle for every discovered branch (including PRs).
 - **Batch**: A group of commits, for all branches defined by the parent bundle. These commits build together.[^2]
 - **Trigger**: Logic to automate creation of build instances. At a minimum you need one trigger per project to build new code eg, a new commit on odoo/odoo -[automatic batch creation]-> new batch -[trigger]-> new build to run odoo tests.
-- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is invoked).[^3] Builds generally run code and produce output (logs, build artifacts, running odoo instance for testing).
+- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is launched).[^3] Builds generally execute code and produce output (logs, build artifacts, running odoo instance for testing).
 
 
 [^1]: Matching only links related repositories within the same project.  
@@ -38,7 +38,7 @@ Mainly to allow to distribute runbot on multiple machine and avoid cron worker l
 
 ## Operational requirements
 
-You can safely skip ahead to [Setup Runbot](#setup-runbot) if you are interested in trying out Runbot.  
+You can safely skip ahead to [First steps with Runbot](#first-steps-with-runbot) if you are interested in trying out Runbot.  
 This section lists Runbot's expectations for the platform it's running on and configuration examples.
 
 ### DNS
@@ -68,7 +68,7 @@ This config is an `ir_ui_view` (runbot.nginx_config) and can be edited if needed
 
 It is also advised to adapt this config to work in `https`.
 
-### Unattended run
+### Running unattended
 
 The directory [./runbot/runbot/example_scripts]() has example configuration to launch every Runbot process. This section explains how to configure Systemd to run Runbot unattended.
 
@@ -113,7 +113,7 @@ sudo systemctl status runbot
 Ensure startup completed succesfully, then start and verify the other runbot processes too.  
 Several log files should have been created in `/home/runbot/odoo/logs/`, one per service.
 
-## Runbot up and running
+## First steps with Runbot
 
 Follow along to get a new Runbot instance configured that tests code from this (Runbot) repository. Runbotception!  
 Note that Runbot runs on top of Odoo community and we'll not be testing Odoo community itself.
@@ -128,13 +128,11 @@ Runbot is an addon for odoo, meaning that both odoo and runbot repositories are 
 2. [Run the server - Odoo setup guide](https://www.odoo.com/documentation/19.0/developer/tutorials/setup_guide.html#run-the-server)
 
 
-Install Runbot requirements.
+Install Runbot dependencies.
 
 ```bash
 sudo apt-get install docker.io python3-unidiff python3-docker python3-matplotlib
 ```
-
-### Setup
 
 Choose a workspace to clone both repositories and checkout the default branch in both of them.
 The directory used in example scripts is `/home/$USER/odoo/` 
@@ -183,7 +181,7 @@ docker ps
 If the command returns an error, add the unix user to the 'docker' group and logout/login again.
 
 
-### Install and start runbot
+#### Install runbot database
 
 Initialise a new Odoo database with Runbot automatically installed.
 
@@ -195,7 +193,7 @@ workspace="/home/$USER/odoo/"
 
 This is all the preparation necessary to start every runbot process. Usually you'll start each of them in the proper order.
 
-#### Runbot web
+### Runbot process
 
 All requirements are met, go ahead and launch!
 
@@ -204,24 +202,21 @@ All requirements are met, go ahead and launch!
 "$workspace/runbot/runbot/example_scripts/runbot/runbot.sh"
 ```
 
-Navigate your browser to [http://127.0.0.1:8069]() to land on the bundle overview page. This page is empty because nothing is configured yet.  
-Navigate to [http://127.0.0.1:8069/odoo/settings]()
-
 You can now connect to your running instance and configure runbot.
 - Page [http://127.0.0.1:8069]() shows an empty bundle overview page. Nothing is configured yet.
 - Log into the backend as admin (default password: admin).
 - Visit page [Runbot > Settings > Settings](http://127.0.0.1:8069/odoo/settings) to update your instance settings:
-     Default number of workers should be the max number of parallel build, consider having max `#cpu - 1`
-    - Modify `Default odoorc for builds` to change the running build master password to something unique ([ideally a hashed one](https://github.com/odoo/odoo/blob/19.0/odoo/tools/config.py#L787)).
+    - `Default number of workers` equals the maximum number of builds to run in parallel, consider setting the value to `#cpu - 1`.
+    - Modify `Default odoorc for builds` to change the running build master password to something unique ([ideally a hashed one](https://github.com/odoo/odoo/blob/master/odoo/tools/config.py#L1148)).
     - Tweak the garbage collection settings, if you have limited disk space.
-    - The `number of running build` is the number of parallel running builds.
-    - `Max commit age (in days)` will limt the max age of commit to detect. Increase this limit to detect older branches.
+    - `Max running builds` equals the maximum number of builds that remain externally accessible in parallel. These are the odoo-instances intended for manual intergration testing.
+    - `Max commit age (in days)` ensures new commits are created recently. Increase this limit in exceptional cases to detect older branches.
 
-If you intend to have this instance running in a production environment, read through the Odoo documentation to secure your instance.  
+If you intend to run this Runbot instance in a production environment, read through the Odoo documentation to secure it properly.  
 - Update the instance master password, which is used at the `/web/database/manager` endpoint. ([More info here](https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html#reset-the-master-password))
 - Change the login credentials of the admin user
 
-##### Leader
+### Leader process
 
 All requirements are met, go ahead and launch!
 
@@ -230,22 +225,36 @@ All requirements are met, go ahead and launch!
 "$workspace/runbot/runbot/example_scripts/runbot/leader.sh"
 ```
 
-# -- TODO
+Right away the leader process will not do anything, an instance admin must assign the leader role to this process first.
+- Open the backend, navigate to Runbot > Hosts
+- Open the record with hostname 'leader' (configurable name, see 'forced-host-name' parameter)
+- Enable options `Is leader` and `Is assigner`, disable `Is builder`, then save
 
-##### Builder
+Observe the leader process stopped writing "..is not a leader host.." to the console.
 
-The launch script `builder.sh` should be adapted, mainly for the  `--forced-host-name` parameter value:
+
+### Builder process
+
+The launch script `builder.sh` should be adapted, specifically the `forced-host-name` parameter value:
 
 ```bash
 sed -i "s/runbot.domain.com/runbot.my_real_domain.com/" ~/bin/runbot/builder.sh
 ```
 
-*The hostname is initally the machine hostname but it should be different per process, having the same hostname for leader and builder is not ideal. This is why the script is using the forced-host-name parameter.*
+*The host name equals the machine hostname and cannot be changed from the backend. The host name should be different per process, having the same host name for leader and builder is not ideal. The forced-host-name parameter is available to manually set a custom host name when launching the process.*
 
-*The most important one is the builder hostname since it will be used to define running build, zip download and logs urls. We recommand setting your main domain name on this process. The nginx config given in example should be adapted if not.*
+Note: The host name of the builder process must match your DNS configuration (resolvable domain name). Runbot uses the host name to construct URLs for running builds (live test-instances), artifact downloads and log files. This value should be a fully qualified domain name that includes your real domain.  
+The example nginx configuration file demonstrates how to accept and proxy incoming connections on the builder process host.
 
+#### DOCKER images
+A default docker image (name 'DockerDefault') record is present in the database. The corresponding docker image should be built automatically by builder processes.  
+The code you're trying to build/test may require additional preinstalled dependencies. The recommended approach is to modify the default Dockerfile to match your situation.
+
+The Odoo Runbot team maintains a set of prebuilt docker images that are compatible with actively supported Odoo versions. Ask them for a link to use in your own Runbot.
 
 #### Bootstrap
+# --- TODO
+
 Once launched, the leader process should start to do basic work and bootstrap will start to setup some directories in static.
 
 ```bash
@@ -266,12 +275,12 @@ A database defined by *runbot.runbot_db_template* icp will be created. By defaul
 
 Other cron operations are still disabled for now.
 
-#### DOCKER images
-A default docker image is present in the database and should automatically be build (this may take some time, check builder logs). 
-Depending on your version it may not be enough.
-You can modify it to fit your needs or ask us for the latest version of the Dockerfile waiting for an official link.
 
-#### Add remotes and repositories
+## Test Runbot code
+All the Runbot processes are running and provisioned with basic configuration.  
+This section explains the configuration to achieve automated Runbot testing.
+
+### Repositories and remotes
 Access runbot app and go to the `Runbot>Setting>Repositories` menu
 
 Create a new repo for odoo
@@ -303,7 +312,7 @@ Create a repo for your custom addons repo
 
 A config file with your remotes should be created for each repo. You can check the content in `/runbot/static/repo/(runbot|odoo)/config`. The repo will be fetched, this operation may take some time too. After that, you should start seeing empty batches in both projects on the frontend (`/` or `/runbot`)
 
-#### Triggers and config
+### Triggers and linked config
 At this point, runbot will discover new branches, new commits, create bundle, but no build will be created.
 
 When a new commit is discovered, the branch is updated with a new commit. Then this commit is added in a batch, a container for new builds when they arrive, but only if a trigger corresponding to this repo exists. After one minute without a new commit update in the batch, the different triggers will create one build each.
@@ -343,11 +352,11 @@ CI options will only be used to send status on remotes of trigger repositories h
 
 You can either push, or go on the frontend bundle page and use the `Force new batch` button (refresh icon) to test this new trigger.
 
-#### Bundles
+### Bundles
 
 Bundles can be marked as `no_build`, so that new commit(s) won't create batch creation and the bundle won't be displayed on the main page.
 
-#### Hosts
+### Hosts
 Runbot is able to share pending builds across multiple hosts. In the present case, there is only one. A new host will never assign a pending build to itself by default.
 Go to the "Build Hosts" menu and choose yours. Uncheck *Only accept assigned build*. You can also tweak the number of parallel builds for this host.
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Runbot use a set of concept in order to cover all the use cases we need
 
 Mainly to allow to distribute runbot on multiple machine and avoid cron worker limitations, the runbot is using 2 processes besides the main server.
 
-- **runbot process**: the main runbot process, serving the frontend. This is the odoo-bin process.
-- **leader process**: this process should only be started once, detect new commits and creates builds for builders.
-- **builder process**: this process can run at most once per physical host, will execute the builds assigned to themselves.
+- **runbot web process**: The main runbot process serving web requests. A typical Odoo instance (odoo-bin process).
+- **leader process**: This process should only be started once, detect new commits and creates builds for builders.
+- **builder process**: This process can run at most once per physical host, will execute the builds assigned to themselves.
 
 ## Operational requirements
 
@@ -68,10 +68,57 @@ This config is an `ir_ui_view` (runbot.nginx_config) and can be edited if needed
 
 It is also advised to adapt this config to work in `https`.
 
+### Unattended run
+
+The directory [./runbot/runbot/example_scripts]() has example configuration to launch every Runbot process. This section explains how to configure Systemd to run Runbot unattended.
+
+NOTE: This part assumes a dedicated user 'runbot' exists for running Runbot and accessing docker and postgresql.
+
+Copy the runbot launch scripts to a known static location on the system.  
+If you want to store your launch scripts elsewhere, update the `ExecStart` parameter inside the systemd service unit files to match.
+
+```bash
+workspace="/home/runbot/odoo/"
+
+su runbot
+mkdir ~/bin
+cp -r "${workspace}/runbot/runbot/example_scripts/runbot" ~/bin/runbot
+```
+
+Create the corresponding services. You can copy them from the example scripts and adapt them:
+
+```bash
+exit # go back to a sudoer user
+
+runbot_user="runbot"
+sudo cp "${workspace}/runbot/runbot/example_scripts/services/*" /etc/systemd/system/
+sudo sed -i "s/runbot_user/${runbot_user}/" /etc/systemd/system/runbot.service
+sudo sed -i "s/runbot_user/${runbot_user}/" /etc/systemd/system/leader.service
+sudo sed -i "s/runbot_user/${runbot_user}/" /etc/systemd/system/builder.service
+```
+
+Enable all services and start the runbot frontend.
+
+```bash
+sudo systemctl daemon-reload
+
+sudo systemctl enable runbot
+sudo systemctl enable leader
+sudo systemctl enable builder
+
+sudo systemctl start runbot
+sudo systemctl status runbot
+```
+
+Ensure startup completed succesfully, then start and verify the other runbot processes too.  
+Several log files should have been created in `/home/runbot/odoo/logs/`, one per service.
+
 ## Runbot up and running
 
-This section explains how to configure Runbot. You most likely want to divert to support your own use case. Follow along to get a new Runbot instance configured that tests code from this (Runbot) repository. Runbotception!  
+Follow along to get a new Runbot instance configured that tests code from this (Runbot) repository. Runbotception!  
 Note that Runbot runs on top of Odoo community and we'll not be testing Odoo community itself.
+
+You most likely want to divert from these instructions to better support your own use case.
 
 ### Requirements
 
@@ -79,9 +126,6 @@ Runbot is an addon for odoo, meaning that both odoo and runbot repositories are 
 
 1. [Prepare - Odoo source install](https://www.odoo.com/documentation/19.0/administration/on_premise/source.html#prepare)
 2. [Run the server - Odoo setup guide](https://www.odoo.com/documentation/19.0/developer/tutorials/setup_guide.html#run-the-server)
-
-Can you create and launch a new (empty) Odoo database from the command-line?  
-If yes, let's focus now on Runbot itself!
 
 
 Install Runbot requirements.
@@ -95,10 +139,10 @@ sudo apt-get install docker.io python3-unidiff python3-docker python3-matplotlib
 Choose a workspace to clone both repositories and checkout the default branch in both of them.
 The directory used in example scripts is `/home/$USER/odoo/` 
 
-Note: It is highly advised to create a user for runbot.
+Note: It is highly advised to create a dedicated user for runbot.
 
 ```bash
-# This example creates a new user `runbot` with the right environment permissions
+# This example creates a new unix user `runbot` with permissions to use docker and postgresql.
 
 sudo adduser runbot
 
@@ -136,21 +180,61 @@ Finally, check that you have access to docker, listing the docker containers sho
 ```bash
 docker ps 
 ```
-If the command returns an error, ensure the unix user is part of the docker group and logout/login again.
+If the command returns an error, add the unix user to the 'docker' group and logout/login again.
 
-# --- TODO
+
 ### Install and start runbot
 
-This part is only consist in configuring and starting the 3 services.
-
-Some example scripts are given in `runbot/runbot/example_scripts`
+Initialise a new Odoo database with Runbot automatically installed.
 
 ```bash
-mkdir ~/bin # if does not exist
-cp -r ~/odoo/runbot/runbot/example_scripts/runbot ~/bin/runbot
+workspace="/home/$USER/odoo/"
+
+"$workspace/odoo/odoo-bin" --addons-path "$workspace/odoo/addons,$workspace/runbot" -d runbot -i runbot --stop-after-init
 ```
 
-Scripts should be adapted, mainly for the  `--forced-host-name parameter` in `builder.sh`:
+This is all the preparation necessary to start every runbot process. Usually you'll start each of them in the proper order.
+
+#### Runbot web
+
+All requirements are met, go ahead and launch!
+
+```bash
+# Launch the Runbot web service
+"$workspace/runbot/runbot/example_scripts/runbot/runbot.sh"
+```
+
+Navigate your browser to [http://127.0.0.1:8069]() to land on the bundle overview page. This page is empty because nothing is configured yet.  
+Navigate to [http://127.0.0.1:8069/odoo/settings]()
+
+You can now connect to your running instance and configure runbot.
+- Page [http://127.0.0.1:8069]() shows an empty bundle overview page. Nothing is configured yet.
+- Log into the backend as admin (default password: admin).
+- Visit page [Runbot > Settings > Settings](http://127.0.0.1:8069/odoo/settings) to update your instance settings:
+     Default number of workers should be the max number of parallel build, consider having max `#cpu - 1`
+    - Modify `Default odoorc for builds` to change the running build master password to something unique ([ideally a hashed one](https://github.com/odoo/odoo/blob/19.0/odoo/tools/config.py#L787)).
+    - Tweak the garbage collection settings, if you have limited disk space.
+    - The `number of running build` is the number of parallel running builds.
+    - `Max commit age (in days)` will limt the max age of commit to detect. Increase this limit to detect older branches.
+
+If you intend to have this instance running in a production environment, read through the Odoo documentation to secure your instance.  
+- Update the instance master password, which is used at the `/web/database/manager` endpoint. ([More info here](https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html#reset-the-master-password))
+- Change the login credentials of the admin user
+
+##### Leader
+
+All requirements are met, go ahead and launch!
+
+```bash
+# Launch the Runbot leader process
+"$workspace/runbot/runbot/example_scripts/runbot/leader.sh"
+```
+
+# -- TODO
+
+##### Builder
+
+The launch script `builder.sh` should be adapted, mainly for the  `--forced-host-name` parameter value:
 
 ```bash
 sed -i "s/runbot.domain.com/runbot.my_real_domain.com/" ~/bin/runbot/builder.sh
@@ -160,54 +244,6 @@ sed -i "s/runbot.domain.com/runbot.my_real_domain.com/" ~/bin/runbot/builder.sh
 
 *The most important one is the builder hostname since it will be used to define running build, zip download and logs urls. We recommand setting your main domain name on this process. The nginx config given in example should be adapted if not.*
 
-
-Create the corresponding services. You can copy them from the example scripts and adapt them:
-
-```bash
-exit # go back to a sudoer user
-runbot_user="runbot"
-sudo bash -c "cp /home/${runbot_user}/odoo/runbot/runbot/example_scripts/services/* /etc/systemd/system/"
-sudo sed -i "s/runbot_user/${runbot_user}/" /etc/systemd/system/runbot.service
-sudo sed -i "s/runbot_user/${runbot_user}/" /etc/systemd/system/leader.service
-sudo sed -i "s/runbot_user/${runbot_user}/" /etc/systemd/system/builder.service
-```
-
-Enable all services and start runbot frontend
-
-```bash
-sudo systemctl enable runbot
-sudo systemctl enable leader
-sudo systemctl enable builder
-sudo systemctl daemon-reload
-sudo systemctl start runbot
-sudo systemctl status runbot
-```
-
-Runbot service should be running
-
-You can now connect to your backend and preconfigure runbot. 
-- Install runbot module, if it wasn't done before.
-- Navigate to `/web` to leave the website configurator.
-- Connect as admin (default password: admin).
-
-Check odoo documentation for other needed security configuration (master password). This is mainly needed for production purpose.
-You can check that in the `/web/database/manager` page. ([more info here](https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html#reset-the-master-password)) \
-Change your admin user login and password
-You may want to check the runbot settings (`Runbot > Setting > setting`):
-- Default number of workers should be the max number of parallel build, consider having max `#cpu - 1`
-- Modify `Default odoorc for builds` to change the running build master password to something unique ([ideally a hashed one](https://github.com/odoo/odoo/blob/19.0/odoo/tools/config.py#L787)).
-- Tweak the garbage collection settings, if you have limited disk space.
-- The `number of running build` is the number of parallel running builds.
-- `Max commit age (in days)` will limt the max age of commit to detect. Increase this limit to detect older branches.
-
-Finally, start the two other services:
-
-```bash
-systemctl start leader
-systemctl start builder
-```
-
-Several log files should have been created in `/home/runbot/odoo/logs/`, one per service.
 
 #### Bootstrap
 Once launched, the leader process should start to do basic work and bootstrap will start to setup some directories in static.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Runbot encodes concepts that cover all the testing and validation use-cases for 
 - **Project**: Logical grouping of repositories that are related to each other. Usually one project is enough and a default *R&D* project is automatically created.
 - **Repository**: Logical grouping of remotes. Usually you create *odoo* and *enterprise*.
 - **Remote**: A location to find (Git) repository information. Example: odoo/odoo, odoo-dev/odoo
-- **Bundle**: A group of matched[^1] branches across repositories eg, odoo/odoo/19.0 matches odoo/enterprise/19.0. Usually you see one bundle for every discovered branch (including PRs).
-- **Batch**: A group of commits, for all branches defined by the parent bundle. These commits build together.[^2]
+- **Bundle**: A group of matched[^branch-matching] branches across repositories eg, odoo/odoo/19.0 matches odoo/enterprise/19.0. Usually you see one bundle for every discovered branch (including PRs).
+- **Batch**: A group of commits, for all branches defined by the parent bundle. These commits build together.[^batches]
 - **Trigger**: Logic to automate creation of build instances. At a minimum you need one trigger per project to build new code eg, a new commit on odoo/odoo -[automatic batch creation]-> new batch -[trigger]-> new build to run odoo tests.
-- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is launched).[^3] Builds generally execute code and produce output (logs, build artifacts, running odoo instance for testing).
+- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is launched).[^build-start-delay] Builds generally execute code and produce output (logs, build artifacts, running odoo instance for testing).
 
 
-[^1]: Matching only links related repositories within the same project.  
-[^2]: Batches are created automatically by the parent bundle after detection of new commits.  
-[^3]: By default, build creation is delayed until 60 seconds (debounce) after the most recent commit on the linked batch. This debounce value is part of the project configuration.  
+[^branch-matching]: Matching only links related repositories within the same project.  
+[^batches]: Batches are created automatically by the parent bundle after detection of new commits.  
+[^build-start-delay]: By default, build creation is delayed until 60 seconds (debounce) after the most recent commit on the linked batch. This debounce value is part of the project configuration.  
 
 ## Processes
 
@@ -246,71 +246,78 @@ sed -i "s/runbot.domain.com/runbot.my_real_domain.com/" ~/bin/runbot/builder.sh
 Note: The host name of the builder process must match your DNS configuration (resolvable domain name). Runbot uses the host name to construct URLs for running builds (live test-instances), artifact downloads and log files. This value should be a fully qualified domain name that includes your real domain.  
 The example nginx configuration file demonstrates how to accept and proxy incoming connections on the builder process host.
 
-#### DOCKER images
-A default docker image (name 'DockerDefault') record is present in the database. The corresponding docker image should be built automatically by builder processes.  
-The code you're trying to build/test may require additional preinstalled dependencies. The recommended approach is to modify the default Dockerfile to match your situation.
+#### Docker images
+Builder processes run builds inside docker containers. These containers are instantiations from docker images defined inside Runbot model 'Docker file', a common docker file is provisioned by default. Builders will fetch (see Remote Registries) or build (see [Dockerfiles](#dockerfiles)) the images for every docker file automatically.
 
-The Odoo Runbot team maintains a set of prebuilt docker images that are compatible with actively supported Odoo versions. Ask them for a link to use in your own Runbot.
+#### Local data
 
-#### Bootstrap
-# --- TODO
-
-Once launched, the leader process should start to do basic work and bootstrap will start to setup some directories in static.
+The processes attempt to cache as much data as possible to reduce total wait time until builds finish. This data is stored inside the directory 'static'.
 
 ```bash
 su runbot
+
 ls ~/odoo/runbot/runbot/static
+> build  docker  nginx  repo  sources  src
+
 ```
 
->build  docker  nginx  repo  sources  src
-
-- **repo** contains the bare repositories
+- **repo** contains bare git repositories for each remote
 - **sources** contains the exported sources needed for each build
-- **build** contains the different workspaces for dockers, containing logs/ filestore, ...
+- **build** contains the run-environments (r/w volume mount into docker container) for builds, containing logs/ filestore, ...
 - **docker** contains DockerFile and docker build logs
 - **nginx** contains the nginx config used to access running instances
-All of them are empty for now.
 
-A database defined by *runbot.runbot_db_template* icp will be created. By default, runbot use template0. This database will be used as a template for testing builds. You can change this database for more customisation.
+All of the above directories are empty right now, we haven't configured Runbot to build anything.
+
+Runbot also supports picking specific database templates to be initialised before build launch. Runbot uses 'template0' by default, but can be overwritten through `Runbot > Settings > Settings` or instance parameter *runbot.runbot_db_template*.
 
 Other cron operations are still disabled for now.
 
 
 ## Test Runbot code
-All the Runbot processes are running and provisioned with basic configuration.  
-This section explains the configuration to achieve automated Runbot testing.
+All the Runbot processes are running and provisioned with basic configuration. Now it's time to perform some actual continuous integration (CI)!
 
 ### Repositories and remotes
-Access runbot app and go to the `Runbot>Setting>Repositories` menu
+Runbot needs code to build. It can retrieve code automatically through git repository synchronisation.
 
-Create a new repo for odoo
+Open the Runbot backend and open `Runbot > Setting > Repositories`.
+
+Create a new repository to represent the odoo git repository
 ![Odoo repo configuration](runbot/documentation/images/repo_odoo.png "Odoo repo configuration")
 
-- **Name**: `odoo` It will be used as the directory name to export the sources.
-- **Identity File** is only useful if you want to use another ssh key to access a repo.
+- **Name**: `odoo`, name of the target directory when source code is exported.
+- **Identity File** `<empty>` useful if you want to use a specific ssh key to access the repo.
 - **Project**: `R&D` by default.
-- **Modules to install**: `-*` in order to remove them from the default `-i`. This will speed up installation. To install and test all modules, leave this space empty or use `*`. Some modules may be blacklisted individually, by using `*-module,-other_module, l10n_*`.
-- **Server files**: `odoo-bin` will allow runbot to know the possible file to use to launch odoo. `odoo-bin` is the one to use for the last version, but you may want to add other server files for older versions (comma separated list). The same logic is used for manifest files.
+- **Modules to install**: `-*` to remove all from the default value for `-i`([odoo-bin cli](https://www.odoo.com/documentation/19.0/developer/reference/cli.html#cmdoption-odoo-bin-i)). This will speed up installation. [^modules-to-install]
+- **Server files**: `odoo-bin`, will instruct runbot how to launch odoo. [^bin-files]
 - **Manifest files**: `__manifest__.py`. This field is only useful to configure old versions of odoo.  
 - **Addons path**: `addons,odoo/addons`. The paths where addons are stored in this repository.
-- **Mode**: `poll` since github won't hook your runbot instance. Poll mode is limited to one update every 5 minutes. *It is advised to set it in hook mode later and hook it manually of from a cron or automated action to have more control*.
-- **Remotes**: `git@github.com:odoo/odoo.git` A single remote is added, the base odoo repo. Only branches will be fetched to limit disk usage and branches will be created in the backend. It is possible to add multiple remotes for forks.
+- **Mode**: `poll`, since integrating github hooks is out of scope for this guide.  
+    Poll mode is limited to one update every 5 minutes.
+- **Remotes**: `git@github.com:odoo/odoo.git`, the odoo community git repository.[^remotes]  
+    WARNING: Runbot will retrieve _all_ the repository data automatically! Downloading the entire odoo repository will take a long time.
 
-Create another project for your repositories `Runbot>Setting>Project`
+[^modules-to-install]: To install and test all modules, leave this space empty or use `*`. Some modules may be blacklisted individually, by using `*-module,-other_module, l10n_*`.
+[^bin-files]: `odoo-bin` is the entrypoint to use since Odoo v11, but you may want to add other server files for older versions (comma separated list). All the entrypoint names are tried in definition order.
+[^remotes]: You can add more remotes to logically combine the work saved on (private) forks of the project, or to simply have redundancy.
 
-This is optionnal you could use the R&D one, but this may be more noisy since every update in odoo/odoo will be displayed on the same page as your own repo one. Splitting by project also allows to manage access rights. 
 
-Create a repo for your custom addons repo
+Create a new repository to represent the runbot git repository
 ![Odoo repo configuration](runbot/documentation/images/repo_runbot.png "Odoo repo configuration")
 - **Name**: `runbot`
-- **Project**: `runbot`.
-- **Modules to install**: `-*,runbot` to only install the runbot module.
-- **Addons path**: No `addons_path` given to use repo root as default.
-- (optionnal) For your custom repo, it is advised to configure the repo in `hook` mode if possible, adding a webhook on `/runbot/hook`. Use `/runbot/hook/<repo_id>` to do it manually.
+- **Project**: `R&D`.
+- **Modules to install**: `-*,runbot`, only install the runbot module (and module dependencies of course).
+- **Addons path**: `\<empty>`, without addons path Runbot uses the repository root to find modules.
+- **Mode**: `poll`, since integrating github hooks is out of scope for this scope.
 - **Remotes**: `git@github.com:odoo/runbot.git` 
 - The remote *PR* option can be checked if needed to fetch pull request too. Will work only if a github token is given for this repo.
 
-A config file with your remotes should be created for each repo. You can check the content in `/runbot/static/repo/(runbot|odoo)/config`. The repo will be fetched, this operation may take some time too. After that, you should start seeing empty batches in both projects on the frontend (`/` or `/runbot`)
+If you link your own repository, it is advised to set **mode** to `hook`. The endpoint `/runbot/hook` becomes available to process incoming webhooks from Github. Other systems, like cron, can call endpoint `/runbot/hook/<repo_id>` to refresh the repository.  
+*It is advised to change the mode to 'hook' for all repositories to reduce end-to-end test latency.*
+
+A config file with your remotes should be created for each repository. Verify the file contents at `/runbot/static/repo/(runbot|odoo)/config`.  
+The repositories will be fetched automatically, this operation may take some time too.  
+After fetching finishes you should see empty batches in both projects on the website frontend (`/` or `/runbot`)
 
 ### Triggers and linked config
 At this point, runbot will discover new branches, new commits, create bundle, but no build will be created.
@@ -377,18 +384,19 @@ createdb template_runbot -T template0
 
 ## Dockerfiles
 
-Runbot is using a Dockerfile Odoo model to define the Dockerfile used for builds and is shipped with a default one. This default Dockerfile is based on Ubuntu Bionic and is intended to build recent supported versions of Odoo.
+Runbot is using odoo model 'docker file' to define the Dockerfile used for builds and is shipped with a default record. This default Dockerfile is based on Ubuntu Noble (24.04) and is capable of building (supported versions of) Odoo.
 
-The model is using Odoo QWeb views as templates.
+The model uses Odoo QWeb views to compile Dockerfile contents.
 
 A new Dockerfile can be created as needed either by duplicating the default one and adapt parameters in the view. e.g.: changing the key `'from': 'ubuntu:jammy'` to `'from': 'debian:buster'` will create a new Dockerfile based on Debian instead of ubuntu.
 Or by providing a plain Dockerfile in the template.
 
 Once the Dockerfile is created and the `to_build` field is checked, the Dockerfile will be built (pay attention that no other operations will occur during the build).
 
-A version or a bundle can be assigned a specific Dockerfile.
+A specific docker file can be assigned to the models version and bundle.
 
+The Odoo Runbot team maintains a set of prebuilt docker images that are compatible with actively supported Odoo versions. Ask them for a link to use in your own Runbot.
 
 ## User documentation
 
- You can find a more detailed user documentation [here](./runbot/documentation/readme.md)
+You can find a more detailed user documentation [here](./runbot/documentation/readme.md)

--- a/README.md
+++ b/README.md
@@ -10,44 +10,56 @@ This repository contains the source code of Odoo testing bot [runbot.odoo.com](h
 
 **Runbot changes some default odoo behaviours** Runbot database may work with other modules, but without any guarantee.
 
-**Runbot is not safe by itself** This tutorial describes the minimal way to deploy runbot, without too many security considerations. Only trusted code should be executed with this single machine setup. For more security the builder should be deployed separately with minimal access.
+**Runbot is not safe by itself** This tutorial describes the minimal way to deploy runbot, without security considerations. Only trusted code should be executed with this single machine setup. For more security the builder should be deployed separately with minimal access.
 
 ## Glossary/models
 Runbot use a set of concept in order to cover all the use cases we need
 
-- **Project**: regroups a set of repositories that works together. Usually one project is enough and a default *R&D* project exists.
-- **Repository**: A repository name regrouping repo and forks Ex: odoo, enterprise
-- **Remote**: A remote for a repository. Example: odoo/odoo, odoo-dev/odoo
-- **Build**: A test instance, using a set of commits and parameters to run some code and produce a result.
-- **Trigger**: Indicates that a build should be created when a new commit is pushed on a repo. A trigger has both trigger repos, and dependency repo. Ex: new commit on runbot-> build with runbot and a dependency with odoo.
-- **Bundle**: A set or branches that work together: all the branches with the same name and all linked pr in the same project.
-- **Batch**: A container for builds and commits of a bundle. When a new commit is pushed on a branch, if a trigger exists for the repo of that branch, a new batch is created with this commit. After 60 seconds, if no other commit is added to the batch, a build is created by trigger having a new commit in this batch.
+- **Project**: Logical grouping of repositories that are related to each other. Usually one project is enough and a default *R&D* project is automatically created.
+- **Repository**: Logical grouping of remotes. Usually you create *odoo* and *enterprise*.
+- **Remote**: A location to find (Git) repository information. Example: odoo/odoo, odoo-dev/odoo
+- **Bundle**: A group of matched[^1] branches across repositories eg, odoo/odoo/19.0 matches odoo/enterprise/19.0. Usually you see one bundle for every discovered branch (including PRs).
+- **Batch**: A group of commits, for all branches defined by the parent bundle. These commits build together.[^2]
+- **Trigger**: Logic to automate creation of build instances. At a minimum you need one trigger per project to build new code eg, a new commit on odoo/odoo -[automatic batch creation]-> new batch -[trigger]-> new build to run odoo tests.
+- **Build**: Represents the execution of odoo, in practice this is when testing happens (`odoo-bin --tests-enabled <..>` is invoked).[^3] Builds generally run code and produce output (logs, build artifacts, running odoo instance for testing).
+
+
+[^1]: Matching only links related repositories within the same project.  
+[^2]: Batches are created automatically by the parent bundle after detection of new commits.  
+[^3]: By default, build creation is delayed until 60 seconds (debounce) after the most recent commit on the linked batch. This debounce value is part of the project configuration.  
 
 ## Processes
 
-Mainly to allow to distribute runbot on multiple machine and avoid cron worker limitations, the runbot is using 2 process besides the main server.
+Mainly to allow to distribute runbot on multiple machine and avoid cron worker limitations, the runbot is using 2 processes besides the main server.
 
 - **runbot process**: the main runbot process, serving the frontend. This is the odoo-bin process.
 - **leader process**: this process should only be started once, detect new commits and creates builds for builders.
-- **builder process**: this process can run at most once per physical host, will pick unassigned builds and execute them.
+- **builder process**: this process can run at most once per physical host, will execute the builds assigned to themselves.
 
-## HOW TO
+## Operational requirements
 
-This section give the basic steps to follow to configure the runbot. The configuration may differ from one use to another, this one will describe how to test addons for odoo, needing to fetch odoo core but without testing vanilla odoo. As an example, the runbot odoo addon will be used as a test case. Runbotception. 
+You can safely skip ahead to [Setup Runbot](#setup-runbot) if you are interested in trying out Runbot.  
+This section lists Runbot's expectations for the platform it's running on and configuration examples.
 
 ### DNS
 
 You may configure a DNS entry for your runbot domain as well as a CNAME for all subdomain.
 
 ```
-*        IN CNAME  runbot.domain.com.
+;; The documentation writer assumes the reader knows how to interpret this fragment of code.
+;; The reader can also skip DNS configuration to use Runbot with a limited feature set.
+
+$ORIGIN domain.com.
+runbot.domain.com.  IN A      127.0.0.1
+*                   IN CNAME  runbot.domain.com.
 ```
-This is mainly useful to access running build but will also give more freedom for future configurations. 
-This is not needed but many features won't work without that.
+
+This configuration is not necessary for a minimal setup.  
+You need similar domain setup to deploy Runbot in a production environment that gives access to running test database and test artifacts.
 
 ### nginx
 
-An exemple of config is given in the `example_scripts` folder.
+An example of config is given in the `example_scripts` folder.
 
 This may be adapted depending on your setup, mainly for domain names. This can be adapted during the install but serving at least the runbot frontend (proxy pass `80` to `8069`) is the minimal config needed.
 Note that runbot also has a dynamic nginx config listening on the `8080` port, mainly for running build.
@@ -56,11 +68,23 @@ This config is an `ir_ui_view` (runbot.nginx_config) and can be edited if needed
 
 It is also advised to adapt this config to work in `https`.
 
+## Runbot up and running
+
+This section explains how to configure Runbot. You most likely want to divert to support your own use case. Follow along to get a new Runbot instance configured that tests code from this (Runbot) repository. Runbotception!  
+Note that Runbot runs on top of Odoo community and we'll not be testing Odoo community itself.
+
 ### Requirements
 
-Runbot is an addon for odoo, meaning that both odoo and runbot code are needed to run. Some tips to configure odoo are available in [odoo setup documentation](https://www.odoo.com/documentation/19.0/setup/install.html#setup-install-source) (requirements, postgres, ...) This page will mainly focus on runbot specificities.
+Runbot is an addon for odoo, meaning that both odoo and runbot repositories are needed to launch Runbot. The information below guides you through installation of git, python+dependencies, postgresql as those are Odoo dependencies.
 
-You will also need to install docker and other requirements before running runbot.
+1. [Prepare - Odoo source install](https://www.odoo.com/documentation/19.0/administration/on_premise/source.html#prepare)
+2. [Run the server - Odoo setup guide](https://www.odoo.com/documentation/19.0/developer/tutorials/setup_guide.html#run-the-server)
+
+Can you create and launch a new (empty) Odoo database from the command-line?  
+If yes, let's focus now on Runbot itself!
+
+
+Install Runbot requirements.
 
 ```bash
 sudo apt-get install docker.io python3-unidiff python3-docker python3-matplotlib
@@ -68,12 +92,14 @@ sudo apt-get install docker.io python3-unidiff python3-docker python3-matplotlib
 
 ### Setup
 
-Choose a workspace to clone both repositories and checkout the right branch in both of them.
+Choose a workspace to clone both repositories and checkout the default branch in both of them.
 The directory used in example scripts is `/home/$USER/odoo/` 
 
-Note: It is highly advised to create a user for runbot. This example creates a new user `runbot`
+Note: It is highly advised to create a user for runbot.
 
 ```bash
+# This example creates a new user `runbot` with the right environment permissions
+
 sudo adduser runbot
 
 # needed access rights, docker, postgress
@@ -89,9 +115,9 @@ mkdir odoo
 cd odoo
 ```
 
-You may [add valid ssh key linked to a github account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
- to this user in order to clone the different repositories. You could clone in `https` but this may be a problem later to access your private repositories. 
-It is important to clone the repo with the runbot user:
+You may [add a valid ssh key to a github account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+ to be used by user `runbot` to clone the next repositories. You could clone in `https` but this may be a problem later to access your private repositories.  
+It is important to clone the repositories as the runbot user:
 
 ```bash
 git clone --depth=1 --branch=19.0 git@github.com:odoo/odoo.git
@@ -103,15 +129,16 @@ git -C runbot checkout 19.0
 mkdir logs
 ```
 
-Note: `--depth=1 --branch=19.0 ` is optionnal but will help to reduce the disc usage for the odoo repo.
+Note: `--depth=1 --branch=19.0 ` is optional but this approach requires less available disk space. The odoo community and odoo enterprises repositories are large, monitor your free disk space regularly when you use them inside Runbot. (50+ GiB at minimum)
 
-Finally, check that you have acess to docker, listing the dockers should work without error (but will be empty).
+Finally, check that you have access to docker, listing the docker containers should work without error (but the list will be empty).
 
 ```bash
 docker ps 
 ```
-If it is not working, ensure you have the docker group and logout if needed.
+If the command returns an error, ensure the unix user is part of the docker group and logout/login again.
 
+# --- TODO
 ### Install and start runbot
 
 This part is only consist in configuring and starting the 3 services.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Runbot functionality is split to allow some horizontal scaling of the platform a
 
 ## Operational requirements
 
-You can skip ahead to [First steps with Runbot](#first-steps-with-runbot) if you are interested to try Runbot.  
+You can skip ahead to [User guide](#user-guide) if you are interested to try Runbot.  
 This section describes Runbot's expectations of its host with configuration examples.
 
 ### DNS
@@ -57,7 +57,7 @@ runbot.domain.com.  IN A      127.0.0.1
 
 ### nginx
 
-An example of config is given in the [./runbot/runbot/example_scripts]() directory.
+An example of config is given in the [./runbot/runbot/example_scripts] directory.
 
 This may be adapted depending on your setup, mainly for domain names. This can be adapted during the install but serving at least the runbot frontend (proxy pass `80` to `8069`) is the minimal config needed.
 Note that runbot also has a dynamic nginx config listening on the `8080` port, mainly for running build.
@@ -68,7 +68,7 @@ It is also advised to adapt this config to work in `https`.
 
 ### Running unattended
 
-The directory [./runbot/runbot/example_scripts]() has example configuration to launch every Runbot process. This section explains how to configure Systemd to start Runbot unattended.
+The directory [./runbot/runbot/example_scripts] has example configuration to launch every Runbot process. This section explains how to configure Systemd to start Runbot unattended.
 
 NOTE: This part assumes a dedicated user 'runbot' exists to start Runbot and 'runbot' has write permissions to docker and postgresql.
 
@@ -201,7 +201,7 @@ All requirements are met, go ahead and launch!
 ```
 
 You can now connect to your running instance and configure runbot.
-- Page [http://127.0.0.1:8069]() shows an empty bundle overview page. Nothing is configured yet.
+- Page [http://127.0.0.1:8069] shows an empty bundle overview page. Nothing is configured yet.
 - Log into the backend as admin (default password: admin).
 - Visit page [Runbot > Settings > Settings](http://127.0.0.1:8069/odoo/settings) to update your instance settings:
     - **Default number of worker**, the maximum number of builds to run in parallel. Consider setting the value to `#cpu - 1`.
@@ -267,7 +267,7 @@ ls ~/odoo/runbot/runbot/static
 
 All of the above directories are empty right now, we haven't configured Runbot to build anything.
 
-Runbot also supports picking specific database templates to be initialised before build launch. By default template 'template0' is used (see [db template](#db template)).
+Runbot also supports picking specific database templates to be initialised before build launch. By default template 'template0' is used (see [db template](#db-template)).
 
 Other cron operations are still disabled for now.
 

--- a/README.md
+++ b/README.md
@@ -414,4 +414,4 @@ The Odoo Runbot team also maintains a set of prebuilt docker images that are com
 
 ## User documentation
 
-You can find a more detailed user documentation [here](./runbot/documentation/readme.md)
+You can find a more detailed user documentation [here](./runbot/documentation/readme.md).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ sudo systemctl status runbot
 Ensure startup completed succesfully, then start and verify the other runbot processes too.  
 Several log files should have been created in `/home/runbot/odoo/logs/`, one per service.
 
-## First steps with Runbot
+## User guide
 
 Follow along to get a new Runbot instance configured that tests code from this (Runbot) repository. Runbotception!  
 Note that Runbot runs on top of Odoo community and we'll not be testing Odoo community itself.
@@ -308,7 +308,7 @@ Create a new repository to represent the runbot git repository
 - **Project**: `R&D`.
 - **Modules to install**: `-*,runbot`, only install the runbot module (and module dependencies of course).
 - **Addons path**: `\<empty>`, without addons path Runbot uses the repository root to find modules.
-- **Mode**: `poll`, since integrating github hooks is out of scope for this scope.
+- **Mode**: `poll`, since integrating github hooks is out of scope for this guide.
 - **Remotes**: `git@github.com:odoo/runbot.git` 
 - The remote *PR* option can be checked if needed to fetch pull request too. Will work only if a github token is given for this repo.
 
@@ -316,86 +316,105 @@ If you link your own repository, it is advised to set **mode** to `hook`. The en
 *It is advised to change the mode to 'hook' for all repositories to reduce end-to-end test latency.*
 
 A config file with your remotes should be created for each repository. Verify the file contents at `/runbot/static/repo/(runbot|odoo)/config`.  
-The repositories will be fetched automatically, this operation may take some time too.  
+Data is fetched from the remotes automatically, the first fetch will take a long time.  
 After fetching finishes you should see empty batches in both projects on the website frontend (`/` or `/runbot`)
 
 ### Triggers and linked config
-At this point, runbot will discover new branches, new commits, create bundle, but no build will be created.
+At this point, runbot discovers new branches, new commits, creates bundles, but no builds.
 
-When a new commit is discovered, the branch is updated with a new commit. Then this commit is added in a batch, a container for new builds when they arrive, but only if a trigger corresponding to this repo exists. After one minute without a new commit update in the batch, the different triggers will create one build each.
-In this example, we want to create a new build when a new commit is pushed on runbot, and this build needs a commit in odoo as a dependency.
+To test the runbot code we want to create builds when the remote has new commits. To run runbot we also need a commit from the odoo repository. These requirements can be configured as a trigger.  
+When triggers activate, they take the linked config to create one or multiple builds. 
 
-By default the basic config will use the step `all` to test all addons. The installed addons will depends on the repo configuration, but all dependencies tests will be executed too.
-This may not be wanted because some `base` or `web` test may be broken. This is the case with runbot addons. Also, selecting only the test for the addons
-we are interested in will speedup the build a lot.
+Runbot has a couple of pre-configured configurations (config) that perform common operations like execute tests, keep test-build running, create coverage report, start multiple parallel builds for the same batch etc.
 
-Even if it would be better to create new Config and steps, we will modify the curent `all` config step.
+Configurations are composed of configuration steps. One of the default configuration steps is `all`, configured to test *all addons* including those from dependencies.  
+At the moment we're only interested in testing runbot, skipping tests from odoo `base` and `web` finishes our builds more quickly and doesn't give false positive errors in case some of those tests break.  
+We could duplicate an existing configuration but it's quicker to just modify the `all` config step.
 
-`Runbot > Configs > Build Config Steps`
+Open the Runbot backend and open `Runbot > Configs > Build Config Steps`
 
-Edit the `all` config step and set `/runbot` as **Test tags**
+Edit the config step `all` to restrict which tests to run
+- Open the record named `all`
+- **Test tags**: set to value `/runbot` ([More info about test tags](https://www.odoo.com/documentation/19.0/developer/reference/cli.html#cmdoption-odoo-bin-test-tags))
 
-We can also check the config were going to use:
+Open `Runbot > Configs > Build Config`
 
-`Runbot > Configs > Build Config`
+Remove the config step `base` from the config `Default no run`:
+- Open the record named `Default no run`
+- Inside the step order, remove config step `base`
 
-Optionnaly, edit `Default no run` config and remove the `base` step. It will only test the module base.
+Config and steps are powerful concepts, even allowing Python code to be executed. Advanced usage is out of scope for this guide.
 
-Config and steps can be usefull to create custom test behaviour but this is out of the scope of this tutorial.
+Open `Runbot > Triggers`
 
-Create a new trigger like this:
+Create a new trigger that will generate builds for the runbot repo:
+- *Name*: `Runbot`, just for display.
+- *Project id*: `runbot`, the trigger only reacts to repository updates linked to this project.
+- *Repositories*: Add link to `runbot`, commits from runbot are the main subject.
+- *Dependencies*: Add link to `odoo`, odoo source is required to run Runbot.
+- *Config*: `Default no run`, start a build but don't keep a test-build running at the end. You can still wake up a build.
 
-`Runbot>Triggers`
+You can either push new commits to the remote, or go on the frontend bundle page and use the `Force new batch` button (refresh icon) to test this new trigger. Build 'Runbot' is automatically created.
 
-- *Name*: `Runbot` Just for display 
-- *Project id*: `runbot` This is important since you can only chose repo triggering a new build in this project.
-- *Triggers*: `runbot` A new build will be created int the project when pushing on this repo.
-- *Dependencies*: `odoo` Runbot needs odoo to run
-- *Config*: `Default no run` Will start a build but don't make it running at the end. You can still wake up a build.
+If CI options are configured, triggers will send build status information to remotes that have a valid API token. This completes the CI feedback loop.
 
-When a branch is pushed, a new batch will be created, and after one minute the new build will be created if no other change is detected.
+Runbot is now configured to automatically test changes made to the runbot code. This is the end of the guide. Good luck!
 
-CI options will only be used to send status on remotes of trigger repositories having a valid token.
+## Bundles
 
-You can either push, or go on the frontend bundle page and use the `Force new batch` button (refresh icon) to test this new trigger.
+Bundles can be marked as `no_build`, so that new commit(s) won't create batches. The bundle won't be displayed on the overview page either.
 
-### Bundles
+## Hosts
+Runbot is able to automatically assign pending builds across multiple hosts. Currently, this action is performed by the leader process. The platform can run without a leader process or with exactly one active leader process.  
+A builder host will never assign a pending build to itself nor work-steal pending builds from other builders.
 
-Bundles can be marked as `no_build`, so that new commit(s) won't create batch creation and the bundle won't be displayed on the main page.
+To manually assign builds to your fleet, exclude your buildhosts from the assignment pool and assign your build records directly to a specific builder.
 
-### Hosts
-Runbot is able to share pending builds across multiple hosts. In the present case, there is only one. A new host will never assign a pending build to itself by default.
-Go to the "Build Hosts" menu and choose yours. Uncheck *Only accept assigned build*. You can also tweak the number of parallel builds for this host.
+Open `Runbot > Hosts`
+- Pick your desired builder
+- **Only accept assigned build**: `checked`, remove the current host from the assignment pool
 
-### Modules filters
-Modules to install can be filtered by repo, and by config step. The first filter to be applied is the repo one, creating the default list for a config step.
-Addon `-module` on a repo will remove the module from the default, it is advised to reflect the default case on repo. To test only a custom module, adding `-*` on odoo repo will disable all odoo addons. Only dependencies of custom modules will be installed. Some specific modules can also be filtered using `-module1,-module1` or somme specific modules can be kept using `-*,module1,module2`.
-Modules can also be filtered on a config step with the same logic as repo filter, except that repo's blacklist can be disabled to allow all modules by starting the list with `*` (all available modules)
-It is also possible to add test-tags to config step to allow more module to be installed but only testing some specific one. Test tags: `/module1,/module2`
+Open `Runbot > Objects > Builds`
+- Pick a build that the system created for you
+- (optional) Duplicate it
+- **Host name**: `<name of your builder>`, manually assign this build to the specified builder host
 
-### db template
-Db creation will use `template0` by default. It is possible to specify a specific template to use in runbot config *Postgresql template*. It is mainly used to add extensions. This will also avoid having issue if `template0` is used when creating a new database.
 
-It is recommended to generate a `template_runbot`  database based on `template0` and set this value in the runbot settings
+## Modules filters
+Modules to install can be filtered by repo, and by config step. The filter configured on the repository is applied first, resulting in a 'default modules list' for all configurations. The filter configured on config is applied on top of the default modules list.
 
-```
+Prefixing a module name with a minus `-` sign eg, `-base`, will exclude it from the modules list. The Odoo Runbot team suggests installing handpicked toplevel modules to prevent installation of unnecessary modules taking additional build time.  
+Use an asterisk to target all default modules eg, `-*` removes all modules from the list, and this can be suffixed with module name(s) we want to install eg, `-*,runbot` (comma seperated list).  
+Ofcourse this requires the manifest of module `runbot` is correctly declaring its own module dependencies.
+
+Tests can be filtered separately from modules, and an unconfigured value will run tests for all installed modules. You can restrict which test(s) to run using [the test-tags syntax](https://www.odoo.com/documentation/19.0/developer/reference/cli.html?highlight=cli#cmdoption-odoo-bin-test-tags) eg, `/runbot,/runbot_builder` will only run tests defined inside the modules runbot and runbot_builder.
+
+## db template
+Database creation before starting a build will use `template0` by default. It is possible to specify a specific template to use in the runbot settings field *Postgresql template*. A custom database is mainly used to add extensions.
+
+The Odoo Runbot team recommends generating a new template database `template_runbot` based on `template0`, prepare it according to your needs, and set its name in the runbot settings.
+
+```bash
+su postgres
+
 createdb template_runbot -T template0
+# Mark database as template
+psql --dbname postgres --command "update pg_database set datistemplate = true where datname = 'template_runbot'"
+
+# Activate extensions and other manipulations
+# psql --dbname template_runbot --command "CREATE EXTENSION <...>"
 ```
 
 ## Dockerfiles
 
-Runbot is using odoo model 'docker file' to define the Dockerfile used for builds and is shipped with a default record. This default Dockerfile is based on Ubuntu Noble (24.04) and is capable of building (supported versions of) Odoo.
+Runbot automatically installs a default 'docker file' model to represent the runtime environment of the builds. This Dockerfile is based on Ubuntu Noble (24.04) and is capable of testing/running (supported versions of) Odoo.
+DockerFile records  can be assigned to the models version and bundle.
 
-The model uses Odoo QWeb views to compile Dockerfile contents.
+The 'docker file' model uses Odoo QWeb views to compile Dockerfile text. You can construct the Dockerfile contents with reusable layer elements, and you can also paste your own Dockerfile text into a layer of type 'Raw'.  
+All Dockerfile records with `to_build` field checked are built automatically (pay attention that no other operations will occur during the build).
 
-A new Dockerfile can be created as needed either by duplicating the default one and adapt parameters in the view. e.g.: changing the key `'from': 'ubuntu:jammy'` to `'from': 'debian:buster'` will create a new Dockerfile based on Debian instead of ubuntu.
-Or by providing a plain Dockerfile in the template.
-
-Once the Dockerfile is created and the `to_build` field is checked, the Dockerfile will be built (pay attention that no other operations will occur during the build).
-
-A specific docker file can be assigned to the models version and bundle.
-
-The Odoo Runbot team maintains a set of prebuilt docker images that are compatible with actively supported Odoo versions. Ask them for a link to use in your own Runbot.
+The Odoo Runbot team suggests creating a new Dockerfile by duplicating the default one and adapt parameters in the view.  
+The Odoo Runbot team also maintains a set of prebuilt docker images that are compatible with actively supported Odoo versions. Ask them for a link to use in your own Runbot.
 
 ## User documentation
 


### PR DESCRIPTION
The README currently has gaps between content and the real onboarding experience. This PR adds missing information, reworks grammar and spelling mistakes, and updates/rewords wording to match the application.

The intention is to expand the written text. It should contains all the information necessary to setup your first Runbot instance.
After review, another iteration over all the text is planned to contract the text volume and rework into an actual *quick*start. This needs to go hand-in-hand with changes to the process loops and installed data (/demo data).