### PR TITLE
[FIX] runbot: dynamic grid layout for batch slots and commit truncation

### DIFF
--- a/runbot/static/src/css/runbot.css
+++ b/runbot/static/src/css/runbot.css
@@ -285,12 +285,8 @@ a, .btn-link {
 
 .batch_slots {
 	display: grid;
-	grid-template-columns: 1fr;
+	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 	padding: 6px;
-
-	@media (min-width: 576px) {
-		grid-template-columns: repeat(auto-fill, minmax(100px, 50%));
-	}
 }
 
 .batch_commits {

--- a/runbot/templates/frontend.xml
+++ b/runbot/templates/frontend.xml
@@ -128,7 +128,7 @@
             </t>
           </div>
           <div t-if='more' class="batch_commits">
-            <div t-foreach="batch.commit_link_ids.sorted(lambda cl: (cl.commit_id.repo_id.sequence, cl.commit_id.repo_id.id))" t-as="commit_link" class="one_line">
+            <div t-foreach="batch.commit_link_ids.sorted(lambda cl: (cl.commit_id.repo_id.sequence, cl.commit_id.repo_id.id))" t-as="commit_link" class="text-truncate">
 
               <t t-set="match_class" t-value="'info' if commit_link.match_type == 'new' else 'secondary'"/>
               <a t-attf-href="/runbot/commit/#{commit_link.commit_id.id}" t-attf-class="badge text-bg-{{match_class}}">


### PR DESCRIPTION
Replace hardcoded media queries on `.batch_slots` with fluid CSS grid
column wrapping. This enables slot grids to scale relative to container
width rather than viewport size without needing explicit breakpoints.

In addition, replace the legacy `.one_line` CSS class on batch commit
listings with Bootstrap's `.text-truncate` utility to handle text
overflow properly (forgotten during previous cleanup).