### PR TITLE
[FIX] runbot: revert 4c245ac

### DIFF
--- a/runbot/static/src/js/fields/history_graph.js
+++ b/runbot/static/src/js/fields/history_graph.js
@@ -3,8 +3,8 @@ import { useRef, xml, Component, useEffect } from "@odoo/owl";
 
 export class HistoryGraph extends Component {
     static template = xml`
-        <div>
-            <canvas class="w-100" t-ref="canvas"/>
+        <div class="w-100 overflow-auto">
+            <canvas t-ref="canvas"/>
         </div>
     `;
 

--- a/runbot/views/build_error_views.xml
+++ b/runbot/views/build_error_views.xml
@@ -63,7 +63,8 @@
                   <field name="last_seen_date" widget="frontend_url" options="{'link_field': 'last_seen_build_id', 'numeric': True}"/>
                   <field name="first_seen_build_id" invisible="True"/>
                   <field name="last_seen_build_id" invisible="True"/>
-                  <field name="history_data" widget="history_graph" options="{'cell_size': 13, 'mouse_actions': True}"/>
+                  <label for="history_data" colspan="2"/>
+                  <field name="history_data" nolabel="1" colspan="2" widget="history_graph" options="{'cell_size': 13, 'mouse_actions': True}"/>
                   <button name="action_appearing_batches" string="Appearing Batches" type="object" class="btn btn-primary" invisible="not first_seen_batch_ids"/>
                   <button name="action_disappearing_batches" string="Disappearing Batches" type="object" class="btn btn-primary" invisible="not disappearing_batch_ids"/>
                 </group>


### PR DESCRIPTION
Commit [1] made the history graph blurry and broke the hovering of the
cells.
Instead of that fix, we move the widget to the next row, this way it
shouldn't be overflown.

[1]: https://github.com/odoo/runbot/commit/4c245ac9e8c2f251c121db7c6c7e18b9662ab8a0