### PR TITLE
[FIX] runbot: make table filters consistent

### DIFF
--- a/runbot/static/src/js/table_filter.js
+++ b/runbot/static/src/js/table_filter.js
@@ -23,7 +23,7 @@ class TableFilter {
     onFilter() {
         const filters = this.filters.map((filter) => {
             const [key, val] = filter.dataset.filter.split("==");
-            return { checked: filter.checked, selector: `tr:has([data-${key}^="${val}"])` };
+            return { checked: filter.checked, selector: `tr:has([data-${key}="${val}"])` };
         });
         for (const row of this.rows) {
             const isFilteredOut = filters.some(({ checked, selector }) =>

--- a/runbot/static/src/js/table_filter.js
+++ b/runbot/static/src/js/table_filter.js
@@ -7,9 +7,9 @@ class TableFilter {
     constructor(el) {
         this.el = el;
         for (const filter of this.filters) {
-            this.onFilter(filter);
-            filter.addEventListener("change", () => this.onFilter(filter));
+            filter.addEventListener("change", () => this.onFilter());
         }
+        this.onFilter();
     }
 
     get filters() {
@@ -20,11 +20,16 @@ class TableFilter {
         return [...this.el.querySelectorAll("tbody > tr:not(:has(th))")];
     }
 
-    onFilter(filter) {
-        const [key, val] = filter.dataset.filter.split("==");
-        const filteredRows = this.rows.filter((r) => r.matches([`tr:has([data-${key}^="${val}"])`]));
-        for (const row of filteredRows) {
-            row.classList.toggle("d-none", !filter.checked);
+    onFilter() {
+        const filters = this.filters.map((filter) => {
+            const [key, val] = filter.dataset.filter.split("==");
+            return { checked: filter.checked, selector: `tr:has([data-${key}^="${val}"])` };
+        });
+        for (const row of this.rows) {
+            const isFilteredOut = filters.some(({ checked, selector }) =>
+                !checked && row.matches(selector),
+            );
+            row.classList.toggle("d-none", isFilteredOut);
         }
     }
 }


### PR DESCRIPTION
Recompute row visibility from all active filters so rows matching
multiple filters do not depend on toggle order.

Match filter values exactly to prevent tag IDs such as `1` from also
matching `10` or `11`.