### PR TITLE
[IMP] runbot: store diff on CommitLink

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -21,7 +21,7 @@
         'data/runbot_data.xml',
         'data/runbot_error_regex_data.xml',
         'data/website_data.xml',
-
+        'data/gc_cron.xml',
 
         'templates/utils.xml',
         'templates/badge.xml',

--- a/runbot/data/gc_cron.xml
+++ b/runbot/data/gc_cron.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_cron_gc_commit_link_diff" model="ir.cron">
+        <field name="name">GC Commit Link Diffs</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="model_id" ref="model_runbot_commit_link"/>
+        <field name="state">code</field>
+        <field name="code">model._gc_diff(delta_days=1)</field>
+    </record>
+</odoo>

--- a/runbot/models/batch.py
+++ b/runbot/models/batch.py
@@ -529,9 +529,9 @@ class Batch(models.Model):
                     continue
 
                 # diff. Iter on --numstat, easier to parse than --shortstat summary
-                diff = commit.repo_id._git(['diff', '--numstat', merge_base_sha, commit.name]).strip()
-                if diff:
-                    for line in diff.split('\n'):
+                diff_stat = commit.repo_id._git(['diff', '--numstat', merge_base_sha, commit.name]).strip()
+                if diff_stat:
+                    for line in diff_stat.split('\n'):
                         link_commit.file_changed += 1
                         add, remove, _ = line.split(None, 2)
                         try:
@@ -539,6 +539,8 @@ class Batch(models.Model):
                             link_commit.diff_remove += int(remove)
                         except ValueError:  # binary files
                             pass
+                if link_commit.file_changed <= (self.bundle_id.file_limit or 450) and link_commit.base_ahead <= (self.bundle_id.commit_limit or 50):
+                    link_commit.diff = commit.repo_id._git(['diff', f'{merge_base_sha}..{commit.name}', '--', '*'], errors='ignore')
             except subprocess.CalledProcessError:
                 self._warning('Commit info failed between %s and %s', commit.name, base_head.name)
 

--- a/runbot/models/commit.py
+++ b/runbot/models/commit.py
@@ -275,11 +275,22 @@ class CommitLink(models.Model):
     diff_add = fields.Integer('# line added')
     diff_remove = fields.Integer('# line removed')
     tree_hash = fields.Char('Tree hash', compute='_compute_tree_hash')
+    diff = fields.Text('Diff', prefetch=False)
 
     @api.depends('commit_id.tree_hash')
     def _compute_tree_hash(self):
         for link in self:
             link.tree_hash = link.commit_id.tree_hash
+
+    @api.model
+    def _gc_diff(self, delta_days=180):
+        delta_date = self.env.cr.now() - datetime.timedelta(days=delta_days)
+        commit_links = self.search([
+            ('diff', '!=', False),
+            ('create_date', '<', delta_date),
+        ])
+        commit_links.diff = False
+        _logger.info('Cleaned %s commit link diff', len(commit_links))
 
 
 class CommitStatus(models.Model):


### PR DESCRIPTION
When fetching commit info, store the diff as well so that it can be reused later in some build config steps and save time. A mechanism should be added to clean up old diffs.