### PR TITLE
[FIX] mergebot: tweak forwardport auto-disable

### DIFF
--- a/runbot_merge/models/crons/forwardport.py
+++ b/runbot_merge/models/crons/forwardport.py
@@ -81,6 +81,9 @@ class ForwardPortTasks(models.Model):
             if descendant.parent_id:
                 descendant.parent_id = pr.id
 
+    def _search_domain(self):
+        return [('pr_id.repository.project_id.disable_forwardport', '=', False)]
+
     def _complete_batches(self):
         source = pr = self.pr_id
         source_id = pr.source_id or pr

--- a/runbot_merge/models/project.py
+++ b/runbot_merge/models/project.py
@@ -94,6 +94,7 @@ confused (and will probably timeout).
     warn_mergiraf = fields.Boolean(compute='_compute_warn_mergiraf')
 
     fw_nice = fields.Boolean(help="Lower priority of forward-ports")
+    disable_forwardport = fields.Boolean(help="If checked, forward port will be disabled for this project.")
     request_missing_statuses = fields.Boolean(
         help="If some required statuses have never been received on a PR,"
              " request them from the runbot."

--- a/runbot_merge/models/project_freeze/__init__.py
+++ b/runbot_merge/models/project_freeze/__init__.py
@@ -22,6 +22,7 @@ class FreezeWizard(models.Model):
     _description = "Wizard for freezing a project('s master)"
 
     project_id = fields.Many2one('runbot_merge.project', required=True)
+    disable_forwardport = fields.Boolean(related='project_id.forwardport_disabled')
     errors = fields.Text(compute='_compute_errors')
     branch_name = fields.Char(required=True, help="Name of the new branches to create")
 
@@ -179,7 +180,7 @@ class FreezeWizard(models.Model):
         # if there are still errors, reopen the wizard
         if self.errors:
             return self.action_open()
-        self.env.ref('runbot_merge.port_forward').active = False
+        self.project_id.disable_forwardport = True
 
         conflict_crons = self.env.ref('runbot_merge.merge_cron')\
                        | self.env.ref('runbot_merge.staging_cron')\

--- a/runbot_merge/models/project_freeze/__init__.py
+++ b/runbot_merge/models/project_freeze/__init__.py
@@ -63,12 +63,6 @@ class FreezeWizard(models.Model):
          "There should be only one ongoing freeze per project"),
     ]
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        r = super().create(vals_list)
-        self.env.ref('runbot_merge.port_forward').active = False
-        return r
-
     @api.onchange('release_label')
     def _onchange_release_label(self):
         if not self.release_label:
@@ -185,9 +179,11 @@ class FreezeWizard(models.Model):
         # if there are still errors, reopen the wizard
         if self.errors:
             return self.action_open()
+        self.env.ref('runbot_merge.port_forward').active = False
 
         conflict_crons = self.env.ref('runbot_merge.merge_cron')\
                        | self.env.ref('runbot_merge.staging_cron')\
+                       | self.env.ref('runbot_merge.port_forward')\
                        | self.env.ref('runbot_merge.process_updated_commits')
         # we don't want to run concurrently to the crons above, though we
         # don't need to prevent read access to them

--- a/runbot_merge/models/project_freeze/views.xml
+++ b/runbot_merge/models/project_freeze/views.xml
@@ -12,6 +12,7 @@
                     <group>
                         <group colspan="2">
                             <field name="branch_name"/>
+                            <field name="disable_forwardport"/>
                             <field name="required_pr_ids" widget="many2many_tags"
                                 options="{'color_field': 'state_color', 'no_create': True}"/>
                             <field name="pr_state_key" readonly="1"/>

--- a/runbot_merge/views/runbot_merge_project.xml
+++ b/runbot_merge/views/runbot_merge_project.xml
@@ -61,6 +61,7 @@
                                 </group>
                                 <group>
                                     <field name="fw_nice" widget="boolean_toggle"/>
+                                    <field name="disable_forwardport" widget="boolean_toggle"/>
                                     <field name="use_mergiraf" widget="boolean_toggle"/>
                                     <field name="lateness_limit"/>
                                     <field name="uniquifier" widget="boolean_toggle"/>

--- a/runbot_merge/views/templates.xml
+++ b/runbot_merge/views/templates.xml
@@ -65,9 +65,9 @@
             <div class="alert alert-light col-md-12 h6 mb-0">
                 <a href="/runbot_merge/changelog">Changelog</a>
             </div>
-            <t t-set="fpcron" t-value="env(user=1).ref('runbot_merge.port_forward')"/>
-            <div t-if="not fpcron.active" class="alert alert-warning col-12" role="alert">
-                Forward-port is disabled, merged pull requests will not be forward-ported.
+            <t t-set="disabled_projects_forwardports" t-value="env(user=1)['runbot_merge.project'].search([('disable_forwardport', '=', True)])"/>
+            <div t-if="disabled_projects_forwardports" class="alert alert-warning col-12" role="alert">
+                Forward-port is disabled in some projects, merged pull requests will not be forward-ported.
             </div>
             <t t-set="stagingcron" t-value="env(user=1).ref('runbot_merge.staging_cron')"/>
             <div t-if="not stagingcron.active" class="alert alert-warning col-12 mb-0" role="alert">


### PR DESCRIPTION
If a wizard is created for demo purpose (or missclick) then cancelled, the forwardport are disabled silently.

A less bug prone approach would be to disable forwardports only when freezing.

Additionnaly, the second commit proposes to disable only the project forwardports when freezing. This will also give a more direct access to disable or enable the forwardport without the need to access the scheduled actions.