### PR TITLE
[ADD] runbot: add UI tours for frontend and error management flows

### DIFF
--- a/runbot/__manifest__.py
+++ b/runbot/__manifest__.py
@@ -77,6 +77,9 @@
             'runbot/static/src/js/fields/*',
             'runbot/static/src/js/components/*',
         ],
+        'web.assets_tests': [
+            'runbot/static/tests/tours/*.js',
+        ],
         'runbot.assets_frontend': [
             'web/static/lib/odoo_ui_icons/style.css',
             'runbot/static/lib/bootstrap/css/bootstrap.css',

--- a/runbot/static/tests/tours/runbot_error_main_flow.js
+++ b/runbot/static/tests/tours/runbot_error_main_flow.js
@@ -1,0 +1,106 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("runbot_error_main_flow", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Runbot",
+            trigger: ".o_app[data-menu-xmlid=\"runbot.runbot_menu_root\"]",
+            run: "click",
+        },
+        {
+            content: "Open error management",
+            trigger: "button[data-menu-xmlid=\"runbot.runbot_menu_manage_errors\"]",
+            run: "click",
+        },
+        {
+            content: "Open the errors list",
+            trigger: "a[data-menu-xmlid=\"runbot.runbot_menu_build_error_tree\"]",
+            run: "click",
+        },
+        {
+            content: "Errors list is rendered",
+            trigger: ".o_content .o_list_renderer",
+        },
+        {
+            content: "Filter the errors on the tour fixture",
+            trigger: ".o_searchview_input",
+            run: "edit UI tour error",
+        },
+        {
+            content: "Apply the error filter",
+            trigger: ".o_searchview_input",
+            run: "press Enter",
+        },
+        {
+            content: "The error list renders the compact pull request URL",
+            trigger: ".o_data_row:has(.o_data_cell:contains(\"UI tour error\")) "
+                + ".o_field_widget[name=\"fixing_pr_url\"] a:contains(\"odoo/runbot#12345\")",
+        },
+        {
+            content: "The error list renders the history graph",
+            trigger: ".o_data_row:has(.o_data_cell:contains(\"UI tour error\")) "
+                + ".o_field_widget[name=\"history_data\"] canvas",
+        },
+        {
+            content: "Open the error",
+            trigger: ".o_data_row:has(.o_data_cell:contains(\"UI tour error\")) "
+                + ".o_data_cell:contains(\"UI tour error\")",
+            run: "click",
+        },
+        {
+            content: "The compact pull request URL is also rendered on the form",
+            trigger: ".o_form_view .o_field_widget[name=\"fixing_pr_url\"] "
+                + "a:contains(\"odoo/runbot#12345\")",
+        },
+        {
+            content: "The first seen date links to the Runbot build",
+            trigger: ".o_form_view .o_field_widget[name=\"first_seen_date\"] "
+                + "a[href^=\"/runbot/build/\"]",
+        },
+        {
+            content: "Hover a history cell",
+            trigger: ".o_form_view .o_field_widget[name=\"history_data\"] canvas",
+            run() {
+                const canvas = this.anchor;
+                const rect = canvas.getBoundingClientRect();
+                canvas.dispatchEvent(new MouseEvent("mousemove", {
+                    bubbles: true,
+                    clientX: rect.left + canvas.width - 7,
+                    clientY: rect.top + 7,
+                }));
+            },
+        },
+        {
+            content: "The history graph displays details for the hovered cell",
+            trigger: ".history-graph-tooltip:contains(\"Version: master\")",
+        },
+        {
+            content: "Open the qualifiers tab",
+            trigger: ".o_notebook_headers .nav-link:contains(\"Qualifiers\")",
+            run: "click",
+        },
+        {
+            content: "The JSON field colorizes qualifier keys",
+            trigger: ".o_field_widget.o_field_runbotjsonb[name=\"common_qualifiers\"] "
+                + ".o_runbot_json_key:contains(\"test_class\")",
+        },
+        {
+            content: "Update the multiline test tags",
+            trigger: ".o_field_widget[name=\"test_tags\"] textarea",
+            async run(helpers) {
+                await helpers.edit("/runbot:new_failure\n/runbot:shared_context");
+            },
+        },
+        ...stepUtils.saveForm(),
+        {
+            content: "The chatter renders removed lines as a diff",
+            trigger: ".o-mail-Message-tracking .code_diff .code.removed:contains(\"old_failure\")",
+        },
+        {
+            content: "The chatter renders added lines as a diff",
+            trigger: ".o-mail-Message-tracking .code_diff .code.added:contains(\"new_failure\")",
+        },
+    ],
+});

--- a/runbot/static/tests/tours/runbot_frontend_main_flow.js
+++ b/runbot/static/tests/tours/runbot_frontend_main_flow.js
@@ -1,0 +1,99 @@
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("runbot_frontend_main_flow", {
+    steps: () => [
+        {
+            content: "Open the frontend tour project from the main Runbot page",
+            trigger: `#top_menu .nav-link:contains("Runbot UI Tour Project")`,
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "The project frontend is selected",
+            trigger: `.active_project:contains("Runbot UI Tour Project")`,
+        },
+        {
+            content: "Search for the frontend tour bundle",
+            trigger: `form[role="search"] input[name="search"]`,
+            run: "edit ui-tour-active",
+        },
+        {
+            content: "Submit the bundle search",
+            trigger: `form[role="search"] button[type="submit"]`,
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "The bundles page renders the fixture batch",
+            trigger: `.bundle_row:has(a[title="View Bundle ui-tour-active"]) .slot_name:contains("Frontend tour trigger")`,
+        },
+        {
+            content: "Copy the bundle name",
+            trigger: `.bundle_row:has(a[title="View Bundle ui-tour-active"]) button[data-copy-text="ui-tour-active"]`,
+            async run() {
+                const expected = "ui-tour-active";
+                const origWriteText = browser.navigator.clipboard.writeText;
+                browser.navigator.clipboard.writeText = (text) => {
+                    let success = false;
+                    if (text === expected) {
+                        success = true;
+                    }
+                    browser.navigator.clipboard.writeText = origWriteText;
+                    if (!success) {
+                        throw new Error(`Clipboard mock received "${text}" but expected "${expected}"`);
+                    }
+                }
+                await this.anchor.click();
+            },
+        },
+        {
+            content: "Open the accessible lazy build options",
+            trigger: `.bundle_row:has(a[title="View Bundle ui-tour-active"]) build-options-dropdown[role="button"][tabindex="0"]`,
+            run: "click",
+        },
+        {
+            content: "The build options are rendered lazily",
+            trigger: `.bundle_row:has(a[title="View Bundle ui-tour-active"]) build-options-dropdown + .dropdown-menu .dropdown-item:contains("Rebuild"):not(:visible)`,
+        },
+        {
+            content: "Open the bundle from the bundles page",
+            trigger: `a[title="View Bundle ui-tour-active"]`,
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "The bundle page renders its batch",
+            trigger: `.batch_row .slot_name:contains("Frontend tour trigger")`,
+        },
+        {
+            content: "Open the batch from the bundle page",
+            trigger: `.batch_row .batch_tile > .card > a`,
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "The batch page renders the bundle and build",
+            trigger: `table:has(td:contains("Builds")) .slot_name:contains("Frontend tour trigger")`,
+        },
+        {
+            content: "Open the build from the batch page",
+            trigger: `table:has(td:contains("Builds")) .slot_name:contains("Frontend tour trigger")`,
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "The build page preserves the bundle, batch, and build context",
+            trigger: `.breadcrumb:has(a:contains("ui-tour-active")):has(a:contains("Frontend tour trigger")):has(a:contains("Frontend UI tour build"))`,
+        },
+        {
+            content: "Hide successful build rows",
+            trigger: `button[data-toggle="hide-success"][aria-expanded="true"]`,
+            run: "click",
+        },
+        {
+            content: "The build page records the successful-row preference",
+            trigger: `html.hide-success button[data-toggle="hide-success"][aria-expanded="false"]`,
+        },
+    ],
+});

--- a/runbot/templates/utils.xml
+++ b/runbot/templates/utils.xml
@@ -10,6 +10,10 @@
 
                     <t t-call-assets="runbot.assets_frontend" t-js="False"/>
                     <t t-call-assets="runbot.assets_frontend" t-css="False" defer_load="True"/>
+                    <t t-if="'tests' in debug or test_mode_enabled">
+                        <t t-call-assets="web.assets_frontend" t-css="False" defer_load="True"/>
+                    </t>
+                    <t t-call="web.conditional_assets_tests" ignore_missing_deps="True"/>
 
                     <t t-if="refresh">
                         <meta http-equiv="refresh" t-att-content="refresh"/>

--- a/runbot/tests/__init__.py
+++ b/runbot/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_commit
 from . import test_upgrade
 from . import test_dockerfile
 from . import test_host
+from . import test_ui

--- a/runbot/tests/test_ui.py
+++ b/runbot/tests/test_ui.py
@@ -1,0 +1,130 @@
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestRunbotUi(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project = cls.env['runbot.project'].create({
+            'name': 'Runbot UI Tour Project',
+        })
+        cls.repo = cls.env['runbot.repo'].create({
+            'name': 'runbot',
+            'project_id': cls.project.id,
+            'mode': 'disabled',
+        })
+        cls.remote = cls.env['runbot.remote'].create({
+            'name': 'https://github.com/odoo/runbot.git',
+            'repo_id': cls.repo.id,
+        })
+
+    def _create_branch(self, **values):
+        values['remote_id'] = self.remote.id
+        with patch(
+            'odoo.addons.runbot.models.branch.Branch._update_branch_infos',
+            return_value=None,
+        ):
+            return self.env['runbot.branch'].create(values)
+
+    def _create_done_build(self, bundle, description, trigger=None):
+        config = self.env.ref('runbot.runbot_build_config_default')
+        batch = self.env['runbot.batch'].create({
+            'bundle_id': bundle.id,
+            'state': 'done',
+        })
+        params_values = {
+            'project_id': self.project.id,
+            'version_id': bundle.version_id.id,
+            'create_batch_id': batch.id,
+            'config_id': config.id,
+        }
+        if trigger:
+            params_values['trigger_id'] = trigger.id
+        params = self.env['runbot.build.params'].create(params_values)
+        build = self.env['runbot.build'].create({
+            'params_id': params.id,
+            'description': description,
+        })
+        build.write({
+            'local_state': 'done',
+            'local_result': 'ok',
+        })
+        if trigger:
+            self.env['runbot.batch.slot'].create({
+                'batch_id': batch.id,
+                'trigger_id': trigger.id,
+                'build_id': build.id,
+                'params_id': params.id,
+                'link_type': 'created',
+            })
+        bundle.last_batch = batch
+        return build
+
+    def test_frontend_main_flow(self):
+        bundle = self.env['runbot.bundle'].create({
+            'name': 'ui-tour-active',
+            'project_id': self.project.id,
+        })
+        self._create_branch(
+            name='10001',
+            pull_head_remote_id=self.remote.id,
+            is_pr=True,
+            pull_head_name='odoo-dev:ui-tour-active',
+            target_branch_name='master',
+            alive=True,
+        )
+        bundle.description = 'Active frontend tour'
+        trigger = self.env['runbot.trigger'].create({
+            'name': 'Frontend tour trigger',
+            'project_id': self.project.id,
+            'repo_ids': [(6, 0, self.repo.ids)],
+            'config_id': self.env.ref('runbot.runbot_build_config_default').id,
+            'batch_dependent': True,
+        })
+        self._create_done_build(bundle, 'Frontend UI tour build', trigger)
+
+        self.start_tour('/runbot', 'runbot_frontend_main_flow', login='admin')
+
+    def test_error_main_flow(self):
+        bundle = self.project.master_bundle_id
+        fixing_pr = self._create_branch(
+            name='12345',
+            is_pr=True,
+            pull_head_name='odoo-dev:error-tour',
+            target_branch_name='master',
+        )
+        build = self._create_done_build(bundle, 'UI tour build')
+        error = self.env['runbot.build.error'].create({
+            'name': 'UI tour error',
+            'fixing_pr_id': fixing_pr.id,
+            'test_tags': '/runbot:old_failure\n/runbot:shared_context',
+        })
+        with patch(
+            'odoo.addons.runbot.models.build_error.ErrorQualifyRegex._get_cache',
+            return_value=self.env['runbot.error.qualify.regex'],
+        ):
+            error_content = self.env['runbot.build.error.content'].create({
+                'error_id': error.id,
+                'content': 'UI tour error\nTraceback for the backend tour',
+            })
+        error_content.qualifiers = {
+            'test_class': 'TestRunbotUi',
+            'test_method': 'test_error_main_flow',
+        }
+        self.env['runbot.build.error.link'].create({
+            'build_id': build.id,
+            'error_content_id': error_content.id,
+            'log_date': fields.Datetime.now(),
+        })
+
+        self.start_tour('/odoo', 'runbot_error_main_flow', login='admin')
+
+        self.assertEqual(
+            error.test_tags,
+            '/runbot:new_failure\n/runbot:shared_context',
+        )


### PR DESCRIPTION
Add UI tour tests covering main user flows in runbot:

- Add 'runbot_frontend_main_flow' tour covering project navigation,
  bundle search, lazy options dropdowns, and build context
  breadcrumbs.
- Add 'runbot_error_main_flow' tour covering error filtering, history
  graph inspection, JSON qualifier parsing, and chatter diffs.