### PR TITLE
[IMP] runbot: limit history graph's width to 100%

### DIFF
--- a/runbot/static/src/js/fields/history_graph.js
+++ b/runbot/static/src/js/fields/history_graph.js
@@ -3,8 +3,8 @@ import { useRef, xml, Component, useEffect } from "@odoo/owl";
 
 export class HistoryGraph extends Component {
     static template = xml`
-        <div class="w-100">
-            <canvas t-ref="canvas"/>
+        <div>
+            <canvas class="w-100" t-ref="canvas"/>
         </div>
     `;
 


### PR DESCRIPTION
In some cases (e.g. smaller screen size, zoomed in, etc) you couldn't see the history graph completely.
This commit makes the canvas responsive.

Example:
|Before|After|
|----------|-------|
|<img width="580" height="242" alt="1788183183117319253" src="https://github.com/user-attachments/assets/30f12ca2-6298-4f6b-9c43-18c5b7fcc0c4" />|<img width="550" height="193" alt="1788183171096799113" src="https://github.com/user-attachments/assets/803c703c-99f3-4764-a181-e26501dd3051" />| 
