### PR TITLE
[FIX] runbot: replace inline onclick with data-copy-text attribute

### DIFF
--- a/runbot/static/src/js/runbot.js
+++ b/runbot/static/src/js/runbot.js
@@ -30,14 +30,17 @@
     });
 })(jQuery);
 
-
-function copyToClipboard(text) {
+document.addEventListener('click', function (e) {
+    const button = e.target.closest('[data-copy-text]');
+    if (!button) {
+        return;
+    }
     if (!navigator.clipboard) {
         console.error('Clipboard not supported');
         return;
     }
-    navigator.clipboard.writeText(text);
-}
+    navigator.clipboard.writeText(button.dataset.copyText);
+});
 
 document.addEventListener('DOMContentLoaded', function() {
     const collapseElement = document.getElementById('customTriggers');

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -465,7 +465,7 @@
         </template>
 
         <template id="runbot.branch_copy_button">
-            <button t-attf-class="btn btn-default {{btn_size or 'btn-ssm'}}" title="Copy Bundle name" aria-label="Copy Bundle name" t-attf-onclick="copyToClipboard('{{ bundle.name.split(':')[-1] }}')">
+            <button type="button" t-attf-class="btn btn-default {{btn_size or 'btn-ssm'}}" title="Copy Bundle name" aria-label="Copy Bundle name" t-att-data-copy-text="bundle.name.split(':')[-1]">
               <i t-attf-class="fa fa-clipboard"/>
             </button>
         </template>


### PR DESCRIPTION
Avoid inline JS evaluation and string interpolation issues in `branch_copy_button` by passing the target string via a `data-copy-text` dataset attribute. A delegated listener in `runbot.js` handles the clipboard copy logic natively.