### PR TITLE
[REF] runbot: modernize stylesheet variables and clean up CSS rules

### DIFF
--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -6,6 +6,7 @@
 	--active-project-color: #777;
 	--text-color-link: #507279;
 	--bs-font-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	--bs-link-decoration: none;
 	/* FIXME: style all links, should be theme based */
 	--bs-link-color: #00A09D;
 	--bs-link-color-rgb: 0, 160, 157;
@@ -183,7 +184,7 @@ dialog.modal {
 }
 
 a, .btn-link {
-    text-decoration: none;
+    text-decoration: none; /* until --bs-link-decoration is actually used, see twbs/bootstrap#41737 */
 }
 
 .breadcrumb {

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -6,6 +6,7 @@
 	--active-project-color: #777;
 	--text-color-link: #507279;
 	--bs-font-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	--bs-body-font-size: 0.875rem;
 	--bs-link-decoration: none;
 	/* FIXME: style all links, should be theme based */
 	--bs-link-color: #00A09D;
@@ -149,7 +150,6 @@
 
 body {
 	margin: 0;
-    font-size: 0.875rem;
     font-weight: 400;
     line-height: 1.5;
     text-align: left;
@@ -157,10 +157,6 @@ body {
 
 form {
     margin: 0;
-}
-
-table {
-    font-size: 0.875rem;
 }
 
 dialog.modal {

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -121,7 +121,6 @@
     --bs-btn-disabled-border-color: #17a2b8;
 }
 
-
 .accordion {
 	--bs-accordion-btn-padding-y: 0.3rem; /* more condensed build error views */
 }
@@ -146,17 +145,6 @@
 .active_project {
 	color: var(--active-project-color);
 	margin-left: 15px;
-}
-
-body {
-	margin: 0;
-    font-weight: 400;
-    line-height: 1.5;
-    text-align: left;
-}
-
-form {
-    margin: 0;
 }
 
 dialog.modal {
@@ -336,7 +324,6 @@ a, .btn-link {
 	padding: 2px;
 }
 
-
 .batch_row .slot_container {
 	flex: 1 0 200px;
 	padding: 0 4px;
@@ -431,7 +418,6 @@ a, .btn-link {
 	margin-left: 0px !important;
 }
 
-
 code {
 	white-space: pre-wrap;
 }
@@ -477,7 +463,7 @@ code {
 	--runbot-tag-associated-color: color-mix(in lab, var(--runbot-tag-color), white 90%);
 	color: var(--runbot-tag-color);
 	background-color: var(--runbot-tag-associated-color);
-	
+
 	:root[data-bs-theme=dark] & {
 		color: var(--runbot-tag-associated-color);
 		background-color: var(--runbot-tag-color);

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -1,5 +1,4 @@
 :root {
-	--gray:  #6c757d; /* used for batch limitation */
 	--btn-default-color: var(--bs-body-color);
 	--btn-default-bg: var(--bs-body-bg);
 	--btn-default-hover-bg: color-mix(in lab, var(--btn-default-bg), black 15%);
@@ -356,7 +355,7 @@ a, .btn-link {
 }
 
 .bundle_row {
-	border-bottom: 1px solid var(--gray);
+	border-bottom: 1px solid var(--bs-gray);
 }
 
 .bundle_row .batch_commits {

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -141,10 +141,6 @@
     table-layout: fixed;
 }
 
-/*.accordion-button:not(.collapsed) {
-	background-color: transparent; /* remove crappy color
-}*/
-
 .active_project {
 	color: var(--active-project-color);
 	margin-left: 15px;
@@ -382,23 +378,6 @@ body, .table {
 .bundle_row .more .batch_commits {
 	display: block;
 }
-
-/*.bundle_row .nomore .batch_commits {
-	display: none;
-	padding: 8px;
-}
-
-.bundle_row .nomore.batch_tile:hover .batch_commits {
-	display: block;
-	position: absolute;
-	bottom: 1px;
-	transform: translateY(100%);
-	z-index: 100;
-	border: 1px solid rgba(0, 0, 0, 0.125);
-	border-radius: 0.2rem;
-	box-sizing: border-box;
-	margin-left: -1px;
-}*/
 
 .chart-legend {
 	max-height: calc(100vh - 160px);

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -243,10 +243,6 @@ a, .btn-link {
 	background-color: #aaa;
 }
 
-.table-condensed td {
-	padding: 0.25rem;
-}
-
 .line-through {
 	text-decoration: line-through;
 }
@@ -421,7 +417,7 @@ code {
 	text-decoration: underline;
 }
 
-.table-condensed .log-server td, .table-condensed .log-details td {
+.table-sm .log-server td, .table-sm .log-details td {
 	padding-top: 0;
 	padding-bottom: 0;
 	border: none;

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -227,12 +227,6 @@ a, .btn-link {
 	content: none;
 }
 
-.one_line {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
 .batch_tile {
 	padding: 6px;
 }

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -121,10 +121,6 @@
     --bs-btn-disabled-border-color: #17a2b8;
 }
 
-.accordion {
-	--bs-accordion-btn-padding-y: 0.3rem; /* more condensed build error views */
-}
-
 .text-bg-default {
 	color: var(--bs-body-color) !important;
 	background-color: RGBA(var(--bs-body-bg-rgb), var(--bs-bg-opacity, 1)) !important;
@@ -241,21 +237,8 @@ a, .btn-link {
 	padding: 6px;
 }
 
-.branch_time {
-	float: right;
-	margin-left: 10px;
-}
-
 .text-info {
 	color: #096b72 !important;
-}
-
-.build_subject_buttons {
-	display: flex;
-}
-
-.build_buttons {
-	margin-left: auto;
 }
 
 .bg-killed {
@@ -350,10 +333,6 @@ a, .btn-link {
 
 .bundle_row .slot_filler {
 	flex: 1 0 50%;
-}
-
-.bundle_row .more .batch_commits {
-	display: block;
 }
 
 .chart-legend {

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -179,10 +179,6 @@ dialog.modal {
     }
 }
 
-.fa {
-	line-height: inherit; /* reset fa icon line height to body height*/
-}
-
 a, .btn-link {
     text-decoration: none; /* until --bs-link-decoration is actually used, see twbs/bootstrap#41737 */
 }
@@ -228,17 +224,19 @@ a, .btn-link {
 }
 
 .btn-sm, .btn-group-sm > .btn {
-	padding: 0.25rem 0.5rem;
-	font-size: 0.89rem;
-	line-height: 1.5;
-	border-radius: 0.2rem;
+	--bs-btn-padding-y: 0.25rem;
+	--bs-btn-padding-x: 0.5rem;
+	--bs-btn-font-size: 0.89rem;
+	--bs-btn-line-height: 1.5;
+	--bs-btn-border-radius: 0.2rem;
 }
 
 .btn-ssm, .btn-group-ssm > .btn {
-	padding: 0.22rem 0.4rem;
-	font-size: 0.82rem;
-	line-height: 1;
-	border-radius: 0.2rem;
+	--bs-btn-padding-y: 0.22rem;
+	--bs-btn-padding-x: 0.4rem;
+	--bs-btn-font-size: 0.82rem;
+	--bs-btn-line-height: 1;
+	--bs-btn-border-radius: 0.2rem;
 }
 
 .killed, .bg-killed, .bg-killed-light {

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -6,6 +6,7 @@
 	--btn-default-border: #ccc;
 	--active-project-color: #777;
 	--text-color-link: #507279;
+	--bs-font-sans-serif: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	/* FIXME: style all links, should be theme based */
 	--bs-link-color: #00A09D;
 	--bs-link-color-rgb: 0, 160, 157;
@@ -225,11 +226,6 @@ a, .btn-link {
 .separator {
 	border-top: 0.2em solid #666;
 }
-
-body, .table {
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
-
 
 .btn-sm, .btn-group-sm > .btn {
 	padding: 0.25rem 0.5rem;
@@ -456,7 +452,7 @@ code {
 
 .pre {
 	display: block;
-    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+	font-family: var(--bs-font-monospace);
     white-space: pre;
 	overflow: auto;
 	font-size: 0.875em;

--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -126,10 +126,6 @@
 	background-color: RGBA(var(--bs-body-bg-rgb), var(--bs-bg-opacity, 1)) !important;
 }
 
-.table-responsive {
-	display: block;  /* more condensed table, to replace */
-}
-
 .table {
 	--bs-table-bg: transparent; /* Forced to white in bootstrap latest version, hides the color of sub builds, batch commits, ...*/
 }

--- a/runbot/templates/batch.xml
+++ b/runbot/templates/batch.xml
@@ -96,7 +96,7 @@
                                     </t>
                                     <a t-attf-href="/runbot/commit/#{commit.id}" t-att-title="commit_title">
                                         <i t-attf-class="fa fa-fw {{commit_icon}}"/>
-                                        <span class="label" t-out="commit.dname"/>
+                                        <span t-out="commit.dname"/>
                                     </a>
                                     <a t-att-href="'https://%s/commit/%s' % (commit_link.branch_id.remote_id.base_url, commit_link.commit_id.name)" title="View Commit on Github"><i class="fa fa-github"/></a>
                                     <small t-if="commit_link.match_type and commit_link.match_type.startswith('base')">

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -16,7 +16,7 @@
                   </div>
                 </h3>
               </div>
-              <table class="table table-sm table-responsive">
+              <table class="table table-sm d-block overflow-x-auto">
                 <tr>
                   <td>Remote:</td>
                   <td t-out="branch.remote_id.name"></td>

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -16,7 +16,7 @@
                   </div>
                 </h3>
               </div>
-              <table class="table table-condensed table-responsive">
+              <table class="table table-sm table-responsive">
                 <tr>
                   <td>Remote:</td>
                   <td t-out="branch.remote_id.name"></td>
@@ -58,7 +58,7 @@
                   </tr>
                 </t>
               </table>
-                <table t-if="branch.reflog_ids" class="table table-condensed table-striped" style="table-layout: initial;">
+                <table t-if="branch.reflog_ids" class="table table-sm table-striped" style="table-layout: initial;">
                   <thead>
                       <tr>
                           <th>Ref Date</th>

--- a/runbot/templates/branch.xml
+++ b/runbot/templates/branch.xml
@@ -6,7 +6,7 @@
         <div class="container-fluid">
           <div class="row">
             <div class='col-md-12'>
-              <div class="navbar navbar-default">
+              <div class="navbar">
                 <h3>
                   <span class="text-muted"><t t-out="branch.remote_id.short_name"/>:</span><t t-out="branch.name"/> <i t-if="not branch.alive" title="deleted/closed" class="fa fa-ban text-danger"/>
                   <div class="btn-group" role="group">

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -4,7 +4,7 @@
     <template id="runbot.build">
       <t t-call='runbot.layout'>
         <t t-set="nav_form">
-          <form class="form-inline">
+          <form>
             <div class="btn-group">
               <t t-call="runbot.build_button">
                 <t t-set="bu" t-value="build"/>

--- a/runbot/templates/build.xml
+++ b/runbot/templates/build.xml
@@ -276,7 +276,7 @@
           </div>
           <div class="col-md-6" t-if="build.children_ids or build.linked_children_build_ids">
             Children:
-            <table class="table table-condensed">
+            <table class="table table-sm">
               <t t-foreach="(build.children_ids | build.linked_children_build_ids).sorted(lambda b: b.id)" t-as="child">
                 <t t-set="rowclass">
                   <t t-call="runbot.build_class">
@@ -326,7 +326,7 @@
           </div>
           <t t-set="nb_subbuild" t-value="len(build.children_ids)"/>
           <div class="col-md-12">
-            <table class="table table-condensed">
+            <table class="table table-sm">
               <tr>
                 <th>Date (UTC)</th>
                 <th>Level</th>
@@ -404,7 +404,7 @@
       <t t-call='runbot.layout'>
         <div class="row g-0">
           <div class="col-md-12">
-            <table class="table table-condensed">
+            <table class="table table-sm">
               <t t-foreach="builds" t-as="build">
                 <t t-set="rowclass">
                   <t t-call="runbot.build_class">

--- a/runbot/templates/build_stats.xml
+++ b/runbot/templates/build_stats.xml
@@ -8,7 +8,7 @@
         </script>
         <input type="hidden" id="bundle_id" t-att-value="bundle.id"/>
         <div class="container-fluid">
-          <nav class="navbar navbar-light">
+          <nav class="navbar">
             <div class="container">
                 <div class="d-flex flex-wrap align-items-center gap-2">
                 <b>Bundle:</b><t t-out="bundle.name"/>

--- a/runbot/templates/build_stats.xml
+++ b/runbot/templates/build_stats.xml
@@ -48,8 +48,8 @@
             </div>
           </nav>
           <div class="row">
-            <div class="col-xs-9 col-md-10"><canvas id="canvas"></canvas></div>
-            <div class="col-xs-3 col-md-2">
+            <div class="col-md-10"><canvas id="canvas"></canvas></div>
+            <div class="col-md-2">
                 <b>Mode:</b>
                 <select id="mode_selector" class="form-select" aria-label="Display mode">
                   <option title="Real Values ordered by value" selected="selected" value="normal">Value</option>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -36,7 +36,7 @@
                                         </t>
                                 </div></h5>
                             
-                            <table class="table table-condensed table-responsive">
+                            <table class="table table-sm table-responsive">
                                 <tr>
                                     <td>Version</td>
                                     <td>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -36,7 +36,7 @@
                                         </t>
                                 </div></h5>
                             
-                            <table class="table table-sm table-responsive">
+                            <table class="table table-sm d-block overflow-x-auto">
                                 <tr>
                                     <td>Version</td>
                                     <td>

--- a/runbot/templates/bundle.xml
+++ b/runbot/templates/bundle.xml
@@ -23,15 +23,15 @@
                                                 <i class="fa fa-play"/> Actions <i class="fa fa-caret-down ms-1"/>
                                             </button>
                                             <ul class="dropdown-menu">
-                                                <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force a new batch using base commits mainly for random errors debugging">
+                                                <li><a groups="runbot.group_runbot_advanced_user" class="dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force?use_base_commits=1" title="Force a new batch using base commits mainly for random errors debugging">
                                                     <i class="fa fa-fast-backward"/> Start a batch without the branch commits
-                                                </a>
-                                                <a groups="runbot.group_runbot_advanced_user" class="btn btn-default dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Create a new Batch, applies new trigger configurations and updates build references for upgrades if needed">
+                                                </a></li>
+                                                <li><a groups="runbot.group_runbot_advanced_user" class="dropdown-item" t-attf-href="/runbot/bundle/{{bundle.id}}/force" title="Create a new Batch, applies new trigger configurations and updates build references for upgrades if needed">
                                                     <i class="fa fa-play"/> Start a new batch
-                                                </a>
-                                                <a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" class="btn btn-default dropdown-item"  title="Force A New Batch with automatic rebase, useful to test outdated branches without pushing before a merge">
+                                                </a></li>
+                                                <li><a t-if="bundle.env.user.has_group('runbot.group_runbot_advanced_user') or (bundle.env.user.has_group('runbot.group_user') and ':' in bundle.name)" t-attf-href="/runbot/bundle/{{bundle.id}}/force?auto_rebase=1" class="dropdown-item"  title="Force A New Batch with automatic rebase, useful to test outdated branches without pushing before a merge">
                                                     <i class="fa fa-fast-forward"/> Start a batch with simulated autorebase
-                                                </a>
+                                                </a></li>
                                             </ul>
                                         </t>
                                 </div></h5>

--- a/runbot/templates/bundles_by_tag.xml
+++ b/runbot/templates/bundles_by_tag.xml
@@ -35,7 +35,7 @@
         <template id="runbot.bundles_by_tag">
             <t t-call='runbot.layout'>
                 <div class="container-fluid">
-                    <table class="table table-condensed table-group table-filter caption-top text-body-secondary">
+                    <table class="table table-sm table-group table-filter caption-top text-body-secondary">
                         <caption>
                             <div class="row align-items-center">
                                 <h1 class="col-12 col-md-auto text-capitalize">

--- a/runbot/templates/commit_link_details.xml
+++ b/runbot/templates/commit_link_details.xml
@@ -11,7 +11,7 @@
                         <p>
                             <span type="button" data-bs-toggle="collapse" t-att-data-bs-target="href" role="button" aria-expanded="true" t-att-aria-controls="collapse"><i class="fa fa-toggle-up"/></span>
                                 <a t-attf-href="/runbot/commit/#{commit.id}">
-                                    <span class="label" t-esc="commit.dname"/>
+                                    <span t-esc="commit.dname"/>
                                     <span t-esc="'+%s' % commit_link.diff_add" class="text-success"/>
                                     <span t-esc="'-%s' % commit_link.diff_remove" class="text-danger"/>
                                     <span class="text-info">

--- a/runbot/templates/commit_link_details.xml
+++ b/runbot/templates/commit_link_details.xml
@@ -7,7 +7,7 @@
                     <t t-set="commit" t-value="commit_link.commit_id"/>
                     <t t-set="collapse" t-value="'collapse' + str(commit_link.id)"/>
                     <t t-set="href" t-value="'#' + collapse"/>
-                    <div class="container sticky-top bg-white" style="margin-left: 50%;">
+                    <div class="container sticky-top bg-body" style="margin-left: 50%;">
                         <p>
                             <span type="button" data-bs-toggle="collapse" t-att-data-bs-target="href" role="button" aria-expanded="true" t-att-aria-controls="collapse"><i class="fa fa-toggle-up"/></span>
                                 <a t-attf-href="/runbot/commit/#{commit.id}">

--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -245,7 +245,7 @@
             </div>
             <div class="col-md-9 col-lg-10">
               <div class="table-responsive">
-                <table class="table table-condensed">
+                <table class="table table-sm">
                   <t t-foreach="builds" t-as="build">
                     <t t-set="rowclass">
                       <t t-call="runbot.build_class">

--- a/runbot/templates/dashboard.xml
+++ b/runbot/templates/dashboard.xml
@@ -235,7 +235,7 @@
             <t t-set="builds" t-value="bundle_builds[1]"/>
 
             <div class="col-md-3 col-lg-2 cell">
-              <div class="one_line">
+              <div class="text-truncate">
                 <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
                 <a t-attf-href="/runbot/bundle/#{bundle.id}" title="View Bundle">
                   <b t-out="bundle.name"/>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -36,7 +36,7 @@
               <div t-else="">
                 <div t-foreach="bundles" t-as="bundle" class="row bundle_row">
                   <div class="col-md-3 col-lg-2 cell">
-                    <div class="one_line">
+                    <div class="text-truncate">
                       <i t-if="bundle.sticky" class="fa fa-star" style="color: #f0ad4e" />
                       <a t-attf-href="/runbot/bundle/#{bundle.id}" t-attf-title="View Bundle #{bundle.name}">
                         <b t-out="bundle.name"/>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -4,8 +4,8 @@
     <template id="runbot.bundles">
       <t t-call='runbot.layout'>
         <t t-set="nav_form">
-          <form class="form-inline my-2 my-lg-0" role="search" t-att-action="qu(search='')" method="get">
-            <div class="input-group md-form form-sm form-2 ps-0">
+          <form class="my-2 my-lg-0" role="search" t-att-action="qu(search='')" method="get">
+            <div class="input-group ps-0">
               <input class="form-control my-0 py-1" type="text" placeholder="Search" aria-label="Search" name="search" t-att-value="search" autofocus="autofocus"/>
               <a t-if="has_pr" class="btn btn-primary" title="All" t-att-href="qu(has_pr=None)">
                 <i class="fa fa-github"/>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -22,7 +22,7 @@
         <div class="container-fluid frontend">
           <div class="row">
             <div class='col-md-12'>
-              <span  class="pull-right" >
+              <span  class="float-end" >
                 <t t-call="runbot.slots_infos"/>
               </span>
             </div>

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -59,7 +59,9 @@
                         </t></div>
                       <div class="btn-group" role="group">
                         <t t-if="not bundle.sticky" t-call="runbot.branch_copy_button"/>
-                        <t t-call="runbot.branch_github_menu"/>
+                        <div class="btn-group" role="group">
+                          <t t-call="runbot.branch_github_menu"/>
+                        </div>
                       </div>
                     </div>
                     <div t-if="bundle.host_id">

--- a/runbot/templates/tree_hash.xml
+++ b/runbot/templates/tree_hash.xml
@@ -28,7 +28,7 @@
             </table>
           </div>
           <!-- Commits -->
-          <table class="table table-condensed" style="table-layout: initial;">
+          <table class="table table-sm" style="table-layout: initial;">
             <thead>
               <tr>
                 <th colspan="6">Commits:</th>
@@ -59,7 +59,7 @@
             </tr>
           </table>
           <!-- Bundles / Batches -->
-          <table class="table table-condensed" style="table-layout: initial;">
+          <table class="table table-sm" style="table-layout: initial;">
             <thead>
               <tr>
                 <th colspan="3">Batches:</th>

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -66,14 +66,11 @@
                                             </li>
                                         </t>
                                     </t>
-                                    <li class="nav-item divider"/>
-
                                     <li class="nav-item">
                                         <button command="show-modal" commandfor="collapsePreference" type="button" class="nav-link">
                                             <i class="fa fa-gear"/>
                                         </button>
                                     </li>
-                                    <li class="nav-item divider" t-ignore="true"/>
                                     <t t-if="not user_id._is_public()">
                                         <t t-if="env.user.has_group('runbot.group_runbot_admin')">
                                             <t t-set="docker_files" t-value="env['runbot.dockerfile'].search([])"/>
@@ -227,7 +224,6 @@
 
         <template id="runbot.build_errors_link">
             <t t-if="nb_assigned_errors">
-                <li class="nav-item divider"/>
                 <li class="nav-item">
                     <a href="/runbot/errors" class="nav-link text-danger" t-attf-title="You have {{nb_assigned_errors}} random bug assigned">
                         <i class="fa fa-bug"/>
@@ -237,7 +233,6 @@
                 </li>
             </t>
             <t t-elif="nb_team_errors">
-                <li class="nav-item divider"/>
                 <li class="nav-item">
                     <a href="/runbot/errors" class="nav-link text-warning" t-attf-title="Your team has {{nb_team_errors}} random bug assigned">
                         <i class="fa fa-bug"/>
@@ -246,7 +241,6 @@
                 </li>
             </t>
             <t t-elif="nb_build_errors">
-                <li class="nav-item divider"/>
                 <li class="nav-item">
                     <a href="/runbot/errors" class="nav-link" title="Random Bugs"><i class="fa fa-bug"/></a>
                 </li>
@@ -452,7 +446,6 @@
         <template id="runbot.branch_github_menu">
           <button t-attf-class="{{btn_classes or 'btn btn-default btn-ssm'}} dropdown-toggle" data-bs-toggle="dropdown" title="Github links" aria-label="Github links" aria-expanded="false">
             <i t-attf-class="fa fa-github {{'text-primary' if any(branch_id.is_pr and branch_id.alive for branch_id in bundle.branch_ids) else 'text-secondary' if all(not branch_id.alive for branch_id in bundle.branch_ids) else ''}}"/>
-            <span class="caret"/>
           </button>
           <div  class="dropdown-menu" role="menu">
             <t t-foreach="bundle.branch_ids.sorted(key=lambda b: (not b.alive, b.remote_id.repo_id.sequence, b.remote_id.repo_id.id, b.is_pr, b.id))" t-as="branch">

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -100,15 +100,15 @@
                                                     <span t-out="user_id.name[:23] + '...' if user_id.name and len(user_id.name) &gt; 25 else user_id.name"/>
                                                 </b>
                                             </a>
-                                            <div class="dropdown-menu dropdown-menu-end js_usermenu" role="menu">
-                                                <a class="dropdown-item" id="o_logout" role="menuitem" t-attf-href="/web/session/logout?redirect=/">Logout</a>
-                                                <a class="dropdown-item" role="menuitem" t-attf-href="/odoo">Backend</a>
-                                                <div t-if="user_id.runbot_team_ids" class="dropdown-divider"/>
-                                                <div t-if="user_id.runbot_team_ids" class="dropdown-header">Teams</div>
-                                                <a t-foreach="user_id.runbot_team_ids" t-as="team" class="dropdown-item" role="menuitem" t-attf-href="/runbot/teams/{{team.id}}">
+                                            <ul class="dropdown-menu dropdown-menu-end js_usermenu" role="menu">
+                                                <li><a class="dropdown-item" id="o_logout" role="menuitem" t-attf-href="/web/session/logout?redirect=/">Logout</a></li>
+                                                <li><a class="dropdown-item" role="menuitem" t-attf-href="/odoo">Backend</a></li>
+                                                <li><div t-if="user_id.runbot_team_ids" class="dropdown-divider"/></li>
+                                                <li><div t-if="user_id.runbot_team_ids" class="dropdown-header">Teams</div></li>
+                                                <li><a t-foreach="user_id.runbot_team_ids" t-as="team" class="dropdown-item" role="menuitem" t-attf-href="/runbot/teams/{{team.id}}">
                                                     <t t-out="team.name.capitalize()"/>
-                                                </a>
-                                            </div>
+                                                </a></li>
+                                            </ul>
                                         </li>
                                     </t>
                                     <t t-else="">
@@ -447,14 +447,14 @@
           <button t-attf-class="{{btn_classes or 'btn btn-default btn-ssm'}} dropdown-toggle" data-bs-toggle="dropdown" title="Github links" aria-label="Github links" aria-expanded="false">
             <i t-attf-class="fa fa-github {{'text-primary' if any(branch_id.is_pr and branch_id.alive for branch_id in bundle.branch_ids) else 'text-secondary' if all(not branch_id.alive for branch_id in bundle.branch_ids) else ''}}"/>
           </button>
-          <div  class="dropdown-menu" role="menu">
-            <t t-foreach="bundle.branch_ids.sorted(key=lambda b: (not b.alive, b.remote_id.repo_id.sequence, b.remote_id.repo_id.id, b.is_pr, b.id))" t-as="branch">
+          <ul class="dropdown-menu" role="menu">
+            <li t-foreach="bundle.branch_ids.sorted(key=lambda b: (not b.alive, b.remote_id.repo_id.sequence, b.remote_id.repo_id.id, b.is_pr, b.id))" t-as="branch">
               <t t-set="link_title" t-value="'View %s %s on Github' % ('PR' if branch.is_pr else 'Branch', branch.name)"/>
               <a t-att-href="branch.branch_url" class="dropdown-item" t-att-title="link_title">
                 <span class="fst-italic text-muted" t-out="branch.remote_id.short_name"/> <span t-att-class="'' if branch.alive else 'line-through'" t-out="branch.name"/> <i t-if="not branch.alive" title="deleted/closed" class="fa fa-ban text-danger"/>
               </a>
-            </t>
-          </div>
+            </li>
+          </ul>
         </template>
 
         <template id="runbot.branch_copy_button">

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -314,7 +314,7 @@
         </template>
 
         <template id="runbot.build_button">
-            <div t-attf-class="pull-right">
+            <div t-attf-class="float-end">
                 <div t-attf-class="btn-group {{klass}}">
                     <a t-if="bu.local_state == 'running' and bu.database_ids" t-attf-href="/runbot/run/{{bu.id}}" class="btn btn-info" title="Sign in on this build" aria-label="Sign in on this build">
                         <i class="fa fa-sign-in"/>


### PR DESCRIPTION
Modernize runbot UI components, clean up deprecated markup, and improve theme support:
- Delegate fonts, sizes, buttons, and colors to native Bootstrap 5 `--bs-*` CSS variables.
- Swap hardcoded `bg-white` for `bg-body` to support dark mode themes.
- Replace legacy BS3 classes (`.table-condensed`, `col-xs-*`, `.pull-right`, `.form-inline`, `.one_line`)
  with native Bootstrap 5 utilities and grid rules.
- Fix table overflow behavior and standardize dropdown menus with clean `<ul>`/`<li>` structures.
- Purge dead CSS classes, commented-out rules, redundant Reboot resets, and obsolete markup (`.label`, `.divider`, `.caret`).

Note: no visual change should be expected.