### PR TITLE
[FIX] runbot: parameterless toggle desync in TableGroup JS class

### DIFF
--- a/runbot/static/src/js/table_group.js
+++ b/runbot/static/src/js/table_group.js
@@ -35,8 +35,12 @@ class TableGroup {
         return group.querySelector(this.constructor.groupHeaderSelector);
     }
 
-    toggleGroup(group, force = false) {
-        group.classList.toggle(this.constructor.hiddenGroupClass, force ? true : undefined);
+    toggleGroup(group, force) {
+        if (force === undefined) {
+            group.classList.toggle(this.constructor.hiddenGroupClass);
+        } else {
+            group.classList.toggle(this.constructor.hiddenGroupClass, force);
+        }
     }
 
     toggleCollapse() {


### PR DESCRIPTION
Fix `toggleGroup` in TableGroup so that calling it without a `force` argument correctly flips the hidden class state instead of evaluating to `false`.

Steps to reproduce:
- on the errors frontend page, expand one of the error
- click on "Expand all" for the error's group => the previously expanded error is now collapsed