### PR TITLE
[REF] runbot: replace slot_filler hack with CSS grid in batch_slots

### DIFF
--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -284,9 +284,13 @@ a, .btn-link {
 }
 
 .batch_slots {
-	display: flex;
-	flex-wrap: wrap;
+	display: grid;
+	grid-template-columns: 1fr;
 	padding: 6px;
+
+	@media (min-width: 576px) {
+		grid-template-columns: repeat(auto-fill, minmax(100px, 50%));
+	}
 }
 
 .batch_commits {
@@ -294,13 +298,6 @@ a, .btn-link {
 }
 
 .batch_row .slot_container {
-	flex: 1 0 200px;
-	padding: 0 4px;
-}
-
-.batch_row .slot_filler {
-	width: 100px;
-	height: 0px;
 	flex: 1 0 200px;
 	padding: 0 4px;
 }
@@ -314,10 +311,6 @@ a, .btn-link {
 }
 
 .bundle_row .slot_container {
-	flex: 1 0 50%;
-}
-
-.bundle_row .slot_filler {
 	flex: 1 0 50%;
 }
 

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -126,7 +126,6 @@
                 </t>
               </t>
             </t>
-            <div class="slot_filler" t-foreach="range(10)" t-as="x"/>
           </div>
           <div t-if='more' class="batch_commits">
             <div t-foreach="batch.commit_link_ids.sorted(lambda cl: (cl.commit_id.repo_id.sequence, cl.commit_id.repo_id.id))" t-as="commit_link" class="one_line">


### PR DESCRIPTION
Previously, batch slots relied on a Flexbox layout that required rendering 10 empty `.slot_filler` `<div>` elements in QWeb templates to force proper flex item wrapping and alignment.

This commit:
- Replaces the Flexbox layout on `.batch_slots` with responsive CSS Grid rules.
- Removes the dummy `<div class="slot_filler"/>` loop.
- Drops obsolete `.slot_filler` CSS rules.